### PR TITLE
Add mach6mini-plan and mach6mini-implement skills

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -668,6 +668,25 @@ async function executeToolCallsParallel(
 		if (preparation.kind === "immediate") {
 			if (preparation.result.endTurn) endTurn = true;
 			results.push(await emitToolCallOutcome(toolCall, preparation.result, preparation.isError, emit));
+		} else if (preparation.tool.name === "chdir") {
+			// Execute chdir eagerly before other tools so that subsequent tool
+			// preparations use refreshed bindings (e.g. updated cwd).
+			const executed = await executePreparedToolCall(preparation, signal, emit);
+			if (executed.result.endTurn) endTurn = true;
+			results.push(
+				await finalizeExecutedToolCall(
+					currentContext,
+					assistantMessage,
+					preparation,
+					executed,
+					config,
+					signal,
+					emit,
+				),
+			);
+			if (config.getLatestTools) {
+				currentContext.tools = config.getLatestTools();
+			}
 		} else {
 			runnableCalls.push(preparation);
 		}
@@ -692,6 +711,12 @@ async function executeToolCallsParallel(
 				emit,
 			),
 		);
+	}
+
+	// Refresh tools from live state after the batch — allows tools like chdir
+	// to rebuild tool bindings so subsequent turns use the updated cwd.
+	if (config.getLatestTools) {
+		currentContext.tools = config.getLatestTools();
 	}
 
 	return { results, endTurn };

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -652,11 +652,20 @@ async function executeToolCallsParallel(
 	signal: AbortSignal | undefined,
 	emit: AgentEventSink,
 ): Promise<ToolExecutionResult> {
-	const results: ToolResultMessage[] = [];
-	const runnableCalls: PreparedToolCall[] = [];
+	// Use an indexed slots array to preserve source ordering across two passes.
+	const resultSlots: (ToolResultMessage | undefined)[] = new Array(toolCalls.length);
+	const runnableCalls: Array<{ prepared: PreparedToolCall; index: number }> = [];
 	let endTurn = false;
 
-	for (const toolCall of toolCalls) {
+	// Pass 1: Execute tools marked requiresSerialExecution (e.g. chdir) eagerly and in
+	// order, refreshing currentContext.tools after each. This ensures all subsequent
+	// tool preparations — in Pass 2 — use up-to-date bindings regardless of where in
+	// the LLM response the serial tools appear.
+	for (let i = 0; i < toolCalls.length; i++) {
+		const toolCall = toolCalls[i];
+		const lookedUpTool = currentContext.tools?.find((t) => t.name === toolCall.name);
+		if (!lookedUpTool?.requiresSerialExecution) continue;
+
 		await emit({
 			type: "tool_execution_start",
 			toolCallId: toolCall.id,
@@ -667,59 +676,77 @@ async function executeToolCallsParallel(
 		const preparation = await prepareToolCall(currentContext, assistantMessage, toolCall, config, signal);
 		if (preparation.kind === "immediate") {
 			if (preparation.result.endTurn) endTurn = true;
-			results.push(await emitToolCallOutcome(toolCall, preparation.result, preparation.isError, emit));
-		} else if (preparation.tool.name === "chdir") {
-			// Execute chdir eagerly before other tools so that subsequent tool
-			// preparations use refreshed bindings (e.g. updated cwd).
+			resultSlots[i] = await emitToolCallOutcome(toolCall, preparation.result, preparation.isError, emit);
+		} else {
 			const executed = await executePreparedToolCall(preparation, signal, emit);
 			if (executed.result.endTurn) endTurn = true;
-			results.push(
-				await finalizeExecutedToolCall(
-					currentContext,
-					assistantMessage,
-					preparation,
-					executed,
-					config,
-					signal,
-					emit,
-				),
+			resultSlots[i] = await finalizeExecutedToolCall(
+				currentContext,
+				assistantMessage,
+				preparation,
+				executed,
+				config,
+				signal,
+				emit,
 			);
 			if (config.getLatestTools) {
 				currentContext.tools = config.getLatestTools();
 			}
-		} else {
-			runnableCalls.push(preparation);
 		}
 	}
 
-	const runningCalls = runnableCalls.map((prepared) => ({
+	// Pass 2: Prepare and launch remaining tools in parallel. Because Pass 1 has
+	// already run and refreshed tool bindings, preparations here use the latest cwd.
+	for (let i = 0; i < toolCalls.length; i++) {
+		if (resultSlots[i] !== undefined) continue; // handled in Pass 1
+
+		const toolCall = toolCalls[i];
+		await emit({
+			type: "tool_execution_start",
+			toolCallId: toolCall.id,
+			toolName: toolCall.name,
+			args: toolCall.arguments,
+		});
+
+		const preparation = await prepareToolCall(currentContext, assistantMessage, toolCall, config, signal);
+		if (preparation.kind === "immediate") {
+			if (preparation.result.endTurn) endTurn = true;
+			resultSlots[i] = await emitToolCallOutcome(toolCall, preparation.result, preparation.isError, emit);
+		} else {
+			runnableCalls.push({ prepared: preparation, index: i });
+		}
+	}
+
+	const runningCalls = runnableCalls.map(({ prepared, index }) => ({
 		prepared,
+		index,
 		execution: executePreparedToolCall(prepared, signal, emit),
 	}));
 
 	for (const running of runningCalls) {
 		const executed = await running.execution;
 		if (executed.result.endTurn) endTurn = true;
-		results.push(
-			await finalizeExecutedToolCall(
-				currentContext,
-				assistantMessage,
-				running.prepared,
-				executed,
-				config,
-				signal,
-				emit,
-			),
+		resultSlots[running.index] = await finalizeExecutedToolCall(
+			currentContext,
+			assistantMessage,
+			running.prepared,
+			executed,
+			config,
+			signal,
+			emit,
 		);
 	}
 
-	// Refresh tools from live state after the batch — allows tools like chdir
-	// to rebuild tool bindings so subsequent turns use the updated cwd.
+	// Refresh tools from live state after the batch so subsequent turns use the
+	// updated bindings (e.g. new cwd after chdir).
 	if (config.getLatestTools) {
 		currentContext.tools = config.getLatestTools();
 	}
 
-	return { results, endTurn };
+	return {
+		results: resultSlots.filter((r): r is ToolResultMessage => r !== undefined),
+		endTurn,
+	};
 }
 
 type PreparedToolCall = {

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -261,9 +261,9 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
 	/**
 	 * Called after tool execution to get the current live tool list.
 	 * In sequential mode: called after each tool call.
-	 * In parallel mode: called after the batch completes (and eagerly after chdir).
-	 * Allows tools like `chdir` to rebuild the tool set mid-turn so that subsequent tool
-	 * calls use updated bindings (e.g. new cwd).
+	 * In parallel mode: called after each `requiresSerialExecution` tool and after the batch.
+	 * Allows tools that mutate shared state (e.g. cwd) to rebuild tool bindings so that
+	 * subsequent tool calls use updated state.
 	 */
 	getLatestTools?: () => AgentTool<any>[];
 }
@@ -336,6 +336,12 @@ export type AgentToolUpdateCallback<T = any> = (partialResult: AgentToolResult<T
 export interface AgentTool<TParameters extends TSchema = TSchema, TDetails = any> extends Tool<TParameters> {
 	// A human-readable label for the tool to be displayed in UI
 	label: string;
+	/**
+	 * When true, this tool is executed eagerly and serially in `executeToolCallsParallel`,
+	 * before any other tools in the same response are prepared. Use for tools that mutate
+	 * shared state (e.g. cwd) so that subsequent tool preparations use the updated state.
+	 */
+	requiresSerialExecution?: boolean;
 	execute: (
 		toolCallId: string,
 		params: Static<TParameters>,

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -259,9 +259,11 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
 	afterToolCall?: (context: AfterToolCallContext, signal?: AbortSignal) => Promise<AfterToolCallResult | undefined>;
 
 	/**
-	 * Called after each tool execution in sequential mode to get the current live tool list.
+	 * Called after tool execution to get the current live tool list.
+	 * In sequential mode: called after each tool call.
+	 * In parallel mode: called after the batch completes (and eagerly after chdir).
 	 * Allows tools like `chdir` to rebuild the tool set mid-turn so that subsequent tool
-	 * calls in the same model response use updated bindings (e.g. new bash cwd).
+	 * calls use updated bindings (e.g. new cwd).
 	 */
 	getLatestTools?: () => AgentTool<any>[];
 }

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -1036,3 +1036,184 @@ describe("length stop reason handling", () => {
 		expect(assistant.content).toEqual([{ type: "text", text: "complete!" }]);
 	});
 });
+
+describe("parallel mode tool refresh after chdir", () => {
+	it("refreshes tools via getLatestTools after a parallel batch completes (cross-turn)", async () => {
+		const toolSchema = Type.Object({ value: Type.String() });
+
+		// Track which tool instances are used across turns
+		let _toolVersion = 1;
+		let secondToolVersion: number | undefined;
+
+		const makeTool = (version: number): AgentTool<typeof toolSchema, { value: string }> => ({
+			name: "echo",
+			label: "Echo",
+			description: "Echo tool",
+			parameters: toolSchema,
+			async execute(_toolCallId, params) {
+				if (params.value === "second-turn") {
+					secondToolVersion = version;
+				}
+				return {
+					content: [{ type: "text", text: `v${version}: ${params.value}` }],
+					details: { value: params.value },
+				};
+			},
+		});
+
+		const chdirSchema = Type.Object({ path: Type.String() });
+		const chdirTool: AgentTool<typeof chdirSchema, { path: string }> = {
+			name: "chdir",
+			label: "Change Directory",
+			description: "Change working directory",
+			parameters: chdirSchema,
+			async execute() {
+				// Simulate what chdir does: rebuild tool bindings
+				_toolVersion = 2;
+				latestTools = [chdirTool, makeTool(2)];
+				return {
+					content: [{ type: "text", text: "Changed directory" }],
+					details: { path: "/new" },
+				};
+			},
+		};
+
+		let latestTools: AgentTool<any>[] = [chdirTool, makeTool(1)];
+
+		const context: AgentContext = {
+			systemPrompt: "",
+			messages: [],
+			tools: [chdirTool, makeTool(1)],
+		};
+
+		const userPrompt: AgentMessage = createUserMessage("chdir then echo");
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+			toolExecution: "parallel",
+			getLatestTools: () => latestTools,
+		};
+
+		let callIndex = 0;
+		const stream = agentLoop([userPrompt], context, config, undefined, () => {
+			const mockStream = new MockAssistantStream();
+			queueMicrotask(() => {
+				if (callIndex === 0) {
+					// Turn 1: call chdir
+					const message = createAssistantMessage(
+						[{ type: "toolCall", id: "tool-1", name: "chdir", arguments: { path: "/new" } }],
+						"toolUse",
+					);
+					mockStream.push({ type: "done", reason: "toolUse", message });
+				} else if (callIndex === 1) {
+					// Turn 2: call echo — should use refreshed tool (version 2)
+					const message = createAssistantMessage(
+						[{ type: "toolCall", id: "tool-2", name: "echo", arguments: { value: "second-turn" } }],
+						"toolUse",
+					);
+					mockStream.push({ type: "done", reason: "toolUse", message });
+				} else {
+					const message = createAssistantMessage([{ type: "text", text: "done" }]);
+					mockStream.push({ type: "done", reason: "stop", message });
+				}
+				callIndex++;
+			});
+			return mockStream;
+		});
+
+		for await (const _ of stream) {
+			// consume
+		}
+
+		// The echo tool in turn 2 should have used the refreshed version (v2)
+		expect(secondToolVersion).toBe(2);
+	});
+
+	it("executes chdir eagerly before other tools in a parallel batch (intra-turn)", async () => {
+		const toolSchema = Type.Object({ value: Type.String() });
+
+		let _toolVersion = 1;
+		let echoToolVersion: number | undefined;
+		const executionOrder: string[] = [];
+
+		const makeTool = (version: number): AgentTool<typeof toolSchema, { value: string }> => ({
+			name: "echo",
+			label: "Echo",
+			description: "Echo tool",
+			parameters: toolSchema,
+			async execute(_toolCallId, params) {
+				executionOrder.push("echo");
+				echoToolVersion = version;
+				return {
+					content: [{ type: "text", text: `v${version}: ${params.value}` }],
+					details: { value: params.value },
+				};
+			},
+		});
+
+		const chdirSchema = Type.Object({ path: Type.String() });
+		const chdirTool: AgentTool<typeof chdirSchema, { path: string }> = {
+			name: "chdir",
+			label: "Change Directory",
+			description: "Change working directory",
+			parameters: chdirSchema,
+			async execute() {
+				executionOrder.push("chdir");
+				_toolVersion = 2;
+				latestTools = [chdirTool, makeTool(2)];
+				return {
+					content: [{ type: "text", text: "Changed directory" }],
+					details: { path: "/new" },
+				};
+			},
+		};
+
+		let latestTools: AgentTool<any>[] = [chdirTool, makeTool(1)];
+
+		const context: AgentContext = {
+			systemPrompt: "",
+			messages: [],
+			tools: [chdirTool, makeTool(1)],
+		};
+
+		const userPrompt: AgentMessage = createUserMessage("chdir and echo together");
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+			toolExecution: "parallel",
+			getLatestTools: () => latestTools,
+		};
+
+		let callIndex = 0;
+		const stream = agentLoop([userPrompt], context, config, undefined, () => {
+			const mockStream = new MockAssistantStream();
+			queueMicrotask(() => {
+				if (callIndex === 0) {
+					// Single response with both chdir and echo as parallel calls
+					const message = createAssistantMessage(
+						[
+							{ type: "toolCall", id: "tool-1", name: "chdir", arguments: { path: "/new" } },
+							{ type: "toolCall", id: "tool-2", name: "echo", arguments: { value: "hello" } },
+						],
+						"toolUse",
+					);
+					mockStream.push({ type: "done", reason: "toolUse", message });
+				} else {
+					const message = createAssistantMessage([{ type: "text", text: "done" }]);
+					mockStream.push({ type: "done", reason: "stop", message });
+				}
+				callIndex++;
+			});
+			return mockStream;
+		});
+
+		for await (const _ of stream) {
+			// consume
+		}
+
+		// chdir should execute before echo (eagerly during preparation)
+		expect(executionOrder).toEqual(["chdir", "echo"]);
+		// echo should use the refreshed tool (version 2) since chdir ran first
+		expect(echoToolVersion).toBe(2);
+	});
+});

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -1041,8 +1041,6 @@ describe("parallel mode tool refresh after chdir", () => {
 	it("refreshes tools via getLatestTools after a parallel batch completes (cross-turn)", async () => {
 		const toolSchema = Type.Object({ value: Type.String() });
 
-		// Track which tool instances are used across turns
-		let _toolVersion = 1;
 		let secondToolVersion: number | undefined;
 
 		const makeTool = (version: number): AgentTool<typeof toolSchema, { value: string }> => ({
@@ -1067,9 +1065,9 @@ describe("parallel mode tool refresh after chdir", () => {
 			label: "Change Directory",
 			description: "Change working directory",
 			parameters: chdirSchema,
+			requiresSerialExecution: true,
 			async execute() {
 				// Simulate what chdir does: rebuild tool bindings
-				_toolVersion = 2;
 				latestTools = [chdirTool, makeTool(2)];
 				return {
 					content: [{ type: "text", text: "Changed directory" }],
@@ -1129,10 +1127,9 @@ describe("parallel mode tool refresh after chdir", () => {
 		expect(secondToolVersion).toBe(2);
 	});
 
-	it("executes chdir eagerly before other tools in a parallel batch (intra-turn)", async () => {
+	it("executes chdir eagerly before other tools in a parallel batch — chdir listed first", async () => {
 		const toolSchema = Type.Object({ value: Type.String() });
 
-		let _toolVersion = 1;
 		let echoToolVersion: number | undefined;
 		const executionOrder: string[] = [];
 
@@ -1157,9 +1154,9 @@ describe("parallel mode tool refresh after chdir", () => {
 			label: "Change Directory",
 			description: "Change working directory",
 			parameters: chdirSchema,
+			requiresSerialExecution: true,
 			async execute() {
 				executionOrder.push("chdir");
-				_toolVersion = 2;
 				latestTools = [chdirTool, makeTool(2)];
 				return {
 					content: [{ type: "text", text: "Changed directory" }],
@@ -1189,7 +1186,7 @@ describe("parallel mode tool refresh after chdir", () => {
 			const mockStream = new MockAssistantStream();
 			queueMicrotask(() => {
 				if (callIndex === 0) {
-					// Single response with both chdir and echo as parallel calls
+					// chdir listed first, echo second
 					const message = createAssistantMessage(
 						[
 							{ type: "toolCall", id: "tool-1", name: "chdir", arguments: { path: "/new" } },
@@ -1211,9 +1208,99 @@ describe("parallel mode tool refresh after chdir", () => {
 			// consume
 		}
 
-		// chdir should execute before echo (eagerly during preparation)
+		// chdir should execute before echo (pass 1 runs serial tools first)
 		expect(executionOrder).toEqual(["chdir", "echo"]);
 		// echo should use the refreshed tool (version 2) since chdir ran first
+		expect(echoToolVersion).toBe(2);
+	});
+
+	it("executes chdir eagerly before other tools in a parallel batch — chdir listed last", async () => {
+		// This is the order-dependency case: even when echo appears before chdir in the LLM
+		// response, the two-pass approach ensures echo is prepared AFTER chdir has run and
+		// refreshed tool bindings.
+		const toolSchema = Type.Object({ value: Type.String() });
+
+		let echoToolVersion: number | undefined;
+		const executionOrder: string[] = [];
+
+		const makeTool = (version: number): AgentTool<typeof toolSchema, { value: string }> => ({
+			name: "echo",
+			label: "Echo",
+			description: "Echo tool",
+			parameters: toolSchema,
+			async execute(_toolCallId, params) {
+				executionOrder.push("echo");
+				echoToolVersion = version;
+				return {
+					content: [{ type: "text", text: `v${version}: ${params.value}` }],
+					details: { value: params.value },
+				};
+			},
+		});
+
+		const chdirSchema = Type.Object({ path: Type.String() });
+		const chdirTool: AgentTool<typeof chdirSchema, { path: string }> = {
+			name: "chdir",
+			label: "Change Directory",
+			description: "Change working directory",
+			parameters: chdirSchema,
+			requiresSerialExecution: true,
+			async execute() {
+				executionOrder.push("chdir");
+				latestTools = [chdirTool, makeTool(2)];
+				return {
+					content: [{ type: "text", text: "Changed directory" }],
+					details: { path: "/new" },
+				};
+			},
+		};
+
+		let latestTools: AgentTool<any>[] = [chdirTool, makeTool(1)];
+
+		const context: AgentContext = {
+			systemPrompt: "",
+			messages: [],
+			tools: [chdirTool, makeTool(1)],
+		};
+
+		const userPrompt: AgentMessage = createUserMessage("echo and chdir together");
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+			toolExecution: "parallel",
+			getLatestTools: () => latestTools,
+		};
+
+		let callIndex = 0;
+		const stream = agentLoop([userPrompt], context, config, undefined, () => {
+			const mockStream = new MockAssistantStream();
+			queueMicrotask(() => {
+				if (callIndex === 0) {
+					// echo listed first, chdir listed last
+					const message = createAssistantMessage(
+						[
+							{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "hello" } },
+							{ type: "toolCall", id: "tool-2", name: "chdir", arguments: { path: "/new" } },
+						],
+						"toolUse",
+					);
+					mockStream.push({ type: "done", reason: "toolUse", message });
+				} else {
+					const message = createAssistantMessage([{ type: "text", text: "done" }]);
+					mockStream.push({ type: "done", reason: "stop", message });
+				}
+				callIndex++;
+			});
+			return mockStream;
+		});
+
+		for await (const _ of stream) {
+			// consume
+		}
+
+		// chdir should STILL execute before echo (pass 1 runs all serial tools first)
+		expect(executionOrder).toEqual(["chdir", "echo"]);
+		// echo should use the refreshed tool (version 2) even though it was listed first
 		expect(echoToolVersion).toBe(2);
 	});
 });

--- a/packages/coding-agent/docs/mach6.md
+++ b/packages/coding-agent/docs/mach6.md
@@ -63,7 +63,7 @@ Commit changes, push to remote, and post a progress comment.
 - Stages files by name (never `git add -A`)
 - Matches the repository's existing commit style
 - Auto-detects the associated PR from the current branch
-- Posts a `<!-- mach6-progress -->` comment with a summary of changes
+- Posts a `<!-- mach6-progress -->` comment with an **Architecture section** (generated from the diff) describing how touched files and functions relate, plus a summary of new and modified files
 
 ### mach6-review
 

--- a/packages/coding-agent/docs/mach6.md
+++ b/packages/coding-agent/docs/mach6.md
@@ -18,6 +18,17 @@ Inspired by [mach10](https://github.com/LeanAndMean/mach10) (MIT, by Kevin Ryan)
 /skill:mach6-publish 53        # Docs update, merge, tag, release
 ```
 
+### Streamlined Workflow (mach6mini)
+
+For quick iterations without formal issue tracking:
+
+```
+/skill:mach6mini-plan          # Discuss, plan, open PR (no issue)
+/skill:mach6mini-implement 53  # Implement and push in one step
+/skill:mach6-review 53         # Review (same as full workflow)
+/skill:mach6-publish 53        # Merge and release
+```
+
 ## Skills
 
 ### mach6-issue
@@ -111,6 +122,42 @@ Pre-merge checks, version bump, docs update, merge, tag, and release.
 - Merges with `--squash --delete-branch`
 - Optionally creates a git tag and GitHub release
 
+## Streamlined Skills (mach6mini)
+
+For quick iterations where formal issue tracking is unnecessary, two "mini" variants combine multiple steps:
+
+### mach6mini-plan
+
+Streamlined planning that skips issue creation — discuss with user, align on implementation, open PR directly.
+
+```
+/skill:mach6mini-plan                    # Interactive — asks what to build
+/skill:mach6mini-plan add caching layer  # Start from description
+```
+
+- Gathers requirements through discussion (replaces issue creation)
+- Explores codebase with parallel subagents
+- Drafts plan and gets user alignment before proceeding
+- Creates branch `feature/<slug>` (no issue number)
+- Opens draft PR with plan as comment
+
+Use when you want to skip formal issue tracking and go straight to implementation.
+
+### mach6mini-implement
+
+Streamlined implementation that pushes automatically after completion.
+
+```
+/skill:mach6mini-implement 53
+```
+
+- Reads plan and ALL PR comments to build effective requirements
+- **Latest comments win** — if discussion modifies the plan, follows the latest instructions
+- Implements using `feature-dev` subagents
+- Automatically commits, pushes, and posts progress comment
+
+Combines `mach6-implement` + `mach6-push` into one step.
+
 ## Agents
 
 ### feature-dev
@@ -135,7 +182,8 @@ Agents run as [subagents](../README.md#subagents) — `code-reviewer`, `error-au
 
 ## Design Principles
 
-- **GitHub as shared memory** — Plans, reviews, assessments, and progress are posted as PR/issue comments with HTML markers (`<!-- mach6-plan -->`, `<!-- mach6-review -->`, etc.) so any future session can pick up context.
+- **GitHub as shared memory** — Plans, reviews, assessments, and progress are posted as PR/issue comments with HTML markers (`<!-- mach6-plan -->`, `<!-- mach6-review -->`, `<!-- mach6mini-plan -->`, `<!-- mach6mini-progress -->`, etc.) so any future session can pick up context.
+- **Latest comments win** — When PR discussion modifies or contradicts the original plan, `mach6-implement` and `mach6mini-implement` follow the latest instructions. Plans are living documents.
 - **Independent assessment** — Review findings are independently verified before suggesting fixes, separating genuine issues from nitpicks and false positives.
 - **Iterative review cycles** — Review → fix → push → review, repeating until no genuine issues remain.
 - **Safe git** — Never `git add -A`, never stage secrets, stage files by name.

--- a/packages/coding-agent/docs/skills.md
+++ b/packages/coding-agent/docs/skills.md
@@ -275,7 +275,7 @@ cd ${DREB_SKILL_DIR} && npm install
 
 ## Built-in Skills
 
-dreb ships with **mach6**, a development workflow that orchestrates the full issue-to-merge lifecycle using GitHub as shared memory. Six skills cover each stage:
+dreb ships with **mach6**, a development workflow that orchestrates the full issue-to-merge lifecycle using GitHub as shared memory. Eight skills cover each stage:
 
 | Skill | What it does |
 |---|---|
@@ -285,6 +285,8 @@ dreb ships with **mach6**, a development workflow that orchestrates the full iss
 | `mach6-review` | Multi-agent code review with independent assessment |
 | `mach6-implement` | Implement plans, fix review findings, or fix CI failures |
 | `mach6-publish` | Pre-merge checks, docs update, merge, tag, release |
+| `mach6mini-plan` | Streamlined planning — discuss, plan, open PR (no issue) |
+| `mach6mini-implement` | Streamlined implementation — implement and push in one step |
 
 Built-in skills are always available and can be overridden by placing a skill with the same name in any [user or project location](#locations).
 

--- a/packages/coding-agent/skills/mach6-implement/SKILL.md
+++ b/packages/coding-agent/skills/mach6-implement/SKILL.md
@@ -19,6 +19,7 @@ This skill has two modes:
 3. **Safe git** — Never use `git add -A` or `git add .`. Stage files by name. Never stage secrets.
 4. **Task tracking** — Use the `tasks_update` tool to show progress.
 5. **Non-interactive `gh`** — Set `GH_PAGER=cat` and `GH_EDITOR=cat` before all `gh` commands to prevent interactive prompts from hanging the agent. Use `--body-file` instead of inline `--body` for all `gh pr comment`, `gh pr create`, and `gh issue create` calls to avoid shell interpretation of backticks.
+6. **Comment priority** — If PR discussion modifies or contradicts the original plan, **the latest comments are the source of truth**. Parse comment timestamps and apply modifications chronologically. When in doubt, follow the most recent user instructions.
 
 ## Step 1: Parse input
 
@@ -61,16 +62,28 @@ git pull
 
 ## Implement Mode (PR number only)
 
-### Step 3i: Read the plan and full PR context
+### Step 3i: Read the plan and build effective requirements
 
 Read ALL PR comments and the PR body to get complete context:
 ```bash
-gh pr view <pr-number> --json title,body,comments
+gh pr view <pr-number> --json title,body,comments,createdAt
 ```
 
 Find the plan comment (contains `<!-- mach6-plan -->` marker) from the comments. If no plan comment exists, tell the user and suggest running `/skill:mach6-plan` first.
 
-Also read any progress updates, prior review findings, assessments, and discussion — all of this context informs implementation.
+**Build effective requirements:**
+
+1. **Start with the plan** — The `<!-- mach6-plan -->` comment is the baseline.
+
+2. **Scan subsequent comments chronologically** — For each comment after the plan:
+   - If it modifies scope (adds/removes deliverables), update requirements
+   - If it changes acceptance criteria, use the new criteria
+   - If it provides implementation guidance, incorporate it
+   - If it contradicts the plan, **follow the later comment**
+
+3. **Identify the effective requirements** — The plan as modified by all subsequent discussion. This is what you will actually implement.
+
+Also read any progress updates, prior review findings, assessments — all of this context informs implementation. But when the plan and later comments conflict, **the latest comments win**.
 
 ### Step 4i: Set up task tracking
 
@@ -93,9 +106,9 @@ Read all files mentioned in the plan. Understand the existing code before making
 
 Use the `feature-dev` subagent to implement each deliverable. `feature-dev` is a **pre-existing agent definition** shipped with dreb — it has full tool access (read, write, edit, grep, find, ls, bash, search) and uses a strong-tier model with a provider fallback list. Do not override its model unless there's a specific reason.
 
-**For each deliverable in the plan**, launch a `feature-dev` subagent via the `subagent` tool. Provide each agent with:
-- The specific deliverable to implement (files to modify, what to change, expected behavior)
-- The full plan context and any relevant PR discussion
+**For each deliverable in the effective requirements**, launch a `feature-dev` subagent via the `subagent` tool. Provide each agent with:
+- The specific deliverable to implement (from effective requirements, not stale plan if it was modified)
+- The full plan context and any PR discussion that modified the requirements
 - The list of files to read for understanding existing patterns
 - Instructions to run tests and linting after making changes
 - **If the plan includes tests for this deliverable, tests MUST be written as part of the implementation — not deferred**

--- a/packages/coding-agent/skills/mach6-push/SKILL.md
+++ b/packages/coding-agent/skills/mach6-push/SKILL.md
@@ -70,7 +70,26 @@ Update task: push → completed, comment → in_progress.
 
 ## Step 5: Post progress comment
 
-Detect the associated PR or issue:
+### 5a: Inspect the diff
+
+Examine the committed changes to understand their structure:
+
+```bash
+git diff HEAD~1 HEAD
+```
+
+If this is the first commit on the branch (no `HEAD~1`), use:
+
+```bash
+git show HEAD
+```
+
+Analyze the diff:
+- **Multi-file changes**: identify entry points, shared utilities, call direction, and data flow between files
+- **Single-file changes**: identify public API surface, internal helpers, call graph, and key data structures
+- **Trivial changes** (typo fixes, config tweaks, version bumps): note that no structural impact occurred
+
+### 5b: Detect the associated PR or issue
 
 1. **Session context first**: If an earlier mach6 command in this session targeted a specific PR or issue, use that.
 2. **PR detection**: Try `gh pr view --json number,url` on current branch. If a PR exists, comment on it.
@@ -79,21 +98,62 @@ Detect the associated PR or issue:
 
 If session context points to an issue but a PR also exists on the current branch, prefer the PR.
 
-Post a progress comment:
+### 5c: Post the comment
+
+Post a progress comment using the formalized structure below:
+
 ```bash
 cat > /tmp/gh-comment.md << 'MACH6_EOF'
 <!-- mach6-progress -->
 ## Progress Update
 
-<summary of changes in this batch>
+### Architecture
+<generated from diff analysis — see guidance below>
 
-**Commit:** \`<hash>\`
+### New files
+- `path/to/file.ts` — one-line description
+
+### Modified files
+- `path/to/file.ts` — one-line description
+
+**Commit:** `<hash>`
 
 ---
 *Progress tracked by mach6*
 MACH6_EOF
 gh pr comment <number> --body-file /tmp/gh-comment.md
 ```
+
+**Core sections** — always present:
+- **Architecture** — generated from diff analysis (see guidance below)
+- **New files** — omit the header if no new files in this commit
+- **Modified files** — omit the header if no modified files in this commit
+
+**Optional sections** — add when helpful to a reader or future session:
+- `### Verification` — if tests were run or specific behaviors were validated
+- `### Migration notes` — if schema, API, or config changes require consumer action
+- `### Known limitations` — if the work is intentionally incomplete or has known gaps
+
+**Architecture section guidance:**
+
+Write 1–8 sentences that give a **self-contained** structural description of the changes. A reader who sees only this comment should fully understand what was built, how it's organized, and how the pieces connect — without opening any file.
+
+- **Multi-file pushes**: Describe inter-file relationships — which files are entry points, which are shared utilities, which call which, what data flows between them. Then drill into key intra-file structure for non-trivial files (public API surface, internal helpers, class/function relationships).
+- **Single-file pushes**: Describe intra-file structure — public API vs internal helpers, call graph, key data structures, how the parts compose.
+- **Trivial changes** (typo fixes, version bumps, config tweaks): Include the section but keep it brief — e.g., "Single config value change in `settings.json`, no structural impact."
+- **Focus**: on the most architecturally significant relationships. Omit exhaustive detail.
+
+**Examples:**
+
+Multi-file:
+> **Architecture**
+>
+> `acquisition_run_positionAcqf.py` is the main entry point for position-diversified GP acquisition runs. Both it and the existing `acquisition_run.py` delegate shared data-loading and search-space construction to `utils.py` (`load_protein_data`, `build_searchspace`, `build_campaign`). Results are written to `result_metrics_d-*` files, which `acquisition_analysis.ipynb` loads for plotting.
+
+Single-file:
+> **Architecture**
+>
+> `parser.ts` exposes one public function `parse()` which drives the pipeline. It delegates tokenisation to `tokenize()` and AST construction to `buildNode()`, both private. Error recovery is centralised in `recover()`, called by `buildNode()` on unexpected tokens.
 
 Update task: comment → completed.
 

--- a/packages/coding-agent/skills/mach6mini-implement/SKILL.md
+++ b/packages/coding-agent/skills/mach6mini-implement/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: mach6mini-implement
+description: "Streamlined implementation that pushes automatically after completion. Reads plan, implements, commits, pushes, posts progress — all in one. Usage: mach6mini-implement 42"
+argument-hint: "<pr-number>"
+---
+
+# mach6mini-implement — Implement and Push
+
+**User input:** $ARGUMENTS
+
+This is a streamlined workflow that merges implementation + push into one step. After implementing the plan, changes are automatically committed, pushed, and a progress comment is posted.
+
+## Global Rules
+
+1. **GitHub as shared memory** — Plans, reviews, and progress are posted as PR comments with HTML markers.
+2. **HTML markers** — Use `<!-- mach6mini-progress -->` as the first line of progress comment bodies.
+3. **No `#N` in comment bodies** — Use "finding 3", "item 3" etc. instead.
+4. **Safe git** — Never use `git add -A` or `git add .`. Stage files by name. Never stage secrets.
+5. **Task tracking** — Use the `tasks_update` tool to show progress.
+6. **Non-interactive `gh`** — Set `GH_PAGER=cat` and `GH_EDITOR=cat` before all `gh` commands. Use `--body-file` instead of `--body`.
+7. **Comment priority** — If PR discussion modifies or contradicts the original plan, **the latest comments are the source of truth**. Parse comment timestamps and apply modifications chronologically. When in doubt, follow the most recent user instructions.
+
+## Step 1: Parse input and checkout
+
+Extract the PR number from `$ARGUMENTS`.
+
+```bash
+# Get the PR's branch name
+PR_BRANCH=$(gh pr view <pr-number> --json headRefName --jq '.headRefName')
+REPO_NAME=$(basename "$(git rev-parse --show-toplevel)")
+
+# Check if a worktree already exists for this branch
+git worktree list
+# If a worktree exists for the PR branch, reuse it.
+# If not, create one — derive worktree path from branch name
+git worktree add "../${REPO_NAME}-worktrees/<derived-from-branch>" "$PR_BRANCH"
+```
+
+Switch the agent's working directory to the worktree using the `chdir` tool:
+```
+chdir { path: "<worktree-path>" }
+```
+
+Then pull latest changes:
+```bash
+git pull
+```
+
+## Step 2: Read plan and build effective requirements
+
+Read ALL PR comments to get complete context:
+```bash
+gh pr view <pr-number> --json title,body,comments,createdAt
+```
+
+**Build effective requirements:**
+
+1. **Find the plan comment** — Look for `<!-- mach6mini-plan -->` or `<!-- mach6-plan -->` marker. This is the baseline.
+
+2. **Scan subsequent comments chronologically** — For each comment after the plan:
+   - If it modifies scope (adds/removes deliverables), update requirements
+   - If it changes acceptance criteria, use the new criteria
+   - If it provides implementation guidance, incorporate it
+   - If it contradicts the plan, **follow the later comment**
+
+3. **Identify the effective requirements** — The plan as modified by all subsequent discussion. Summarize what you will actually implement.
+
+If no plan comment exists, tell the user and suggest running `/skill:mach6mini-plan` first.
+
+## Step 3: Set up task tracking
+
+Create tasks based on the effective requirements (plan + modifications):
+```
+tasks_update([
+  { id: "read", title: "Read plan and codebase", status: "completed" },
+  { id: "feature-1", title: "Implement <deliverable 1>", status: "in_progress" },
+  { id: "feature-2", title: "Implement <deliverable 2>", status: "pending" },
+  { id: "test", title: "Add/update tests", status: "pending" },
+  { id: "verify", title: "Build and verify", status: "pending" },
+  { id: "push", title: "Commit and push", status: "pending" },
+  { id: "comment", title: "Post progress", status: "pending" }
+])
+```
+
+## Step 4: Read the codebase
+
+Read all files mentioned in the effective requirements. Understand the existing code before making changes.
+
+## Step 5: Implement
+
+Use the `feature-dev` subagent to implement each deliverable. `feature-dev` is a **pre-existing agent definition** shipped with dreb — it has full tool access (read, write, edit, grep, find, ls, bash, search) and uses a strong-tier model with a provider fallback list.
+
+**For each deliverable**, launch a `feature-dev` subagent with:
+- The specific deliverable to implement (from effective requirements, not stale plan)
+- Full context including any PR discussion that modified the requirements
+- The list of files to read for understanding existing patterns
+- Instructions to run tests and linting after making changes
+- **If tests are specified, they MUST be written as part of the implementation**
+
+**Parallelism:** If deliverables are independent (don't modify the same files), run their `feature-dev` agents in parallel. If they have dependencies, run sequentially.
+
+**Small plans (1-2 simple deliverables):** You may implement directly instead of delegating.
+
+Update task tracking as each deliverable completes.
+
+## Step 6: Verify
+
+After all implementation is complete:
+- Run the project's test suite
+- Run any linting/formatting tools
+- Build the project if applicable
+- Verify each deliverable from the **effective requirements** is addressed
+
+Update task: verify → completed, push → in_progress.
+
+## Step 7: Commit and push
+
+Stage all modified files **by name** (never `git add -A`):
+```bash
+git status
+git add <file1> <file2> ...
+```
+
+Check recent commit style and commit:
+```bash
+git log --oneline -5
+git commit -m "<message following repo style>"
+```
+
+Push:
+```bash
+git push
+```
+
+Update task: push → completed, comment → in_progress.
+
+## Step 8: Post progress comment
+
+Examine the committed changes:
+```bash
+git diff HEAD~1 HEAD
+```
+
+Post a progress comment:
+```bash
+cat > /tmp/gh-comment.md << 'MACH6_EOF'
+<!-- mach6mini-progress -->
+## Progress Update
+
+### Architecture
+<describe how the changed files relate — entry points, utilities, data flow>
+
+### New files
+- `path/to/file.ts` — one-line description
+
+### Modified files
+- `path/to/file.ts` — one-line description
+
+### Verification
+<tests run, behaviors validated>
+
+**Commit:** `<hash>`
+
+---
+*Progress tracked by mach6mini*
+MACH6_EOF
+gh pr comment <pr-number> --body-file /tmp/gh-comment.md
+```
+
+Update task: comment → completed.
+
+Suggest next step: `/skill:mach6-review <pr-number>` for code review.

--- a/packages/coding-agent/skills/mach6mini-plan/SKILL.md
+++ b/packages/coding-agent/skills/mach6mini-plan/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: mach6mini-plan
+description: "Streamlined planning that skips issue creation — discuss with user, align on implementation, open PR directly. Usage: mach6mini-plan [description]"
+argument-hint: "[description]"
+---
+
+# mach6mini-plan — Plan and Open PR (No Issue)
+
+**User input:** $ARGUMENTS
+
+This is a streamlined workflow that merges issue discussion + planning into one step. No GitHub issue is created — the PR becomes the source of truth.
+
+This command is strictly for **planning**. Do NOT implement any code changes — no file edits, no file writes.
+
+## Global Rules
+
+1. **GitHub as shared memory** — Plans, reviews, assessments, and progress are posted as PR/issue comments so any future session can pick up context.
+2. **HTML markers** — Use `<!-- mach6mini-plan -->` as the first line of plan comment bodies for reliable discovery.
+3. **No `#N` in comment bodies** — GitHub auto-links `#N` to issues/PRs. Use "finding 3", "item 3", "stage 2" etc. instead.
+4. **Safe git** — Never use `git add -A` or `git add .`. Stage files by name. Never stage secrets.
+5. **Task tracking** — Use the `tasks_update` tool to show progress through multi-step commands.
+6. **Project conventions** — Check for CLAUDE.md, AGENTS.md, .dreb/CONTEXT.md, and CONTRIBUTING.md before planning.
+7. **Non-interactive `gh`** — Set `GH_PAGER=cat` and `GH_EDITOR=cat` before all `gh` commands to prevent interactive prompts from hanging the agent. Use `--body-file` instead of inline `--body` for all `gh pr comment`, `gh pr create`, and `gh issue create` calls to avoid shell interpretation of backticks.
+
+## Step 1: Set up task tracking
+
+```
+tasks_update([
+  { id: "gather", title: "Gather requirements", status: "in_progress" },
+  { id: "explore", title: "Explore codebase", status: "pending" },
+  { id: "plan", title: "Draft implementation plan", status: "pending" },
+  { id: "branch", title: "Create branch and draft PR", status: "pending" },
+  { id: "post", title: "Post plan to PR", status: "pending" }
+])
+```
+
+## Step 2: Gather requirements
+
+If the user provided a description in `$ARGUMENTS`, use it as the starting point.
+
+If no arguments were provided, ask the user:
+- What do they want to build or change?
+- What problem does it solve?
+- Any constraints or requirements?
+
+**Discuss and align** — Before proceeding, ensure you and the user are aligned on:
+- The scope of the work
+- What "done" looks like
+- Any constraints or non-goals
+
+This discussion phase replaces formal issue creation. Get explicit user approval before proceeding to exploration.
+
+Update task: gather → completed, explore → in_progress.
+
+## Step 3: Read project conventions
+
+Check for and read (first found):
+- CONTRIBUTING.md, DEVELOPMENT.md, .github/CONTRIBUTING.md
+- CLAUDE.md, AGENTS.md, .dreb/CONTEXT.md
+
+Extract planning-relevant guidance: project layers, testing expectations, coding conventions.
+
+## Step 4: Explore the codebase
+
+Launch 2-3 Explore subagents in parallel. Agent definitions specify their own model with a provider fallback list — defaults work across providers and are fine for most cases. Override only with good reason.
+- **Similar features**: Find existing code that solves related problems, trace implementation patterns
+- **Architecture**: Map relevant architecture layers, abstractions, data flow
+- **Integration points**: Identify where new code connects to existing systems
+
+Include project conventions in each agent's context. Each agent returns 5-10 key files. Read all identified files.
+
+Update task: explore → completed, plan → in_progress.
+
+## Step 5: Draft the plan
+
+Create an implementation plan with:
+- Clear analysis of the problem
+- **Deliverables**: What will be produced (be specific)
+- **Acceptance criteria**: How to verify the work is done
+- **Files to create or modify**: List each with what changes
+- **Testing approach**: What tests to write, what to verify
+- **Risks and open questions**: Anything that might derail implementation
+
+The plan should be **high-level on implementation details** (avoid cascading spec errors from over-specifying) but **specific on deliverables and acceptance criteria**.
+
+**Project-layer coverage:** Cross-check the plan against discovered project layers. Every affected layer should be addressed.
+
+**Test coverage is mandatory, not optional.** Every new behavior, command handler, formatting function, or event wiring must include tests in the plan. If the target package lacks test infrastructure, the plan must include setting it up as a deliverable — this cannot be deferred.
+
+Present the plan to the user. Discuss and revise if they have feedback.
+
+**Get explicit approval** before creating the branch and PR.
+
+Update task: plan → completed, branch → in_progress.
+
+## Step 6: Create branch and draft PR
+
+Use a git worktree to isolate the PR's work from the current directory.
+
+```bash
+# Derive branch name from the plan
+# Format: feature/<slug> (slug = 3-5 words from title, lowercase, hyphens)
+# Note: No issue number since this workflow skips issue creation
+
+# Check if a worktree already exists for this branch
+git worktree list
+# If a worktree exists for the branch, reuse it (skip branch + worktree creation).
+# If not, create the branch and worktree:
+
+# Create the branch (without switching to it)
+git branch feature/<slug>
+
+# Determine repo name for worktree path convention
+REPO_NAME=$(basename "$(git rev-parse --show-toplevel)")
+
+# Create a worktree for the new branch (use slug for path since no issue number)
+git worktree add "../${REPO_NAME}-worktrees/<slug>" feature/<slug>
+```
+
+Switch the agent's working directory to the worktree using the `chdir` tool:
+```
+chdir { path: "../<repo-name>-worktrees/<slug>" }
+```
+
+Now operating in the worktree — create the empty commit and push:
+```bash
+git commit --allow-empty -m "chore: open PR for <brief description>"
+
+git push -u origin feature/<slug>
+
+# Open draft PR (no "Closes #N" since no issue)
+cat > /tmp/gh-body.md << 'MACH6_EOF'
+<brief description of the change>
+
+## Summary
+
+<2-3 sentence summary of what this PR does>
+
+Implementation plan posted as a comment below.
+MACH6_EOF
+gh pr create --draft --title "<title>" --body-file /tmp/gh-body.md
+```
+
+Update task: branch → completed, post → in_progress.
+
+## Step 7: Post plan to PR
+
+```bash
+cat > /tmp/gh-comment.md << 'MACH6_EOF'
+<!-- mach6mini-plan -->
+## Implementation Plan
+
+<full plan content>
+
+---
+*Plan created by mach6mini*
+MACH6_EOF
+gh pr comment <pr-number> --body-file /tmp/gh-comment.md
+```
+
+Update task: post → completed.
+
+Suggest next step: `/skill:mach6mini-implement <pr-number>` to implement and push in one step.

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -369,6 +369,12 @@ export interface ToolDefinition<TParams extends TSchema = TSchema, TDetails = un
 	promptGuidelines?: string[];
 	/** Parameter schema (TypeBox) */
 	parameters: TParams;
+	/**
+	 * When true, this tool is executed eagerly and serially in `executeToolCallsParallel`,
+	 * before any other tools in the same response are prepared. Use for tools that mutate
+	 * shared state (e.g. cwd) so that subsequent tool preparations use the updated state.
+	 */
+	requiresSerialExecution?: boolean;
 
 	/** Execute the tool. */
 	execute(

--- a/packages/coding-agent/src/core/tools/chdir.ts
+++ b/packages/coding-agent/src/core/tools/chdir.ts
@@ -28,6 +28,7 @@ export function createChdirToolDefinition(
 		description:
 			"Change the working directory. Validates that the target exists and is inside a git repository. All subsequent tool operations will use the new directory.",
 		parameters: chdirSchema,
+		requiresSerialExecution: true,
 		async execute(_toolCallId, { path }: { path: string }, _signal?, _onUpdate?, _ctx?) {
 			const resolvedPath = resolveToCwd(path, cwd);
 

--- a/packages/coding-agent/src/core/tools/tool-definition-wrapper.ts
+++ b/packages/coding-agent/src/core/tools/tool-definition-wrapper.ts
@@ -11,6 +11,7 @@ export function wrapToolDefinition<TDetails = unknown>(
 		label: definition.label,
 		description: definition.description,
 		parameters: definition.parameters,
+		requiresSerialExecution: definition.requiresSerialExecution,
 		execute: (toolCallId, params, signal, onUpdate) =>
 			definition.execute(toolCallId, params, signal, onUpdate, ctxFactory?.() as ExtensionContext),
 	};

--- a/packages/coding-agent/src/core/tools/tool-definition-wrapper.ts
+++ b/packages/coding-agent/src/core/tools/tool-definition-wrapper.ts
@@ -37,6 +37,7 @@ export function createToolDefinitionFromAgentTool(tool: AgentTool<any>): ToolDef
 		label: tool.label,
 		description: tool.description,
 		parameters: tool.parameters as any,
+		requiresSerialExecution: tool.requiresSerialExecution,
 		execute: async (toolCallId, params, signal, onUpdate) => tool.execute(toolCallId, params, signal, onUpdate),
 	};
 }

--- a/packages/coding-agent/test/agent-session-chdir.test.ts
+++ b/packages/coding-agent/test/agent-session-chdir.test.ts
@@ -109,6 +109,70 @@ describe("AgentSession chdir integration", () => {
 		expect(session.systemPrompt).toContain(subDir);
 	});
 
+	it("after chdir, rebuilt tools resolve paths against new cwd", async () => {
+		const settingsManager = SettingsManager.create(tempDir, agentDir);
+		const sessionManager = SessionManager.inMemory();
+		const resourceLoader = new DefaultResourceLoader({
+			cwd: repoDir,
+			agentDir,
+			settingsManager,
+			extensionFactories: [],
+		});
+		await resourceLoader.reload();
+
+		const { session } = await createAgentSession({
+			cwd: repoDir,
+			agentDir,
+			model: findModel("anthropic", "sonnet")!,
+			settingsManager,
+			sessionManager,
+			resourceLoader,
+		});
+
+		// Verify initial cwd
+		expect((session as any)._cwd).toBe(repoDir);
+
+		// Get edit tool before chdir — it should resolve relative paths against repoDir
+		const editBefore = session.getToolDefinition("edit");
+		expect(editBefore).toBeDefined();
+
+		// Execute chdir to subDir
+		const chdirDef = session.getToolDefinition("chdir");
+		await chdirDef!.execute("test-call-id", { path: subDir }, undefined, undefined, undefined as any);
+
+		// Verify cwd was updated
+		expect((session as any)._cwd).toBe(subDir);
+
+		// Get edit tool AFTER chdir — it should be a new instance with the new cwd
+		const editAfter = session.getToolDefinition("edit");
+		expect(editAfter).toBeDefined();
+
+		// The tool instances should be different (rebuilt)
+		expect(editAfter).not.toBe(editBefore);
+
+		// Verify the new edit tool resolves paths against the new cwd by executing
+		// an edit on a file in subDir. Create a file in subDir first.
+		writeFileSync(join(subDir, "test-file.txt"), "old content\n");
+
+		const editResult = await editAfter!.execute(
+			"edit-call-id",
+			{ path: "test-file.txt", oldText: "old content\n", newText: "new content\n" },
+			undefined,
+			undefined,
+			undefined as any,
+		);
+
+		// Should succeed — resolves "test-file.txt" against subDir (new cwd)
+		expect(editResult.content[0]).toMatchObject({
+			type: "text",
+			text: expect.stringContaining("test-file.txt"),
+		});
+
+		// Verify the file was actually edited in subDir
+		const { readFileSync } = await import("node:fs");
+		expect(readFileSync(join(subDir, "test-file.txt"), "utf-8")).toBe("new content\n");
+	});
+
 	it("_changeCwd rolls back on _buildRuntime failure", async () => {
 		const settingsManager = SettingsManager.create(tempDir, agentDir);
 		const sessionManager = SessionManager.inMemory();

--- a/packages/coding-agent/test/agent-session-chdir.test.ts
+++ b/packages/coding-agent/test/agent-session-chdir.test.ts
@@ -9,12 +9,26 @@ import { createAgentSession } from "../src/core/sdk.js";
 import { SessionManager } from "../src/core/session-manager.js";
 import { SettingsManager } from "../src/core/settings-manager.js";
 import { createChdirTool } from "../src/core/tools/chdir.js";
+import { createToolDefinitionFromAgentTool, wrapToolDefinition } from "../src/core/tools/tool-definition-wrapper.js";
 
 // Verify that the production-wrapped chdir tool carries requiresSerialExecution: true so
 // that executeToolCallsParallel's pass 1 correctly identifies it as a serial tool.
 it("createChdirTool carries requiresSerialExecution: true", () => {
 	const tool = createChdirTool(process.cwd());
 	expect(tool.requiresSerialExecution).toBe(true);
+});
+
+// Verify that the AgentTool → ToolDefinition → AgentTool round-trip (used by
+// _buildRuntime when baseToolsOverride is provided) preserves requiresSerialExecution.
+it("createToolDefinitionFromAgentTool preserves requiresSerialExecution through round-trip", () => {
+	const original = createChdirTool(process.cwd());
+	expect(original.requiresSerialExecution).toBe(true);
+
+	const def = createToolDefinitionFromAgentTool(original);
+	expect(def.requiresSerialExecution).toBe(true);
+
+	const rewrapped = wrapToolDefinition(def);
+	expect(rewrapped.requiresSerialExecution).toBe(true);
 });
 
 // Remove GIT_* env vars that leak from git hooks

--- a/packages/coding-agent/test/agent-session-chdir.test.ts
+++ b/packages/coding-agent/test/agent-session-chdir.test.ts
@@ -8,6 +8,14 @@ import { DefaultResourceLoader } from "../src/core/resource-loader.js";
 import { createAgentSession } from "../src/core/sdk.js";
 import { SessionManager } from "../src/core/session-manager.js";
 import { SettingsManager } from "../src/core/settings-manager.js";
+import { createChdirTool } from "../src/core/tools/chdir.js";
+
+// Verify that the production-wrapped chdir tool carries requiresSerialExecution: true so
+// that executeToolCallsParallel's pass 1 correctly identifies it as a serial tool.
+it("createChdirTool carries requiresSerialExecution: true", () => {
+	const tool = createChdirTool(process.cwd());
+	expect(tool.requiresSerialExecution).toBe(true);
+});
 
 // Remove GIT_* env vars that leak from git hooks
 const { GIT_DIR: _, GIT_INDEX_FILE: __, GIT_WORK_TREE: ___, ...cleanEnv } = process.env;


### PR DESCRIPTION
Closes #6

Add two new streamlined mach6 skills for quick iterations where formal issue tracking is unnecessary, plus update existing mach6-implement with "latest comments win" behavior.

Implementation plan posted as a comment below.
