### PR TITLE
VSCode extension Phase 0+1: RPC foundation + MVP chat with streaming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ packages/ai/src/models.generated.ts
 *.env
 .env*
 secrets/
+
+# VS Code extension packages
+*.vsix

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,12 @@
+{
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "Run dreb VSCode Extension",
+			"type": "extensionHost",
+			"request": "launch",
+			"args": ["--extensionDevelopmentPath=${workspaceFolder}/packages/vscode"],
+			"outFiles": ["${workspaceFolder}/packages/vscode/dist/host/**/*.js"]
+		}
+	]
+}

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ The same agent runtime powers multiple surfaces:
 - **SDK** — import `@dreb/coding-agent` and create agent sessions directly in TypeScript.
 - **Telegram** — `@dreb/telegram` runs dreb as a bot with sessions, model controls, file upload/download, live tool status, and visible results for user-facing tools.
 - **Web dashboard** — `dreb dashboard` serves a browser UI (fleet overview of all sessions, full chat with steering, subagent observability, host file browser, dreb memory editor); local-only by default, remote via Tailscale + rotating pairing code. See [dashboard docs](packages/coding-agent/docs/dashboard.md).
+- **VS Code extension** *(early)* — `packages/vscode` embeds a native chat webview driven over RPC: streaming responses with a collapsible thinking/tool activity box, slash commands, and inline prompts. See [its README](packages/vscode/README.md).
 
 ### Web dashboard
 

--- a/biome.json
+++ b/biome.json
@@ -29,6 +29,8 @@
 			"packages/*/test/**/*.ts",
 			"packages/dashboard/src/**/*.tsx",
 			"packages/dashboard/test/**/*.tsx",
+			"packages/vscode/src/**/*.tsx",
+			"packages/vscode/test/**/*.tsx",
 			"packages/coding-agent/examples/**/*.ts",
 			"packages/web-ui/src/**/*.ts",
 			"packages/web-ui/example/**/*.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4556,6 +4556,13 @@
 			"license": "MIT",
 			"optional": true
 		},
+		"node_modules/@types/vscode": {
+			"version": "1.125.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.125.0.tgz",
+			"integrity": "sha512-0icm/ZQAaism87P0ekHqi4/Ju9du+Tm0RUW+y7vqRsxY2cY0FNRX1nAnaW7nT6npPt2tfHiheZ55Zm9UhqonFA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/yauzl": {
 			"version": "2.10.3",
 			"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
@@ -5936,6 +5943,10 @@
 		},
 		"node_modules/dreb-extension-with-deps": {
 			"resolved": "packages/coding-agent/examples/extensions/with-deps",
+			"link": true
+		},
+		"node_modules/dreb-vscode": {
+			"resolved": "packages/vscode",
 			"link": true
 		},
 		"node_modules/dunder-proto": {
@@ -11513,6 +11524,745 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"packages/vscode": {
+			"name": "dreb-vscode",
+			"version": "0.1.0",
+			"license": "MIT",
+			"dependencies": {
+				"@dreb/coding-agent": "*"
+			},
+			"devDependencies": {
+				"@types/node": "^22.10.5",
+				"@types/vscode": "^1.100.0",
+				"dompurify": "^3.4.11",
+				"marked": "^15.0.12",
+				"solid-js": "^1.9.14",
+				"typescript": "^5.9.2",
+				"vite": "^8.1.3",
+				"vite-plugin-solid": "^2.11.12",
+				"vitest": "^4.1.8"
+			},
+			"engines": {
+				"node": "22.x",
+				"vscode": "^1.100.0"
+			}
+		},
+		"packages/vscode/node_modules/@oxc-project/types": {
+			"version": "0.143.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.143.0.tgz",
+			"integrity": "sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/Boshen"
+			}
+		},
+		"packages/vscode/node_modules/@rolldown/binding-android-arm64": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.3.tgz",
+			"integrity": "sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"packages/vscode/node_modules/@rolldown/binding-darwin-arm64": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.3.tgz",
+			"integrity": "sha512-ieIiibVCp0tX7TLu2cafoNPv8wJyYi01ekXpbf8q2j7F4rGAhhXb/eQh7ge9DRBY78GwmRQtvjZDux7EDbA8kA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"packages/vscode/node_modules/@rolldown/binding-darwin-x64": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.3.tgz",
+			"integrity": "sha512-Zh9tCon19eDXJoihx0rqKhMUlMYqzwj3aPsSuHmI4RWZh62dWUL+DJN4C5YQya5TcQBJU/Fe8+rY0jhXTQITqA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"packages/vscode/node_modules/@rolldown/binding-freebsd-x64": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.3.tgz",
+			"integrity": "sha512-nGbJWewA1wrXXZiQhjAT5rhibGfns5ZNkDVqxsO6zJ3f3YvpoDNNmGMSbbhLuXKjNScaBJVOAboztAWVespQMg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"packages/vscode/node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.3.tgz",
+			"integrity": "sha512-QNniJr5Kml0kDEB98jiDOJjXNroxIIi0IXIbdYzY26Xt1pVbeP62+KnoIZLwirOymX/0jDk/2gI/bNUv7A7OIw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"packages/vscode/node_modules/@rolldown/binding-linux-arm64-gnu": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.3.tgz",
+			"integrity": "sha512-TkqEAcmmvH3I/q4114NB4RVt6241Dao48pF45uLcFGrwAaIn0iITgTAKP/dLjbN0R4buJjGb91+UHSoFmpgIWw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"packages/vscode/node_modules/@rolldown/binding-linux-arm64-musl": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.3.tgz",
+			"integrity": "sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"packages/vscode/node_modules/@rolldown/binding-linux-ppc64-gnu": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.3.tgz",
+			"integrity": "sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"packages/vscode/node_modules/@rolldown/binding-linux-s390x-gnu": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.3.tgz",
+			"integrity": "sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"packages/vscode/node_modules/@rolldown/binding-linux-x64-gnu": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.3.tgz",
+			"integrity": "sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"packages/vscode/node_modules/@rolldown/binding-linux-x64-musl": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.3.tgz",
+			"integrity": "sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"packages/vscode/node_modules/@rolldown/binding-openharmony-arm64": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.3.tgz",
+			"integrity": "sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"packages/vscode/node_modules/@rolldown/binding-win32-arm64-msvc": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.3.tgz",
+			"integrity": "sha512-hOtMwTqnME+/gJcH/PCZ0wn0zPUjiWOgkHpxbSJpfGKMezHltx1S7/k1SitzVa7Ww2cqrDDaFbZEhcJZO8o+Jw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"packages/vscode/node_modules/@rolldown/binding-win32-x64-msvc": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.3.tgz",
+			"integrity": "sha512-ekcqMMkI2PlhYnfzQnB/cEdYUVVJViWvoUyLrbzgDoi3Snfc1mVBwdnc306ufA5ejy8JSPjT2RlW1nQSjW7efg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"packages/vscode/node_modules/fdir": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
+			}
+		},
+		"packages/vscode/node_modules/lightningcss": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+			"integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+			"dev": true,
+			"license": "MPL-2.0",
+			"dependencies": {
+				"detect-libc": "^2.0.3"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"lightningcss-android-arm64": "1.33.0",
+				"lightningcss-darwin-arm64": "1.33.0",
+				"lightningcss-darwin-x64": "1.33.0",
+				"lightningcss-freebsd-x64": "1.33.0",
+				"lightningcss-linux-arm-gnueabihf": "1.33.0",
+				"lightningcss-linux-arm64-gnu": "1.33.0",
+				"lightningcss-linux-arm64-musl": "1.33.0",
+				"lightningcss-linux-x64-gnu": "1.33.0",
+				"lightningcss-linux-x64-musl": "1.33.0",
+				"lightningcss-win32-arm64-msvc": "1.33.0",
+				"lightningcss-win32-x64-msvc": "1.33.0"
+			}
+		},
+		"packages/vscode/node_modules/lightningcss-android-arm64": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+			"integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"packages/vscode/node_modules/lightningcss-darwin-arm64": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+			"integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"packages/vscode/node_modules/lightningcss-darwin-x64": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+			"integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"packages/vscode/node_modules/lightningcss-freebsd-x64": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+			"integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"packages/vscode/node_modules/lightningcss-linux-arm-gnueabihf": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+			"integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"packages/vscode/node_modules/lightningcss-linux-arm64-gnu": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+			"integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"packages/vscode/node_modules/lightningcss-linux-arm64-musl": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+			"integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"packages/vscode/node_modules/lightningcss-linux-x64-gnu": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+			"integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"packages/vscode/node_modules/lightningcss-linux-x64-musl": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+			"integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"packages/vscode/node_modules/lightningcss-win32-arm64-msvc": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+			"integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"packages/vscode/node_modules/lightningcss-win32-x64-msvc": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+			"integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"packages/vscode/node_modules/nanoid": {
+			"version": "3.3.18",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+			"integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"bin": {
+				"nanoid": "bin/nanoid.cjs"
+			},
+			"engines": {
+				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+			}
+		},
+		"packages/vscode/node_modules/picomatch": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+			"integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"packages/vscode/node_modules/postcss": {
+			"version": "8.5.26",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+			"integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/postcss"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"nanoid": "^3.3.17",
+				"picocolors": "^1.1.1",
+				"source-map-js": "^1.2.1"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14"
+			}
+		},
+		"packages/vscode/node_modules/rolldown": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.3.tgz",
+			"integrity": "sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@oxc-project/types": "=0.143.0",
+				"@rolldown/pluginutils": "^1.0.0"
+			},
+			"bin": {
+				"rolldown": "bin/cli.mjs"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"optionalDependencies": {
+				"@rolldown/binding-android-arm64": "1.2.3",
+				"@rolldown/binding-darwin-arm64": "1.2.3",
+				"@rolldown/binding-darwin-x64": "1.2.3",
+				"@rolldown/binding-freebsd-x64": "1.2.3",
+				"@rolldown/binding-linux-arm-gnueabihf": "1.2.3",
+				"@rolldown/binding-linux-arm64-gnu": "1.2.3",
+				"@rolldown/binding-linux-arm64-musl": "1.2.3",
+				"@rolldown/binding-linux-ppc64-gnu": "1.2.3",
+				"@rolldown/binding-linux-s390x-gnu": "1.2.3",
+				"@rolldown/binding-linux-x64-gnu": "1.2.3",
+				"@rolldown/binding-linux-x64-musl": "1.2.3",
+				"@rolldown/binding-openharmony-arm64": "1.2.3",
+				"@rolldown/binding-win32-arm64-msvc": "1.2.3",
+				"@rolldown/binding-win32-x64-msvc": "1.2.3"
+			}
+		},
+		"packages/vscode/node_modules/tinyglobby": {
+			"version": "0.2.17",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+			"integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.4"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/SuperchupuDev"
+			}
+		},
+		"packages/vscode/node_modules/vite": {
+			"version": "8.2.1",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
+			"integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"lightningcss": "^1.33.0",
+				"picomatch": "^4.0.5",
+				"postcss": "^8.5.25",
+				"rolldown": "~1.2.1",
+				"tinyglobby": "^0.2.17"
+			},
+			"bin": {
+				"vite": "bin/vite.js"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"funding": {
+				"url": "https://github.com/vitejs/vite?sponsor=1"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			},
+			"peerDependencies": {
+				"@types/node": "^20.19.0 || >=22.12.0",
+				"@vitejs/devtools": "^0.4.0",
+				"esbuild": "^0.27.0 || ^0.28.0",
+				"jiti": ">=1.21.0",
+				"less": "^4.0.0",
+				"sass": "^1.70.0",
+				"sass-embedded": "^1.70.0",
+				"stylus": ">=0.54.8",
+				"sugarss": "^5.0.0",
+				"terser": "^5.16.0",
+				"tsx": "^4.8.1",
+				"yaml": "^2.4.2"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				},
+				"@vitejs/devtools": {
+					"optional": true
+				},
+				"esbuild": {
+					"optional": true
+				},
+				"jiti": {
+					"optional": true
+				},
+				"less": {
+					"optional": true
+				},
+				"sass": {
+					"optional": true
+				},
+				"sass-embedded": {
+					"optional": true
+				},
+				"stylus": {
+					"optional": true
+				},
+				"sugarss": {
+					"optional": true
+				},
+				"terser": {
+					"optional": true
+				},
+				"tsx": {
+					"optional": true
+				},
+				"yaml": {
+					"optional": true
+				}
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 	"scripts": {
 		"clean": "npm run clean --workspaces",
 		"sync-version": "bash scripts/sync-version.sh",
-		"build": "cd packages/tui && npm run build && cd ../ai && npm run build && cd ../agent && npm run build && cd ../semantic-search && npm run build && cd ../coding-agent && npm run build && cd ../telegram && npm run build && cd ../dashboard && npm run build",
+		"build": "cd packages/tui && npm run build && cd ../ai && npm run build && cd ../agent && npm run build && cd ../semantic-search && npm run build && cd ../coding-agent && npm run build && cd ../telegram && npm run build && cd ../dashboard && npm run build && cd ../vscode && npm run build",
 		"dev": "concurrently --names \"ai,agent,coding-agent,tui\" --prefix-colors \"cyan,yellow,red,magenta\" \"cd packages/ai && npm run dev\" \"cd packages/agent && npm run dev\" \"cd packages/coding-agent && npm run dev\" \"cd packages/tui && npm run dev\"",
 		"check": "npm run verify-git-hooks && npm run verify-engines && biome check --write --error-on-warnings . && tsgo --noEmit",
 		"verify-git-hooks": "node scripts/verify-git-hooks.js",

--- a/packages/vscode/.vscodeignore
+++ b/packages/vscode/.vscodeignore
@@ -1,0 +1,13 @@
+.vscode/**
+.vscode-test/**
+src/**
+test/**
+node_modules/**
+tsconfig.build.json
+tsconfig.webview.json
+vite.config.mts
+vitest.config.mts
+.gitignore
+**/*.ts
+**/*.tsx
+**/*.map

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -1,0 +1,79 @@
+# dreb for VS Code
+
+A native chat client for the [dreb](https://github.com/aebrer/dreb) coding agent, embedded in VS Code as a webview. It drives dreb over its RPC protocol (`RpcClient` from `@dreb/coding-agent/rpc`) and streams responses into a chat panel — separating the agent's thinking/tool activity from its final answer, with slash commands and inline prompts.
+
+This package is modeled on `@dreb/dashboard`: an extension **host** owns the RPC child and the authoritative transcript state, and a **webview** renders it. The only transport difference is that the dashboard's HTTP+SSE layer is replaced by VS Code's `postMessage` bridge.
+
+> Status: **Phase 0 + 1** (foundation + MVP chat). See the [tracking issue](https://github.com/Hrovatin/dreb/issues/12) for the roadmap.
+
+## Architecture
+
+```
+src/
+  shared/        # DTOs + pure projection reducer (imported by BOTH sides)
+    protocol.ts       host ↔ webview message envelopes (no @dreb import)
+    projection.ts     RPC events → transcript render model (pure, tested)
+  host/          # extension host (Node, ESM) — compiled with tsgo
+    extension.ts        activate(): registers `dreb.openChat`, owns the panel
+    session-controller.ts  one RpcClient + authoritative transcript per session
+    webview-bridge.ts   postMessage wiring + webview HTML/CSP
+    cli-path.ts         resolve the dreb CLI (setting → dependency)
+    slash-router.ts     route composer text → prompt vs builtin RPC (pure, tested)
+  webview/       # SolidJS UI — bundled with Vite → dist/webview
+    app.tsx             transcript, collapsible activity box, composer, needs-input
+```
+
+- The host keeps the authoritative `TranscriptState`. On (re)load the webview announces `ready` and receives a full snapshot, so recreating the webview never loses the conversation.
+- Host and webview apply the **same** pure `applyEvent` reducer, so live streaming and the reload snapshot stay consistent.
+
+## Requirements
+
+- **VS Code 1.100+** — this is an [ESM extension](https://code.visualstudio.com/updates/v1_100#_esm-support-for-extensions) (`"type": "module"`), which requires the ESM-capable extension host.
+- **Node 22.x** available to the extension host — `RpcClient` spawns `node <cli.js> --mode rpc`.
+- A resolvable dreb CLI (see below).
+
+## Locating the dreb CLI
+
+`RpcClient` spawns the compiled dreb CLI. The host resolves its absolute path in this order:
+
+1. the **`dreb.cliPath`** setting, if set (absolute path to `@dreb/coding-agent`'s `dist/cli.js`);
+2. dependency resolution via the bundled `@dreb/coding-agent` (works out of the box in the F5 dev host).
+
+When running a packaged `.vsix` that does not ship the CLI, set `dreb.cliPath` to a local dreb install's `dist/cli.js`.
+
+## Settings
+
+| Setting | Description |
+| --- | --- |
+| `dreb.cliPath` | Absolute path to the dreb CLI (`dist/cli.js`). Empty = auto-resolve. |
+| `dreb.provider` | Optional provider passed to dreb (e.g. `anthropic`). |
+| `dreb.model` | Optional model id/pattern passed to dreb. |
+
+## Development
+
+From the repo root the package builds as part of the monorepo `build` chain. Standalone:
+
+```bash
+cd packages/vscode
+npm run build            # tsgo (host) + vite (webview) → dist/
+npm test                 # vitest (host + projection logic)
+npm run typecheck:webview  # type-check the DOM/webview code (not in the root check)
+```
+
+Then press **F5** ("Run Extension") to launch an Extension Development Host and run **dreb: Open Chat**.
+
+### Packaging
+
+```bash
+npm run package          # → dreb-vscode-<version>.vsix (via @vscode/vsce)
+```
+
+Install the `.vsix` with `code --install-extension dreb-vscode-<version>.vsix`.
+
+## Testing notes
+
+Host and projection logic are unit-tested with vitest in a node environment (deterministic, no display required). Extension-activation smoke tests via `@vscode/test-electron` are intentionally out of scope for now — the CI `test` job has no display; adding them would require `xvfb-run`.
+
+## Versioning
+
+Unlike the npm-published packages, this extension is **versioned independently** and is excluded from the repo's `sync-version` script. It is not published to the npm registry.

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,0 +1,75 @@
+{
+	"name": "dreb-vscode",
+	"displayName": "dreb",
+	"description": "Native chat client for the dreb coding agent — streaming responses, slash commands, and inline prompts, driven over dreb's RPC protocol.",
+	"version": "0.1.0",
+	"private": true,
+	"license": "MIT",
+	"publisher": "hrovatin",
+	"type": "module",
+	"main": "./dist/host/extension.js",
+	"engines": {
+		"node": "22.x",
+		"vscode": "^1.100.0"
+	},
+	"categories": ["AI", "Chat", "Other"],
+	"activationEvents": [],
+	"contributes": {
+		"commands": [
+			{
+				"command": "dreb.openChat",
+				"title": "Open Chat",
+				"category": "dreb"
+			}
+		],
+		"configuration": {
+			"title": "dreb",
+			"properties": {
+				"dreb.cliPath": {
+					"type": "string",
+					"default": "",
+					"markdownDescription": "Absolute path to the dreb CLI entry point (`dist/cli.js`). Leave empty to auto-resolve the bundled `@dreb/coding-agent`. Required when running a packaged `.vsix` that does not ship the CLI."
+				},
+				"dreb.provider": {
+					"type": "string",
+					"default": "",
+					"description": "Optional model provider passed to dreb (e.g. \"anthropic\"). Leave empty to use dreb's configured default."
+				},
+				"dreb.model": {
+					"type": "string",
+					"default": "",
+					"description": "Optional model id or pattern passed to dreb. Leave empty to use dreb's configured default."
+				}
+			}
+		}
+	},
+	"scripts": {
+		"clean": "shx rm -rf dist *.vsix",
+		"build": "tsgo -p tsconfig.build.json && vite build",
+		"dev": "tsgo -p tsconfig.build.json --watch --preserveWatchOutput",
+		"dev:webview": "vite build --watch",
+		"typecheck:webview": "tsgo -p tsconfig.webview.json",
+		"test": "vitest --run",
+		"package": "npm run build && npx --yes @vscode/vsce package --no-dependencies",
+		"vscode:prepublish": "npm run build"
+	},
+	"dependencies": {
+		"@dreb/coding-agent": "*"
+	},
+	"devDependencies": {
+		"@types/node": "^22.10.5",
+		"@types/vscode": "^1.100.0",
+		"dompurify": "^3.4.11",
+		"marked": "^15.0.12",
+		"solid-js": "^1.9.14",
+		"typescript": "^5.9.2",
+		"vite": "^8.1.3",
+		"vite-plugin-solid": "^2.11.12",
+		"vitest": "^4.1.8"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/Hrovatin/dreb.git",
+		"directory": "packages/vscode"
+	}
+}

--- a/packages/vscode/src/host/cli-path.ts
+++ b/packages/vscode/src/host/cli-path.ts
@@ -1,0 +1,67 @@
+/**
+ * Resolve the absolute path to the dreb CLI entry point (`dist/cli.js`), which
+ * `RpcClient` spawns as `node <cliPath> --mode rpc`. `RpcClient` defaults to a
+ * cwd-relative `"dist/cli.js"`, so the host must always pass an absolute path.
+ *
+ * Precedence (mirrors the plan's layered resolution):
+ *   1. the `dreb.cliPath` setting (explicit override, required for packaged
+ *      `.vsix` installs that do not ship the CLI on disk);
+ *   2. dependency resolution via `@dreb/coding-agent`'s package entry.
+ *
+ * All I/O is injectable so the precedence logic is unit-testable without a real
+ * filesystem or a resolvable dependency.
+ */
+
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export interface CliPathSources {
+	/** The `dreb.cliPath` setting value; empty/whitespace means unset. */
+	configuredPath?: string;
+	/** Directory that should contain `cli.js` (defaults to dependency resolution). */
+	resolveCliDir?: () => string | undefined;
+	/** Existence probe (defaults to `fs.existsSync`). */
+	fileExists?: (path: string) => boolean;
+}
+
+export type CliPathResult = { ok: true; path: string; source: "setting" | "dependency" } | { ok: false; error: string };
+
+export function resolveCliPath(sources: CliPathSources = {}): CliPathResult {
+	const exists = sources.fileExists ?? existsSync;
+
+	const configured = sources.configuredPath?.trim();
+	if (configured) {
+		if (exists(configured)) return { ok: true, path: configured, source: "setting" };
+		return {
+			ok: false,
+			error: `The "dreb.cliPath" setting points to "${configured}", but no file exists there.`,
+		};
+	}
+
+	const resolveCliDir = sources.resolveCliDir ?? defaultResolveCliDir;
+	const dir = resolveCliDir();
+	if (dir) {
+		const candidate = join(dir, "cli.js");
+		if (exists(candidate)) return { ok: true, path: candidate, source: "dependency" };
+	}
+
+	return {
+		ok: false,
+		error: 'Could not locate the dreb CLI. Ensure @dreb/coding-agent is installed, or set the "dreb.cliPath" setting to the absolute path of its dist/cli.js.',
+	};
+}
+
+/**
+ * Resolve the directory holding `@dreb/coding-agent`'s compiled entry point.
+ * Uses `import.meta.resolve` (the package is ESM-only, so a CJS `require.resolve`
+ * cannot reach it) — the same approach the dashboard's runtime pool uses.
+ */
+function defaultResolveCliDir(): string | undefined {
+	try {
+		const resolved = import.meta.resolve("@dreb/coding-agent");
+		return dirname(fileURLToPath(resolved));
+	} catch {
+		return undefined;
+	}
+}

--- a/packages/vscode/src/host/extension.ts
+++ b/packages/vscode/src/host/extension.ts
@@ -1,0 +1,116 @@
+/// <reference types="vscode" />
+
+/**
+ * Extension entry point. Registers the `dreb.openChat` command, which opens (or
+ * reveals) a single chat webview panel backed by one SessionController.
+ *
+ * State lives in the host: the controller owns the authoritative transcript and
+ * the RPC child, so tearing down and recreating the webview re-renders from the
+ * controller's snapshot without losing the conversation.
+ */
+
+import { homedir } from "node:os";
+import * as vscode from "vscode";
+import { resolveCliPath } from "./cli-path.js";
+import { SessionController } from "./session-controller.js";
+import { connectWebview, getWebviewHtml } from "./webview-bridge.js";
+
+interface ChatSession {
+	panel: vscode.WebviewPanel;
+	controller: SessionController;
+	connection: vscode.Disposable;
+}
+
+let current: ChatSession | undefined;
+
+export function activate(context: vscode.ExtensionContext): void {
+	context.subscriptions.push(
+		vscode.commands.registerCommand("dreb.openChat", () => {
+			openChat(context).catch((err) => {
+				vscode.window.showErrorMessage(`dreb: failed to open chat — ${errorText(err)}`);
+			});
+		}),
+	);
+}
+
+export async function deactivate(): Promise<void> {
+	await disposeCurrent();
+}
+
+async function openChat(context: vscode.ExtensionContext): Promise<void> {
+	if (current) {
+		current.panel.reveal(vscode.ViewColumn.Active);
+		return;
+	}
+
+	const config = vscode.workspace.getConfiguration("dreb");
+	const cwd = workspaceCwd();
+	const cli = resolveCliPath({ configuredPath: config.get<string>("cliPath") });
+
+	const controller = new SessionController({
+		cwd,
+		cliPath: cli.ok ? cli.path : "",
+		args: buildArgs(config),
+		logger: (line) => console.warn(`[dreb] ${line}`),
+	});
+
+	const panel = vscode.window.createWebviewPanel("dreb.chat", "dreb", vscode.ViewColumn.Active, {
+		enableScripts: true,
+		retainContextWhenHidden: true,
+		localResourceRoots: [vscode.Uri.joinPath(context.extensionUri, "dist", "webview")],
+	});
+
+	const connection = connectWebview(panel.webview, controller);
+	panel.webview.html = getWebviewHtml(panel.webview, context.extensionUri, makeNonce());
+
+	current = { panel, controller, connection };
+	panel.onDidDispose(() => {
+		void disposeCurrent();
+	});
+
+	if (!cli.ok) {
+		// Surface an actionable error into the transcript; the webview shows it
+		// once it hydrates. No child is spawned.
+		controller.reportFatal(cli.error);
+		return;
+	}
+
+	try {
+		await controller.start();
+	} catch {
+		// start() already surfaced a host_error + status to the transcript.
+	}
+}
+
+async function disposeCurrent(): Promise<void> {
+	if (!current) return;
+	const session = current;
+	current = undefined;
+	session.connection.dispose();
+	await session.controller.dispose();
+	session.panel.dispose();
+}
+
+function workspaceCwd(): string {
+	return vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? homedir();
+}
+
+function buildArgs(config: vscode.WorkspaceConfiguration): string[] {
+	const args: string[] = [];
+	const provider = config.get<string>("provider")?.trim();
+	const model = config.get<string>("model")?.trim();
+	if (provider) args.push("--provider", provider);
+	if (model) args.push("--model", model);
+	return args;
+}
+
+function makeNonce(): string {
+	const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+	let nonce = "";
+	for (let i = 0; i < 32; i++) nonce += chars.charAt(Math.floor(Math.random() * chars.length));
+	return nonce;
+}
+
+function errorText(err: unknown): string {
+	return err instanceof Error ? err.message : String(err);
+}

--- a/packages/vscode/src/host/session-controller.ts
+++ b/packages/vscode/src/host/session-controller.ts
@@ -1,0 +1,232 @@
+/**
+ * SessionController — owns one dreb RPC child process for a single working
+ * directory and keeps the authoritative transcript state for it.
+ *
+ * One controller per session from day one: it holds its own `RpcClient` (via an
+ * injectable factory, so tests can supply a fake and production lazily loads the
+ * ESM-only agent runtime), its own `cwd`, and its own projected state. This
+ * makes a future multi-session pool a matter of holding several controllers,
+ * with no rework here.
+ *
+ * The controller is transport-agnostic: it exposes `onUpdate` and forwards raw
+ * events + status changes. The webview bridge adapts those to `postMessage`.
+ */
+
+import { applyEvent, createTranscriptState, type TranscriptState } from "../shared/projection.js";
+import type { HostStatus, SlashCommandDto, UiResponse } from "../shared/protocol.js";
+import { BUILTIN_COMMANDS, routeInput, stripSlash } from "./slash-router.js";
+
+/**
+ * Structural view of the parts of `RpcClient` the controller uses. Kept
+ * hand-written (not `Pick<RpcClient>`) so unit tests can build a fake without
+ * importing the agent's concrete types. Members are methods so parameter checks
+ * stay bivariant and the real `RpcClient` remains assignable.
+ */
+export interface RpcClientLike {
+	start(): Promise<void>;
+	stop(): Promise<void>;
+	prompt(message: string, images?: unknown[]): Promise<void>;
+	abort(): Promise<void>;
+	compact(customInstructions?: string): Promise<unknown>;
+	getCommands(): Promise<Array<{ name: string; description?: string }>>;
+	sendExtensionUIResponse(response: unknown): void;
+	onEvent(listener: (event: any) => void): () => void;
+	onExit(listener: (info: any) => void): () => void;
+}
+
+export type RpcClientFactory = (options: {
+	cliPath: string;
+	cwd: string;
+	args: string[];
+}) => RpcClientLike | Promise<RpcClientLike>;
+
+export interface SessionControllerOptions {
+	cwd: string;
+	cliPath: string;
+	/** Extra CLI args (e.g. --provider/--model), appended verbatim. */
+	args?: string[];
+	/** Override the RpcClient constructor (tests inject a fake). */
+	clientFactory?: RpcClientFactory;
+	logger?: (line: string) => void;
+}
+
+export type ControllerUpdate = { kind: "event"; event: unknown } | { kind: "status"; status: HostStatus };
+
+/** Lazily loads the ESM-only agent runtime so tests with an injected factory
+ * never pull it in. */
+const defaultClientFactory: RpcClientFactory = async (options) => {
+	const { RpcClient } = await import("@dreb/coding-agent/rpc");
+	return new RpcClient({ cliPath: options.cliPath, cwd: options.cwd, args: options.args });
+};
+
+function formatExit(info: { code?: number | null; signal?: string | null; error?: Error }): string {
+	if (info?.error) return `dreb process failed: ${info.error.message}`;
+	return `dreb process exited (code ${info?.code ?? "null"}, signal ${info?.signal ?? "null"})`;
+}
+
+export class SessionController {
+	private readonly state: TranscriptState = createTranscriptState();
+	private readonly listeners = new Set<(update: ControllerUpdate) => void>();
+	private readonly factory: RpcClientFactory;
+	private readonly logger: (line: string) => void;
+	private readonly options: SessionControllerOptions;
+	private client: RpcClientLike | undefined;
+	private commands: SlashCommandDto[] = [...BUILTIN_COMMANDS];
+	private status: HostStatus;
+	private unsubEvent: (() => void) | undefined;
+	private unsubExit: (() => void) | undefined;
+	private disposed = false;
+
+	constructor(options: SessionControllerOptions) {
+		this.options = options;
+		this.factory = options.clientFactory ?? defaultClientFactory;
+		this.logger = options.logger ?? (() => {});
+		this.status = { connected: false, cwd: options.cwd };
+	}
+
+	get cwd(): string {
+		return this.options.cwd;
+	}
+
+	getTranscript(): TranscriptState {
+		return this.state;
+	}
+
+	getStatus(): HostStatus {
+		return this.status;
+	}
+
+	getCommandList(): SlashCommandDto[] {
+		return this.commands;
+	}
+
+	onUpdate(listener: (update: ControllerUpdate) => void): () => void {
+		this.listeners.add(listener);
+		return () => this.listeners.delete(listener);
+	}
+
+	/** Spawn the RPC child, wire event/exit handlers, and prime the command list. */
+	async start(): Promise<void> {
+		if (this.disposed) throw new Error("SessionController is disposed");
+		const client = await this.factory({
+			cliPath: this.options.cliPath,
+			cwd: this.options.cwd,
+			args: this.options.args ?? [],
+		});
+		this.client = client;
+		this.unsubEvent = client.onEvent((event) => this.handleEvent(event));
+		this.unsubExit = client.onExit((info) => this.handleExit(info));
+		try {
+			await client.start();
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			this.setStatus({ ...this.status, connected: false, error: message });
+			this.handleEvent({ type: "host_error", message: `Failed to start dreb: ${message}` });
+			throw err;
+		}
+		this.setStatus({ ...this.status, connected: true, error: undefined });
+		await this.refreshCommands();
+	}
+
+	/** Fetch the agent's commands and merge with host builtins. */
+	async refreshCommands(): Promise<SlashCommandDto[]> {
+		let agentCommands: SlashCommandDto[] = [];
+		try {
+			const raw = (await this.client?.getCommands()) ?? [];
+			agentCommands = raw.map((c) => ({
+				name: stripSlash(c.name),
+				description: c.description,
+				source: "agent" as const,
+			}));
+		} catch (err) {
+			this.logger(`getCommands failed: ${err instanceof Error ? err.message : String(err)}`);
+		}
+		this.commands = [...agentCommands, ...BUILTIN_COMMANDS];
+		return this.commands;
+	}
+
+	/** Route composer text to the correct RPC call. */
+	async submit(text: string): Promise<void> {
+		if (!this.client) {
+			this.emitNotice("dreb is still starting up — try again in a moment.");
+			return;
+		}
+		const decision = routeInput(text, this.commands);
+		switch (decision.kind) {
+			case "empty":
+				return;
+			case "prompt":
+				await this.client?.prompt(decision.message);
+				return;
+			case "builtin":
+				if (decision.command === "compact") {
+					await this.client?.compact(decision.arg);
+					return;
+				}
+				this.emitNotice(`The /${decision.command} command isn't available yet in this early build.`);
+				return;
+			case "unknown-command":
+				this.emitNotice(`Unknown command: /${decision.name}`);
+				return;
+		}
+	}
+
+	async abort(): Promise<void> {
+		await this.client?.abort();
+	}
+
+	/** Surface a fatal host-side failure (e.g. the CLI could not be located)
+	 * into the transcript + status without spawning a child. */
+	reportFatal(message: string): void {
+		this.setStatus({ ...this.status, connected: false, error: message });
+		this.handleEvent({ type: "host_error", message });
+	}
+
+	/** Answer a blocking extension-UI request. */
+	respondUi(response: UiResponse): void {
+		this.client?.sendExtensionUIResponse({ type: "extension_ui_response", ...response });
+	}
+
+	async dispose(): Promise<void> {
+		this.disposed = true;
+		this.unsubEvent?.();
+		this.unsubExit?.();
+		this.listeners.clear();
+		try {
+			await this.client?.stop();
+		} catch (err) {
+			this.logger(`stop failed: ${err instanceof Error ? err.message : String(err)}`);
+		}
+	}
+
+	private handleEvent(event: unknown): void {
+		applyEvent(this.state, event);
+		this.emit({ kind: "event", event });
+	}
+
+	private handleExit(info: { code?: number | null; signal?: string | null; error?: Error }): void {
+		if (this.disposed) return;
+		const message = formatExit(info);
+		this.setStatus({ ...this.status, connected: false, error: message });
+		this.handleEvent({ type: "host_error", message });
+	}
+
+	private emitNotice(message: string): void {
+		this.handleEvent({ type: "host_notice", message });
+	}
+
+	private setStatus(status: HostStatus): void {
+		this.status = status;
+		this.emit({ kind: "status", status });
+	}
+
+	private emit(update: ControllerUpdate): void {
+		for (const listener of this.listeners) {
+			try {
+				listener(update);
+			} catch (err) {
+				this.logger(`update listener failed: ${err instanceof Error ? err.message : String(err)}`);
+			}
+		}
+	}
+}

--- a/packages/vscode/src/host/session-controller.ts
+++ b/packages/vscode/src/host/session-controller.ts
@@ -28,7 +28,15 @@ export interface RpcClientLike {
 	prompt(message: string, images?: unknown[]): Promise<void>;
 	abort(): Promise<void>;
 	compact(customInstructions?: string): Promise<unknown>;
-	getCommands(): Promise<Array<{ name: string; description?: string }>>;
+	getCommands(): Promise<
+		Array<{
+			name: string;
+			description?: string;
+			source: "extension" | "prompt" | "skill" | "builtin";
+			/** Builtins only: false hides the command from autocomplete. */
+			dashboard?: boolean;
+		}>
+	>;
 	sendExtensionUIResponse(response: unknown): void;
 	onEvent(listener: (event: any) => void): () => void;
 	onExit(listener: (info: any) => void): () => void;
@@ -128,51 +136,79 @@ export class SessionController {
 		await this.refreshCommands();
 	}
 
-	/** Fetch the agent's commands and merge with host builtins. */
+	/** Fetch the agent's commands and merge with host builtins.
+	 *
+	 * Resource commands (extension/prompt/skill) become `source: "agent"` and
+	 * route through `prompt`. Built-ins are surfaced as `source: "builtin"` so
+	 * the router intercepts them (sending a builtin through `prompt` is rejected
+	 * server-side and silently dropped). On success we trust the server's
+	 * builtin list (respecting its `dashboard` visibility flag); if the call
+	 * fails we degrade to the hardcoded builtin fallback. */
 	async refreshCommands(): Promise<SlashCommandDto[]> {
 		let agentCommands: SlashCommandDto[] = [];
+		let builtinCommands: SlashCommandDto[] | undefined;
 		try {
 			const raw = (await this.client?.getCommands()) ?? [];
-			agentCommands = raw.map((c) => ({
-				name: stripSlash(c.name),
-				description: c.description,
-				source: "agent" as const,
-			}));
+			agentCommands = raw
+				.filter((c) => c.source !== "builtin")
+				.map((c) => ({ name: stripSlash(c.name), description: c.description, source: "agent" as const }));
+			builtinCommands = raw
+				.filter((c) => c.source === "builtin" && c.dashboard !== false)
+				.map((c) => ({ name: stripSlash(c.name), description: c.description, source: "builtin" as const }));
 		} catch (err) {
 			this.logger(`getCommands failed: ${err instanceof Error ? err.message : String(err)}`);
 		}
-		this.commands = [...agentCommands, ...BUILTIN_COMMANDS];
+		this.commands = [
+			...agentCommands,
+			...(builtinCommands && builtinCommands.length > 0 ? builtinCommands : BUILTIN_COMMANDS),
+		];
 		return this.commands;
 	}
 
-	/** Route composer text to the correct RPC call. */
+	/** Route composer text to the correct RPC call. Guarded on an active
+	 * connection so a submit that races the spawn window (or lands after a
+	 * child crash) surfaces a notice instead of dispatching into a client that
+	 * isn't ready, and every awaited RPC call is wrapped so a rejection becomes
+	 * a visible notice rather than an unhandled promise rejection. */
 	async submit(text: string): Promise<void> {
-		if (!this.client) {
-			this.emitNotice("dreb is still starting up — try again in a moment.");
+		if (!this.client || !this.status.connected) {
+			this.emitNotice(
+				this.status.error
+					? "dreb isn't connected — reopen the chat to restart it."
+					: "dreb is still starting up — try again in a moment.",
+			);
 			return;
 		}
 		const decision = routeInput(text, this.commands);
-		switch (decision.kind) {
-			case "empty":
-				return;
-			case "prompt":
-				await this.client?.prompt(decision.message);
-				return;
-			case "builtin":
-				if (decision.command === "compact") {
-					await this.client?.compact(decision.arg);
+		if (decision.kind === "empty") return;
+		try {
+			switch (decision.kind) {
+				case "prompt":
+					await this.client.prompt(decision.message);
 					return;
-				}
-				this.emitNotice(`The /${decision.command} command isn't available yet in this early build.`);
-				return;
-			case "unknown-command":
-				this.emitNotice(`Unknown command: /${decision.name}`);
-				return;
+				case "builtin":
+					if (decision.command === "compact") {
+						await this.client.compact(decision.arg);
+						return;
+					}
+					this.emitNotice(`The /${decision.command} command isn't available yet in this early build.`);
+					return;
+				case "unknown-command":
+					this.emitNotice(`Unknown command: /${decision.name}`);
+					return;
+			}
+		} catch (err) {
+			this.emitNotice(`Request failed: ${err instanceof Error ? err.message : String(err)}`);
 		}
 	}
 
 	async abort(): Promise<void> {
-		await this.client?.abort();
+		if (!this.client || !this.status.connected) return;
+		try {
+			await this.client.abort();
+		} catch (err) {
+			this.logger(`abort failed: ${err instanceof Error ? err.message : String(err)}`);
+		}
 	}
 
 	/** Surface a fatal host-side failure (e.g. the CLI could not be located)

--- a/packages/vscode/src/host/slash-router.ts
+++ b/packages/vscode/src/host/slash-router.ts
@@ -3,18 +3,22 @@
  * advertised by the agent (`get_commands`), decide how to dispatch:
  *
  *   - plain text            → send to the agent via `prompt`
- *   - a registered command  → send verbatim via `prompt` (dreb expands it)
- *   - a known TUI builtin    → route to a dedicated RPC method (host-handled)
+ *   - a resource command    → send verbatim via `prompt` (dreb expands it)
+ *   - a built-in command     → route to a host-handled RPC method (never `prompt`)
  *   - anything else          → an unknown command
  *
- * Built-in TUI commands (`/model`, `/compact`, `/tree`, `/resume`, `/settings`)
- * are NOT returned by `get_commands` and would be no-ops if sent through
- * `prompt`, so they must be recognized here and mapped to RPC equivalents.
+ * Built-in commands (`/compact`, `/new`, `/quit`, `/model`, …) ARE returned by
+ * `get_commands` with `source: "builtin"`, but the server *rejects* them when
+ * sent through `prompt` (the rejection is silently discarded by the RPC client),
+ * so every builtin must be intercepted here and routed to a host handler rather
+ * than forwarded as a prompt. Only `/compact` is wired in this early build; the
+ * rest surface a "not available yet" notice instead of silently doing nothing.
  * No DOM/vscode/@dreb imports — unit-testable in plain node.
  */
 
 import type { SlashCommandDto } from "../shared/protocol.js";
 
+/** Built-ins the host has a dedicated handler for (the rest emit a notice). */
 export type BuiltinCommand = "compact" | "model" | "tree" | "resume" | "settings";
 
 /** Builtin commands surfaced in the composer dropdown alongside agent commands. */
@@ -31,7 +35,7 @@ const BUILTIN_NAMES = new Set<BuiltinCommand>(BUILTIN_COMMANDS.map((c) => c.name
 export type RouteDecision =
 	| { kind: "empty" }
 	| { kind: "prompt"; message: string }
-	| { kind: "builtin"; command: BuiltinCommand; arg?: string }
+	| { kind: "builtin"; command: string; arg?: string }
 	| { kind: "unknown-command"; name: string };
 
 /** Strip a single leading slash so command names compare uniformly. */
@@ -50,15 +54,20 @@ export function routeInput(input: string, commands: readonly SlashCommandDto[] =
 
 	const name = match[1];
 	const rest = match[2].trim();
+	const arg = rest.length > 0 ? rest : undefined;
 
-	if (BUILTIN_NAMES.has(name as BuiltinCommand)) {
-		return { kind: "builtin", command: name as BuiltinCommand, arg: rest.length > 0 ? rest : undefined };
+	const advertised = commands.find((c) => stripSlash(c.name) === name);
+
+	// Built-ins are host-handled: forwarding them via `prompt` is rejected
+	// server-side and the rejection is silently swallowed, so intercept every
+	// builtin here (whether advertised by get_commands or a hardcoded fallback).
+	if (advertised?.source === "builtin" || BUILTIN_NAMES.has(name as BuiltinCommand)) {
+		return { kind: "builtin", command: name, arg };
 	}
 
-	// A command dreb advertised (extension/prompt/skill) is expanded server-side,
-	// so forward the raw input through prompt.
-	const known = commands.some((c) => stripSlash(c.name) === name && c.source === "agent");
-	if (known) return { kind: "prompt", message: input };
+	// A resource command dreb advertised (extension/prompt/skill) is expanded
+	// server-side, so forward the raw input through prompt.
+	if (advertised?.source === "agent") return { kind: "prompt", message: input };
 
 	return { kind: "unknown-command", name };
 }

--- a/packages/vscode/src/host/slash-router.ts
+++ b/packages/vscode/src/host/slash-router.ts
@@ -1,0 +1,64 @@
+/**
+ * Pure slash-command routing. Given the composer text and the set of commands
+ * advertised by the agent (`get_commands`), decide how to dispatch:
+ *
+ *   - plain text            → send to the agent via `prompt`
+ *   - a registered command  → send verbatim via `prompt` (dreb expands it)
+ *   - a known TUI builtin    → route to a dedicated RPC method (host-handled)
+ *   - anything else          → an unknown command
+ *
+ * Built-in TUI commands (`/model`, `/compact`, `/tree`, `/resume`, `/settings`)
+ * are NOT returned by `get_commands` and would be no-ops if sent through
+ * `prompt`, so they must be recognized here and mapped to RPC equivalents.
+ * No DOM/vscode/@dreb imports — unit-testable in plain node.
+ */
+
+import type { SlashCommandDto } from "../shared/protocol.js";
+
+export type BuiltinCommand = "compact" | "model" | "tree" | "resume" | "settings";
+
+/** Builtin commands surfaced in the composer dropdown alongside agent commands. */
+export const BUILTIN_COMMANDS: SlashCommandDto[] = [
+	{ name: "compact", description: "Summarize and compact the conversation context", source: "builtin" },
+	{ name: "model", description: "Switch the active model", source: "builtin" },
+	{ name: "tree", description: "Browse and navigate the session tree", source: "builtin" },
+	{ name: "resume", description: "Resume a previous session", source: "builtin" },
+	{ name: "settings", description: "Open dreb settings", source: "builtin" },
+];
+
+const BUILTIN_NAMES = new Set<BuiltinCommand>(BUILTIN_COMMANDS.map((c) => c.name as BuiltinCommand));
+
+export type RouteDecision =
+	| { kind: "empty" }
+	| { kind: "prompt"; message: string }
+	| { kind: "builtin"; command: BuiltinCommand; arg?: string }
+	| { kind: "unknown-command"; name: string };
+
+/** Strip a single leading slash so command names compare uniformly. */
+export function stripSlash(name: string): string {
+	return name.startsWith("/") ? name.slice(1) : name;
+}
+
+export function routeInput(input: string, commands: readonly SlashCommandDto[] = []): RouteDecision {
+	const trimmed = input.trim();
+	if (trimmed.length === 0) return { kind: "empty" };
+	if (!trimmed.startsWith("/")) return { kind: "prompt", message: input };
+
+	const match = /^\/(\S+)\s*([\s\S]*)$/.exec(trimmed);
+	// A lone "/" (or "/ ") is not a command — treat as normal prompt text.
+	if (!match) return { kind: "prompt", message: input };
+
+	const name = match[1];
+	const rest = match[2].trim();
+
+	if (BUILTIN_NAMES.has(name as BuiltinCommand)) {
+		return { kind: "builtin", command: name as BuiltinCommand, arg: rest.length > 0 ? rest : undefined };
+	}
+
+	// A command dreb advertised (extension/prompt/skill) is expanded server-side,
+	// so forward the raw input through prompt.
+	const known = commands.some((c) => stripSlash(c.name) === name && c.source === "agent");
+	if (known) return { kind: "prompt", message: input };
+
+	return { kind: "unknown-command", name };
+}

--- a/packages/vscode/src/host/webview-bridge.ts
+++ b/packages/vscode/src/host/webview-bridge.ts
@@ -1,0 +1,100 @@
+/// <reference types="vscode" />
+
+/**
+ * Webview bridge — adapts a SessionController to a VS Code webview. This is the
+ * transport seam that replaces the dashboard's HTTP+SSE layer: host→webview
+ * uses `webview.postMessage`, webview→host uses `onDidReceiveMessage`.
+ *
+ * Ordering contract: raw events are NOT streamed to the webview until it has
+ * announced `ready` and received the authoritative snapshot. The snapshot is
+ * sent and the "live" flag flipped synchronously (no `await` between), so no
+ * event is ever both baked into the snapshot and re-streamed (which would
+ * duplicate transcript entries).
+ */
+
+import * as vscode from "vscode";
+import type { HostToWebview, WebviewToHost } from "../shared/protocol.js";
+import type { SessionController } from "./session-controller.js";
+
+/** Build the webview HTML shell referencing the vite-built assets. */
+export function getWebviewHtml(webview: vscode.Webview, extensionUri: vscode.Uri, nonce: string): string {
+	const assetUri = (file: string) => webview.asWebviewUri(vscode.Uri.joinPath(extensionUri, "dist", "webview", file));
+	const scriptUri = assetUri("main.js");
+	const styleUri = assetUri("main.css");
+	const csp = [
+		"default-src 'none'",
+		`img-src ${webview.cspSource} https: data:`,
+		`style-src ${webview.cspSource} 'unsafe-inline'`,
+		`font-src ${webview.cspSource}`,
+		`script-src 'nonce-${nonce}'`,
+	].join("; ");
+
+	return `<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta http-equiv="Content-Security-Policy" content="${csp}" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<link rel="stylesheet" href="${styleUri}" />
+		<title>dreb</title>
+	</head>
+	<body>
+		<div id="root"></div>
+		<script type="module" nonce="${nonce}" src="${scriptUri}"></script>
+	</body>
+</html>`;
+}
+
+/** Wire a controller to a webview. Returns a disposable that tears down both. */
+export function connectWebview(webview: vscode.Webview, controller: SessionController): vscode.Disposable {
+	let live = false;
+	const post = (message: HostToWebview): void => {
+		void webview.postMessage(message);
+	};
+
+	const unsubscribe = controller.onUpdate((update) => {
+		if (!live) return;
+		if (update.kind === "event") post({ type: "event", event: update.event });
+		else post({ type: "status", status: update.status });
+	});
+
+	const messageSub = webview.onDidReceiveMessage((raw: WebviewToHost) => {
+		switch (raw?.type) {
+			case "ready": {
+				// Snapshot + go-live must be atomic (no await between) so streamed
+				// events and the snapshot never overlap. `structuredClone` detaches
+				// the snapshot from the live, still-mutating transcript object.
+				post({
+					type: "snapshot",
+					state: structuredClone(controller.getTranscript()),
+					commands: controller.getCommandList(),
+					status: controller.getStatus(),
+				});
+				live = true;
+				void controller
+					.refreshCommands()
+					.then(() => post({ type: "commands", commands: controller.getCommandList() }));
+				return;
+			}
+			case "submit":
+				void controller.submit(raw.text);
+				return;
+			case "abort":
+				void controller.abort();
+				return;
+			case "refresh-commands":
+				void controller
+					.refreshCommands()
+					.then(() => post({ type: "commands", commands: controller.getCommandList() }));
+				return;
+			case "ui-response":
+				controller.respondUi(raw.response);
+				return;
+		}
+	});
+
+	return new vscode.Disposable(() => {
+		unsubscribe();
+		messageSub.dispose();
+	});
+}

--- a/packages/vscode/src/host/webview-bridge.ts
+++ b/packages/vscode/src/host/webview-bridge.ts
@@ -51,6 +51,9 @@ export function connectWebview(webview: vscode.Webview, controller: SessionContr
 	const post = (message: HostToWebview): void => {
 		void webview.postMessage(message);
 	};
+	const pushCommands = (): void => {
+		void controller.refreshCommands().then(() => post({ type: "commands", commands: controller.getCommandList() }));
+	};
 
 	const unsubscribe = controller.onUpdate((update) => {
 		if (!live) return;
@@ -71,9 +74,7 @@ export function connectWebview(webview: vscode.Webview, controller: SessionContr
 					status: controller.getStatus(),
 				});
 				live = true;
-				void controller
-					.refreshCommands()
-					.then(() => post({ type: "commands", commands: controller.getCommandList() }));
+				pushCommands();
 				return;
 			}
 			case "submit":
@@ -83,9 +84,7 @@ export function connectWebview(webview: vscode.Webview, controller: SessionContr
 				void controller.abort();
 				return;
 			case "refresh-commands":
-				void controller
-					.refreshCommands()
-					.then(() => post({ type: "commands", commands: controller.getCommandList() }));
+				pushCommands();
 				return;
 			case "ui-response":
 				controller.respondUi(raw.response);

--- a/packages/vscode/src/shared/projection.ts
+++ b/packages/vscode/src/shared/projection.ts
@@ -137,6 +137,19 @@ function findTool(group: ResponseGroup, toolCallId: string): ToolActivity | unde
 	return undefined;
 }
 
+/** End the in-flight response (if any): stop streaming and collapse its activity
+ * box, optionally stamping a first-seen error. Shared by `agent_end` (clean end)
+ * and `host_error` (fatal end). */
+function closeActiveResponse(state: TranscriptState, error?: string): void {
+	state.streaming = false;
+	const group = activeResponse(state, false);
+	if (group) {
+		group.streaming = false;
+		group.collapsed = true;
+		if (error) group.error = group.error ?? error;
+	}
+}
+
 function partialResultText(payload: unknown): string | undefined {
 	if (typeof payload === "string") return payload;
 	if (payload && typeof payload === "object") {
@@ -159,24 +172,26 @@ function providerErrorText(message: {
 
 function uiRequestFromEvent(event: any): UiRequest | undefined {
 	const method = event?.method as string | undefined;
+	const id = String(event.id);
+	const options = Array.isArray(event.options) ? event.options.map((o: unknown) => String(o)) : undefined;
 	if (method === "select" || method === "confirm" || method === "input" || method === "editor") {
 		return {
-			id: String(event.id),
+			id,
 			method,
 			title: String(event.title ?? ""),
 			message: typeof event.message === "string" ? event.message : undefined,
-			options: Array.isArray(event.options) ? event.options.map((o: unknown) => String(o)) : undefined,
+			options,
 			placeholder: typeof event.placeholder === "string" ? event.placeholder : undefined,
 			prefill: typeof event.prefill === "string" ? event.prefill : undefined,
 		};
 	}
 	if (method === "ask") {
 		return {
-			id: String(event.id),
+			id,
 			method: "ask",
 			title: String(event.title ?? "Question"),
 			question: typeof event.question === "string" ? event.question : "",
-			options: Array.isArray(event.options) ? event.options.map((o: unknown) => String(o)) : undefined,
+			options,
 			allowFreeText: typeof event.allowFreeText === "boolean" ? event.allowFreeText : undefined,
 			multiSelect: typeof event.multiSelect === "boolean" ? event.multiSelect : undefined,
 			multiline: typeof event.multiline === "boolean" ? event.multiline : undefined,
@@ -197,12 +212,7 @@ export function applyEvent(state: TranscriptState, event: any): void {
 			break;
 		}
 		case "agent_end": {
-			state.streaming = false;
-			const group = activeResponse(state, false);
-			if (group) {
-				group.streaming = false;
-				group.collapsed = true;
-			}
+			closeActiveResponse(state);
 			break;
 		}
 		case "message_start": {
@@ -334,13 +344,7 @@ export function applyEvent(state: TranscriptState, event: any): void {
 		case "host_error": {
 			// Synthetic event emitted by the SessionController on RPC child exit.
 			state.hostError = String(event.message ?? "dreb process exited");
-			state.streaming = false;
-			const group = activeResponse(state, false);
-			if (group) {
-				group.streaming = false;
-				group.collapsed = true;
-				group.error = group.error ?? state.hostError;
-			}
+			closeActiveResponse(state, state.hostError);
 			break;
 		}
 		case "host_notice": {

--- a/packages/vscode/src/shared/projection.ts
+++ b/packages/vscode/src/shared/projection.ts
@@ -1,0 +1,365 @@
+/**
+ * Pure transcript projection — folds dreb RPC session events into a render
+ * model. No DOM, no framework, and NO `@dreb/coding-agent` import: this module
+ * is shared verbatim by the extension host (which keeps the authoritative
+ * state) and the webview (which applies the same events for live rendering),
+ * so it must stay dependency-free and unit-testable in plain node.
+ *
+ * Model: an append-only list of transcript items. A "response" groups one agent
+ * run's streamed output, separating the collapsible *activity* (thinking +
+ * tool calls) from the clean *answer* (assistant text). Events are typed
+ * structurally (`any`) on purpose — dispatch on `type`, ignore unknown values.
+ */
+
+export interface ThinkingActivity {
+	kind: "thinking";
+	text: string;
+}
+
+export interface ToolActivity {
+	kind: "tool";
+	toolCallId: string;
+	toolName: string;
+	args: unknown;
+	status: "running" | "done" | "error";
+	/** Result text (or partial output while running). */
+	resultText: string;
+}
+
+export type ActivityItem = ThinkingActivity | ToolActivity;
+
+export interface ResponseGroup {
+	kind: "response";
+	id: number;
+	/** Thinking + tool activity, in arrival order (rendered in the activity box). */
+	activity: ActivityItem[];
+	/** Accumulated final-answer markdown (assistant text content). */
+	answer: string;
+	/** True between agent_start and agent_end for this run. */
+	streaming: boolean;
+	/** Activity box collapse state; auto-collapses when the run ends. */
+	collapsed: boolean;
+	/** Provider failure text, if this run ended in an error. */
+	error?: string;
+}
+
+export interface UserItem {
+	kind: "user";
+	text: string;
+}
+
+export type TranscriptItem = UserItem | ResponseGroup;
+
+/** A pending, blocking extension-UI request the user must answer. */
+export interface UiRequest {
+	id: string;
+	method: "select" | "confirm" | "input" | "editor" | "ask";
+	title: string;
+	message?: string;
+	options?: string[];
+	placeholder?: string;
+	prefill?: string;
+	/** ask: the question prompt. */
+	question?: string;
+	/** ask: offer a free-text field (defaults true). */
+	allowFreeText?: boolean;
+	/** ask: render options as checkboxes instead of radios. */
+	multiSelect?: boolean;
+	/** ask: use a multi-line text area for free text. */
+	multiline?: boolean;
+	/** ask: absolute runtime deadline (ms epoch); survives reload. */
+	expiresAt?: number;
+}
+
+export interface TranscriptState {
+	items: TranscriptItem[];
+	/** True while an agent run is in flight (drives the composer/stop button). */
+	streaming: boolean;
+	/** Blocking extension-UI requests awaiting a response. */
+	uiRequests: UiRequest[];
+	/** Transient non-fatal status (retry/compaction); MVP surfaces a single line. */
+	statusText?: string;
+	/** Fatal host-side error (e.g. the RPC child process exited). */
+	hostError?: string;
+	/** Monotonic id source for response groups. */
+	nextResponseId: number;
+}
+
+export function createTranscriptState(): TranscriptState {
+	return { items: [], streaming: false, uiRequests: [], nextResponseId: 1 };
+}
+
+/** Flatten message content (string or content-part array) to plain text. */
+function contentToText(content: unknown): string {
+	if (typeof content === "string") return content;
+	if (!Array.isArray(content)) return "";
+	const parts: string[] = [];
+	for (const raw of content) {
+		const part = raw as { text?: unknown };
+		if (typeof part?.text === "string") parts.push(part.text);
+	}
+	return parts.join("\n");
+}
+
+/**
+ * The active response is the last item when it is a still-streaming response
+ * group. Everything a single agent run streams (thinking, tools, answer text)
+ * lands in that one group. When `create` is set and there is none, a new group
+ * is appended — this also covers runs that begin without a preceding
+ * `agent_start` (defensive) and steered mid-run user turns.
+ */
+function activeResponse(state: TranscriptState, create: boolean): ResponseGroup | undefined {
+	const last = state.items[state.items.length - 1];
+	if (last && last.kind === "response" && last.streaming) return last;
+	if (!create) return undefined;
+	const group: ResponseGroup = {
+		kind: "response",
+		id: state.nextResponseId++,
+		activity: [],
+		answer: "",
+		streaming: true,
+		collapsed: false,
+	};
+	state.items.push(group);
+	return group;
+}
+
+function lastThinking(group: ResponseGroup): ThinkingActivity | undefined {
+	const last = group.activity[group.activity.length - 1];
+	return last?.kind === "thinking" ? last : undefined;
+}
+
+function findTool(group: ResponseGroup, toolCallId: string): ToolActivity | undefined {
+	for (let i = group.activity.length - 1; i >= 0; i--) {
+		const item = group.activity[i];
+		if (item.kind === "tool" && item.toolCallId === toolCallId) return item;
+	}
+	return undefined;
+}
+
+function partialResultText(payload: unknown): string | undefined {
+	if (typeof payload === "string") return payload;
+	if (payload && typeof payload === "object") {
+		const content = (payload as { content?: unknown }).content;
+		if (content !== undefined) return contentToText(content);
+	}
+	return undefined;
+}
+
+function providerErrorText(message: {
+	role?: unknown;
+	stopReason?: unknown;
+	errorMessage?: unknown;
+}): string | undefined {
+	if (message?.role !== "assistant" || message.stopReason !== "error") return undefined;
+	return typeof message.errorMessage === "string" && message.errorMessage.trim().length > 0
+		? message.errorMessage
+		: "Unknown error";
+}
+
+function uiRequestFromEvent(event: any): UiRequest | undefined {
+	const method = event?.method as string | undefined;
+	if (method === "select" || method === "confirm" || method === "input" || method === "editor") {
+		return {
+			id: String(event.id),
+			method,
+			title: String(event.title ?? ""),
+			message: typeof event.message === "string" ? event.message : undefined,
+			options: Array.isArray(event.options) ? event.options.map((o: unknown) => String(o)) : undefined,
+			placeholder: typeof event.placeholder === "string" ? event.placeholder : undefined,
+			prefill: typeof event.prefill === "string" ? event.prefill : undefined,
+		};
+	}
+	if (method === "ask") {
+		return {
+			id: String(event.id),
+			method: "ask",
+			title: String(event.title ?? "Question"),
+			question: typeof event.question === "string" ? event.question : "",
+			options: Array.isArray(event.options) ? event.options.map((o: unknown) => String(o)) : undefined,
+			allowFreeText: typeof event.allowFreeText === "boolean" ? event.allowFreeText : undefined,
+			multiSelect: typeof event.multiSelect === "boolean" ? event.multiSelect : undefined,
+			multiline: typeof event.multiline === "boolean" ? event.multiline : undefined,
+			expiresAt: typeof event.expiresAt === "number" ? event.expiresAt : undefined,
+		};
+	}
+	return undefined;
+}
+
+/** Apply one session event (or synthetic host event) to the transcript state. */
+export function applyEvent(state: TranscriptState, event: any): void {
+	switch (event?.type) {
+		case "agent_start": {
+			state.streaming = true;
+			state.statusText = undefined;
+			// A new run resolves any prior blocking UI requests server-side.
+			state.uiRequests = [];
+			break;
+		}
+		case "agent_end": {
+			state.streaming = false;
+			const group = activeResponse(state, false);
+			if (group) {
+				group.streaming = false;
+				group.collapsed = true;
+			}
+			break;
+		}
+		case "message_start": {
+			const message = event.message as { role?: string; content?: unknown } | undefined;
+			if (message?.role === "user") {
+				state.items.push({ kind: "user", text: contentToText(message.content) });
+			} else if (message?.role === "assistant") {
+				activeResponse(state, true);
+			}
+			break;
+		}
+		case "message_update": {
+			const stream = event.assistantMessageEvent as { type: string; delta?: string; content?: string } | undefined;
+			if (!stream) break;
+			const group = activeResponse(state, true);
+			if (!group) break;
+			switch (stream.type) {
+				case "text_delta":
+					group.answer += stream.delta ?? "";
+					break;
+				case "text_end":
+					// text_end carries the authoritative block content; if no deltas
+					// were seen (e.g. a non-streaming provider), adopt it.
+					if (typeof stream.content === "string" && group.answer.length === 0) group.answer = stream.content;
+					break;
+				case "thinking_start":
+					group.activity.push({ kind: "thinking", text: "" });
+					break;
+				case "thinking_delta": {
+					const thinking = lastThinking(group);
+					if (thinking) thinking.text += stream.delta ?? "";
+					else group.activity.push({ kind: "thinking", text: stream.delta ?? "" });
+					break;
+				}
+				case "thinking_end": {
+					const thinking = lastThinking(group);
+					if (thinking && typeof stream.content === "string") thinking.text = stream.content;
+					break;
+				}
+				default:
+					// text_start / toolcall_* — tools are tracked via tool_execution_* below.
+					break;
+			}
+			break;
+		}
+		case "message_end": {
+			const message = event.message as { role?: string; stopReason?: string; errorMessage?: string } | undefined;
+			if (message) {
+				const error = providerErrorText(message);
+				if (error) {
+					const group = activeResponse(state, true);
+					if (group) group.error = error;
+				}
+			}
+			break;
+		}
+		case "tool_execution_start": {
+			const group = activeResponse(state, true);
+			if (!group) break;
+			const toolCallId = String(event.toolCallId);
+			const existing = findTool(group, toolCallId);
+			if (existing) {
+				existing.toolName = String(event.toolName);
+				existing.args = event.args;
+				existing.status = "running";
+				existing.resultText = "";
+			} else {
+				group.activity.push({
+					kind: "tool",
+					toolCallId,
+					toolName: String(event.toolName),
+					args: event.args,
+					status: "running",
+					resultText: "",
+				});
+			}
+			break;
+		}
+		case "tool_execution_update": {
+			const group = activeResponse(state, false);
+			const tool = group ? findTool(group, String(event.toolCallId)) : undefined;
+			if (tool) {
+				const text = partialResultText(event.partialResult);
+				if (text !== undefined) tool.resultText = text;
+			}
+			break;
+		}
+		case "tool_execution_end": {
+			const group = activeResponse(state, false);
+			const tool = group ? findTool(group, String(event.toolCallId)) : undefined;
+			if (tool) {
+				tool.status = event.isError ? "error" : "done";
+				const text = partialResultText(event.result);
+				if (text !== undefined) tool.resultText = text;
+			}
+			break;
+		}
+		case "extension_ui_request": {
+			const request = uiRequestFromEvent(event);
+			if (request) {
+				// Replace any stale request with the same id, then append.
+				state.uiRequests = state.uiRequests.filter((r) => r.id !== request.id);
+				state.uiRequests.push(request);
+			} else if (event.method === "setStatus") {
+				state.statusText = typeof event.statusText === "string" ? event.statusText : undefined;
+			}
+			break;
+		}
+		case "extension_ui_response_handled": {
+			state.uiRequests = state.uiRequests.filter((r) => r.id !== String(event.id));
+			break;
+		}
+		case "auto_compaction_start": {
+			state.statusText = "compacting context…";
+			break;
+		}
+		case "auto_compaction_end": {
+			if (state.statusText === "compacting context…") state.statusText = undefined;
+			break;
+		}
+		case "auto_retry_start": {
+			state.statusText = `retrying (${event.attempt}/${event.maxAttempts})…`;
+			break;
+		}
+		case "auto_retry_end": {
+			state.statusText = undefined;
+			break;
+		}
+		case "host_error": {
+			// Synthetic event emitted by the SessionController on RPC child exit.
+			state.hostError = String(event.message ?? "dreb process exited");
+			state.streaming = false;
+			const group = activeResponse(state, false);
+			if (group) {
+				group.streaming = false;
+				group.collapsed = true;
+				group.error = group.error ?? state.hostError;
+			}
+			break;
+		}
+		case "host_notice": {
+			// Synthetic event for host-side, non-fatal feedback (e.g. an unwired
+			// builtin or an unknown command).
+			state.statusText = String(event.message ?? "");
+			break;
+		}
+		default:
+			break;
+	}
+}
+
+/** One-line summary of a response's activity for the collapsed header. */
+export function activitySummary(group: ResponseGroup): string {
+	const toolCount = group.activity.filter((a) => a.kind === "tool").length;
+	const thoughtCount = group.activity.filter((a) => a.kind === "thinking").length;
+	const parts: string[] = [];
+	if (thoughtCount > 0) parts.push(`${thoughtCount} thought${thoughtCount === 1 ? "" : "s"}`);
+	if (toolCount > 0) parts.push(`${toolCount} tool call${toolCount === 1 ? "" : "s"}`);
+	return parts.length > 0 ? parts.join(" · ") : "no activity";
+}

--- a/packages/vscode/src/shared/protocol.ts
+++ b/packages/vscode/src/shared/protocol.ts
@@ -1,0 +1,49 @@
+/**
+ * Host ↔ webview wire protocol.
+ *
+ * The extension host and the webview communicate exclusively through
+ * `postMessage` (structured-clone JSON). This module defines the message
+ * envelopes and the small DTOs that cross the boundary. It intentionally does
+ * NOT import `@dreb/coding-agent` so the webview bundle stays free of any
+ * node-only code — the mirror of the dashboard's `src/shared/protocol.ts`.
+ */
+
+import type { TranscriptState } from "./projection.js";
+
+/** A slash command offered in the composer dropdown. */
+export interface SlashCommandDto {
+	name: string;
+	description?: string;
+	/** Origin: an agent command routed to `prompt`, or a host-handled builtin. */
+	source: "agent" | "builtin";
+}
+
+/** Connection/identity status the webview shows in its header. */
+export interface HostStatus {
+	connected: boolean;
+	cwd: string;
+	model?: string;
+	error?: string;
+}
+
+/** A response to a blocking extension-UI request, mirroring RpcExtensionUIResponse. */
+export type UiResponse =
+	| { id: string; value: string }
+	| { id: string; confirmed: boolean }
+	| { id: string; selected: string[]; customText?: string }
+	| { id: string; cancelled: true };
+
+/** Messages sent from the host to the webview. */
+export type HostToWebview =
+	| { type: "snapshot"; state: TranscriptState; commands: SlashCommandDto[]; status: HostStatus }
+	| { type: "event"; event: unknown }
+	| { type: "commands"; commands: SlashCommandDto[] }
+	| { type: "status"; status: HostStatus };
+
+/** Messages sent from the webview to the host. */
+export type WebviewToHost =
+	| { type: "ready" }
+	| { type: "submit"; text: string }
+	| { type: "abort" }
+	| { type: "refresh-commands" }
+	| { type: "ui-response"; response: UiResponse };

--- a/packages/vscode/src/webview/app.tsx
+++ b/packages/vscode/src/webview/app.tsx
@@ -1,0 +1,425 @@
+import { createEffect, createMemo, createSignal, For, onCleanup, onMount, Show } from "solid-js";
+import { createStore, produce, reconcile } from "solid-js/store";
+import {
+	activitySummary,
+	applyEvent,
+	createTranscriptState,
+	type ResponseGroup,
+	type ToolActivity,
+	type TranscriptState,
+	type UiRequest,
+} from "../shared/projection.js";
+import type { HostStatus, SlashCommandDto, UiResponse } from "../shared/protocol.js";
+import { renderMarkdown } from "./markdown.js";
+import { onHostMessage, postToHost } from "./vscode-api.js";
+
+export function App() {
+	const [state, setState] = createStore<TranscriptState>(createTranscriptState());
+	const [commands, setCommands] = createSignal<SlashCommandDto[]>([]);
+	const [status, setStatus] = createSignal<HostStatus>({ connected: false, cwd: "" });
+	const [tick, setTick] = createSignal(0);
+
+	let scrollEl: HTMLDivElement | undefined;
+	const scrollToBottom = () => {
+		if (scrollEl) scrollEl.scrollTop = scrollEl.scrollHeight;
+	};
+
+	onMount(() => {
+		const off = onHostMessage((msg) => {
+			switch (msg.type) {
+				case "snapshot":
+					setState(reconcile(msg.state));
+					setCommands(msg.commands);
+					setStatus(msg.status);
+					break;
+				case "event":
+					setState(produce((s) => applyEvent(s, msg.event)));
+					break;
+				case "commands":
+					setCommands(msg.commands);
+					break;
+				case "status":
+					setStatus(msg.status);
+					break;
+			}
+			setTick((t) => t + 1);
+		});
+		postToHost({ type: "ready" });
+		onCleanup(off);
+	});
+
+	// Keep the transcript pinned to the latest output on any update.
+	createEffect(() => {
+		tick();
+		queueMicrotask(scrollToBottom);
+	});
+
+	const respondUi = (response: UiResponse) => postToHost({ type: "ui-response", response });
+
+	return (
+		<div class="dreb-app">
+			<header class="dreb-header">
+				<span class="dreb-title">dreb</span>
+				<span class="dreb-cwd" title={status().cwd}>
+					{shortPath(status().cwd)}
+				</span>
+				<span class={`dreb-dot ${status().connected ? "ok" : "off"}`} />
+			</header>
+
+			<Show when={state.hostError}>
+				<div class="dreb-banner error">{state.hostError}</div>
+			</Show>
+
+			<div class="dreb-transcript" ref={scrollEl}>
+				<For each={state.items}>
+					{(item) =>
+						item.kind === "user" ? <div class="dreb-user">{item.text}</div> : <ResponseView group={item} />
+					}
+				</For>
+
+				<For each={state.uiRequests}>{(request) => <UiRequestView request={request} onRespond={respondUi} />}</For>
+
+				<Show when={state.statusText}>
+					<div class="dreb-status-line">{state.statusText}</div>
+				</Show>
+			</div>
+
+			<Composer
+				streaming={state.streaming}
+				commands={commands()}
+				onSubmit={(text) => postToHost({ type: "submit", text })}
+				onAbort={() => postToHost({ type: "abort" })}
+			/>
+		</div>
+	);
+}
+
+function ResponseView(props: { group: ResponseGroup }) {
+	return (
+		<div class="dreb-response">
+			<Show when={props.group.activity.length > 0}>
+				<ActivityBox group={props.group} />
+			</Show>
+			<Show when={props.group.answer.length > 0}>
+				{/* Sanitized markdown — see renderMarkdown. */}
+				<div class="dreb-answer" innerHTML={renderMarkdown(props.group.answer)} />
+			</Show>
+			<Show when={props.group.error}>
+				<div class="dreb-banner error">{props.group.error}</div>
+			</Show>
+		</div>
+	);
+}
+
+function ActivityBox(props: { group: ResponseGroup }) {
+	const [open, setOpen] = createSignal(true);
+	// Auto-collapse once the run finishes; the user can reopen freely afterward.
+	let autoCollapsed = false;
+	createEffect(() => {
+		if (props.group.collapsed && !autoCollapsed) {
+			autoCollapsed = true;
+			setOpen(false);
+		}
+	});
+	const summary = createMemo(() => activitySummary(props.group));
+
+	return (
+		<div class="dreb-activity">
+			<button type="button" class="dreb-activity-head" onClick={() => setOpen(!open())}>
+				<span class="dreb-caret">{open() ? "▾" : "▸"}</span>
+				<Show when={props.group.streaming} fallback={<span class="dreb-activity-label">Worked · {summary()}</span>}>
+					<span class="dreb-activity-label">
+						<span class="dreb-spinner" /> Working · {summary()}
+					</span>
+				</Show>
+			</button>
+			<Show when={open()}>
+				<div class="dreb-activity-body">
+					<For each={props.group.activity}>
+						{(item) =>
+							item.kind === "thinking" ? <div class="dreb-thinking">{item.text}</div> : <ToolCard tool={item} />
+						}
+					</For>
+				</div>
+			</Show>
+		</div>
+	);
+}
+
+function ToolCard(props: { tool: ToolActivity }) {
+	return (
+		<div class={`dreb-tool ${props.tool.status}`}>
+			<div class="dreb-tool-head">
+				<span class="dreb-tool-name">{props.tool.toolName}</span>
+				<span class="dreb-tool-status">{props.tool.status}</span>
+			</div>
+			<Show when={argPreview(props.tool.args)}>{(preview) => <div class="dreb-tool-args">{preview()}</div>}</Show>
+			<Show when={props.tool.resultText}>
+				<pre class="dreb-tool-result">{clip(props.tool.resultText, 4000)}</pre>
+			</Show>
+		</div>
+	);
+}
+
+function UiRequestView(props: { request: UiRequest; onRespond: (response: UiResponse) => void }) {
+	const request = props.request;
+	const cancel = () => props.onRespond({ id: request.id, cancelled: true });
+
+	return (
+		<div class="dreb-uireq">
+			<div class="dreb-uireq-title">{request.title}</div>
+			<Show when={request.message}>
+				<div class="dreb-uireq-message">{request.message}</div>
+			</Show>
+
+			<Show when={request.method === "confirm"}>
+				<div class="dreb-uireq-actions">
+					<button type="button" onClick={() => props.onRespond({ id: request.id, confirmed: true })}>
+						Yes
+					</button>
+					<button type="button" onClick={() => props.onRespond({ id: request.id, confirmed: false })}>
+						No
+					</button>
+					<button type="button" class="ghost" onClick={cancel}>
+						Cancel
+					</button>
+				</div>
+			</Show>
+
+			<Show when={request.method === "select"}>
+				<div class="dreb-uireq-actions column">
+					<For each={request.options ?? []}>
+						{(option) => (
+							<button type="button" onClick={() => props.onRespond({ id: request.id, value: option })}>
+								{option}
+							</button>
+						)}
+					</For>
+					<button type="button" class="ghost" onClick={cancel}>
+						Cancel
+					</button>
+				</div>
+			</Show>
+
+			<Show when={request.method === "input" || request.method === "editor"}>
+				<TextResponse
+					multiline={request.method === "editor"}
+					placeholder={request.placeholder}
+					prefill={request.prefill}
+					onSubmit={(value) => props.onRespond({ id: request.id, value })}
+					onCancel={cancel}
+				/>
+			</Show>
+
+			<Show when={request.method === "ask"}>
+				<AskResponse request={request} onRespond={props.onRespond} onCancel={cancel} />
+			</Show>
+		</div>
+	);
+}
+
+function TextResponse(props: {
+	multiline?: boolean;
+	placeholder?: string;
+	prefill?: string;
+	onSubmit: (value: string) => void;
+	onCancel: () => void;
+}) {
+	const [value, setValue] = createSignal(props.prefill ?? "");
+	return (
+		<div class="dreb-uireq-actions column">
+			<Show
+				when={props.multiline}
+				fallback={
+					<input
+						type="text"
+						placeholder={props.placeholder}
+						value={value()}
+						onInput={(e) => setValue(e.currentTarget.value)}
+					/>
+				}
+			>
+				<textarea
+					rows={6}
+					placeholder={props.placeholder}
+					value={value()}
+					onInput={(e) => setValue(e.currentTarget.value)}
+				/>
+			</Show>
+			<div class="dreb-uireq-actions">
+				<button type="button" onClick={() => props.onSubmit(value())}>
+					Submit
+				</button>
+				<button type="button" class="ghost" onClick={props.onCancel}>
+					Cancel
+				</button>
+			</div>
+		</div>
+	);
+}
+
+function AskResponse(props: { request: UiRequest; onRespond: (response: UiResponse) => void; onCancel: () => void }) {
+	const request = props.request;
+	const [selected, setSelected] = createSignal<string[]>([]);
+	const [customText, setCustomText] = createSignal("");
+	const allowFreeText = request.allowFreeText !== false;
+
+	const toggle = (option: string) => {
+		if (request.multiSelect) {
+			setSelected((prev) => (prev.includes(option) ? prev.filter((o) => o !== option) : [...prev, option]));
+		} else {
+			setSelected([option]);
+		}
+	};
+
+	const submit = () => {
+		const text = customText().trim();
+		props.onRespond({
+			id: request.id,
+			selected: selected(),
+			customText: text.length > 0 ? text : undefined,
+		});
+	};
+
+	return (
+		<div class="dreb-uireq-actions column">
+			<Show when={request.question}>
+				<div class="dreb-uireq-message">{request.question}</div>
+			</Show>
+			<For each={request.options ?? []}>
+				{(option) => (
+					<label class="dreb-option">
+						<input
+							type={request.multiSelect ? "checkbox" : "radio"}
+							name={`ask-${request.id}`}
+							checked={selected().includes(option)}
+							onChange={() => toggle(option)}
+						/>
+						<span>{option}</span>
+					</label>
+				)}
+			</For>
+			<Show when={allowFreeText}>
+				<Show
+					when={request.multiline}
+					fallback={
+						<input
+							type="text"
+							placeholder="Type your own answer…"
+							value={customText()}
+							onInput={(e) => setCustomText(e.currentTarget.value)}
+						/>
+					}
+				>
+					<textarea
+						rows={4}
+						placeholder="Type your own answer…"
+						value={customText()}
+						onInput={(e) => setCustomText(e.currentTarget.value)}
+					/>
+				</Show>
+			</Show>
+			<div class="dreb-uireq-actions">
+				<button type="button" onClick={submit}>
+					Send
+				</button>
+				<button type="button" class="ghost" onClick={props.onCancel}>
+					Cancel
+				</button>
+			</div>
+		</div>
+	);
+}
+
+function Composer(props: {
+	streaming: boolean;
+	commands: SlashCommandDto[];
+	onSubmit: (text: string) => void;
+	onAbort: () => void;
+}) {
+	const [text, setText] = createSignal("");
+
+	const menu = createMemo(() => {
+		const value = text();
+		if (!value.startsWith("/") || value.includes(" ") || value.includes("\n")) return [];
+		const query = value.slice(1).toLowerCase();
+		return props.commands.filter((c) => c.name.toLowerCase().startsWith(query)).slice(0, 8);
+	});
+
+	const submit = () => {
+		const value = text();
+		if (value.trim().length === 0) return;
+		props.onSubmit(value);
+		setText("");
+	};
+
+	const pick = (name: string) => setText(`/${name} `);
+
+	const onKeyDown = (event: KeyboardEvent) => {
+		if (event.key === "Enter" && !event.shiftKey) {
+			event.preventDefault();
+			submit();
+		}
+	};
+
+	return (
+		<div class="dreb-composer">
+			<Show when={menu().length > 0}>
+				<div class="dreb-menu">
+					<For each={menu()}>
+						{(command) => (
+							<button type="button" class="dreb-menu-item" onClick={() => pick(command.name)}>
+								<span class="dreb-menu-name">/{command.name}</span>
+								<Show when={command.description}>
+									<span class="dreb-menu-desc">{command.description}</span>
+								</Show>
+							</button>
+						)}
+					</For>
+				</div>
+			</Show>
+			<div class="dreb-composer-row">
+				<textarea
+					class="dreb-input"
+					rows={2}
+					placeholder="Message dreb…  (/ for commands)"
+					value={text()}
+					onInput={(e) => setText(e.currentTarget.value)}
+					onKeyDown={onKeyDown}
+				/>
+				<Show
+					when={props.streaming}
+					fallback={
+						<button type="button" class="dreb-send" onClick={submit}>
+							Send
+						</button>
+					}
+				>
+					<button type="button" class="dreb-send stop" onClick={props.onAbort}>
+						Stop
+					</button>
+				</Show>
+			</div>
+		</div>
+	);
+}
+
+function argPreview(args: unknown): string | undefined {
+	if (args === undefined || args === null) return undefined;
+	try {
+		const text = typeof args === "string" ? args : JSON.stringify(args);
+		return text.length > 0 ? clip(text, 200) : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function clip(text: string, max: number): string {
+	return text.length > max ? `${text.slice(0, max)}…` : text;
+}
+
+function shortPath(path: string): string {
+	if (!path) return "";
+	const parts = path.split(/[/\\]/).filter(Boolean);
+	return parts.length <= 2 ? path : `…/${parts.slice(-2).join("/")}`;
+}

--- a/packages/vscode/src/webview/index.html
+++ b/packages/vscode/src/webview/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>dreb</title>
+	</head>
+	<body>
+		<div id="root"></div>
+		<script type="module" src="./index.tsx"></script>
+	</body>
+</html>

--- a/packages/vscode/src/webview/index.tsx
+++ b/packages/vscode/src/webview/index.tsx
@@ -1,0 +1,7 @@
+import { render } from "solid-js/web";
+import { App } from "./app.js";
+import "./styles.css";
+
+const root = document.getElementById("root");
+if (!root) throw new Error("dreb webview: #root element missing");
+render(() => <App />, root);

--- a/packages/vscode/src/webview/markdown.ts
+++ b/packages/vscode/src/webview/markdown.ts
@@ -1,0 +1,12 @@
+import DOMPurify from "dompurify";
+import { marked } from "marked";
+
+/**
+ * Render assistant Markdown to sanitized HTML for the answer pane. Model output
+ * is untrusted, so every rendered string passes through DOMPurify before it
+ * reaches the DOM.
+ */
+export function renderMarkdown(text: string): string {
+	const html = marked.parse(text, { async: false, gfm: true, breaks: true }) as string;
+	return DOMPurify.sanitize(html);
+}

--- a/packages/vscode/src/webview/styles.css
+++ b/packages/vscode/src/webview/styles.css
@@ -1,0 +1,346 @@
+:root {
+	color-scheme: light dark;
+}
+
+* {
+	box-sizing: border-box;
+}
+
+body {
+	margin: 0;
+	padding: 0;
+	font-family: var(--vscode-font-family);
+	font-size: var(--vscode-font-size, 13px);
+	color: var(--vscode-foreground);
+	background: var(--vscode-editor-background);
+}
+
+.dreb-app {
+	display: flex;
+	flex-direction: column;
+	height: 100vh;
+}
+
+/* Header ------------------------------------------------------------------ */
+.dreb-header {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 6px 12px;
+	border-bottom: 1px solid var(--vscode-panel-border, rgba(128, 128, 128, 0.35));
+}
+
+.dreb-title {
+	font-weight: 600;
+}
+
+.dreb-cwd {
+	color: var(--vscode-descriptionForeground);
+	font-size: 0.85em;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	flex: 1;
+}
+
+.dreb-dot {
+	width: 8px;
+	height: 8px;
+	border-radius: 50%;
+	background: var(--vscode-charts-red, #d33);
+}
+.dreb-dot.ok {
+	background: var(--vscode-charts-green, #2a2);
+}
+
+/* Transcript -------------------------------------------------------------- */
+.dreb-transcript {
+	flex: 1;
+	overflow-y: auto;
+	padding: 12px;
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+
+.dreb-user {
+	align-self: flex-end;
+	max-width: 85%;
+	white-space: pre-wrap;
+	word-break: break-word;
+	padding: 8px 12px;
+	border-radius: 10px;
+	background: var(--vscode-input-background);
+	border: 1px solid var(--vscode-input-border, transparent);
+}
+
+.dreb-response {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.dreb-answer {
+	white-space: normal;
+	word-break: break-word;
+	line-height: 1.5;
+}
+.dreb-answer :first-child {
+	margin-top: 0;
+}
+.dreb-answer :last-child {
+	margin-bottom: 0;
+}
+.dreb-answer pre {
+	background: var(--vscode-textCodeBlock-background, rgba(128, 128, 128, 0.15));
+	padding: 10px;
+	border-radius: 6px;
+	overflow-x: auto;
+}
+.dreb-answer code {
+	font-family: var(--vscode-editor-font-family, monospace);
+}
+
+/* Activity box ------------------------------------------------------------ */
+.dreb-activity {
+	border: 1px solid var(--vscode-panel-border, rgba(128, 128, 128, 0.3));
+	border-radius: 8px;
+	overflow: hidden;
+	background: var(--vscode-editorWidget-background, rgba(128, 128, 128, 0.06));
+}
+
+.dreb-activity-head {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	width: 100%;
+	text-align: left;
+	padding: 6px 10px;
+	border: none;
+	background: transparent;
+	color: var(--vscode-descriptionForeground);
+	cursor: pointer;
+	font-size: 0.9em;
+}
+
+.dreb-caret {
+	width: 1em;
+}
+
+.dreb-activity-body {
+	padding: 4px 10px 10px;
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.dreb-thinking {
+	white-space: pre-wrap;
+	word-break: break-word;
+	color: var(--vscode-descriptionForeground);
+	font-style: italic;
+	border-left: 2px solid var(--vscode-panel-border, rgba(128, 128, 128, 0.4));
+	padding-left: 8px;
+}
+
+.dreb-tool {
+	border: 1px solid var(--vscode-panel-border, rgba(128, 128, 128, 0.3));
+	border-radius: 6px;
+	padding: 6px 8px;
+	background: var(--vscode-editor-background);
+}
+.dreb-tool.running {
+	border-color: var(--vscode-charts-blue, #38f);
+}
+.dreb-tool.error {
+	border-color: var(--vscode-charts-red, #d33);
+}
+
+.dreb-tool-head {
+	display: flex;
+	justify-content: space-between;
+	gap: 8px;
+	font-size: 0.9em;
+}
+.dreb-tool-name {
+	font-weight: 600;
+}
+.dreb-tool-status {
+	color: var(--vscode-descriptionForeground);
+}
+.dreb-tool-args {
+	font-family: var(--vscode-editor-font-family, monospace);
+	font-size: 0.85em;
+	color: var(--vscode-descriptionForeground);
+	word-break: break-word;
+	margin-top: 4px;
+}
+.dreb-tool-result {
+	margin: 6px 0 0;
+	max-height: 200px;
+	overflow: auto;
+	white-space: pre-wrap;
+	word-break: break-word;
+	font-size: 0.85em;
+}
+
+/* Banners / status -------------------------------------------------------- */
+.dreb-banner {
+	padding: 8px 12px;
+	border-radius: 6px;
+}
+.dreb-banner.error {
+	background: var(--vscode-inputValidation-errorBackground, rgba(220, 50, 50, 0.15));
+	border: 1px solid var(--vscode-inputValidation-errorBorder, #d33);
+	color: var(--vscode-foreground);
+}
+
+.dreb-status-line {
+	color: var(--vscode-descriptionForeground);
+	font-size: 0.85em;
+	font-style: italic;
+}
+
+/* Needs-input ------------------------------------------------------------- */
+.dreb-uireq {
+	border: 1px solid var(--vscode-focusBorder, #38f);
+	border-radius: 8px;
+	padding: 10px 12px;
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	background: var(--vscode-editorWidget-background, rgba(128, 128, 128, 0.06));
+}
+.dreb-uireq-title {
+	font-weight: 600;
+}
+.dreb-uireq-message {
+	white-space: pre-wrap;
+	word-break: break-word;
+}
+.dreb-uireq-actions {
+	display: flex;
+	gap: 8px;
+	flex-wrap: wrap;
+}
+.dreb-uireq-actions.column {
+	flex-direction: column;
+	align-items: stretch;
+}
+.dreb-option {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+}
+
+/* Composer ---------------------------------------------------------------- */
+.dreb-composer {
+	position: relative;
+	border-top: 1px solid var(--vscode-panel-border, rgba(128, 128, 128, 0.35));
+	padding: 8px 12px;
+}
+
+.dreb-composer-row {
+	display: flex;
+	gap: 8px;
+	align-items: flex-end;
+}
+
+.dreb-input {
+	flex: 1;
+	resize: vertical;
+	font-family: inherit;
+	font-size: inherit;
+	color: var(--vscode-input-foreground);
+	background: var(--vscode-input-background);
+	border: 1px solid var(--vscode-input-border, rgba(128, 128, 128, 0.4));
+	border-radius: 6px;
+	padding: 6px 8px;
+}
+
+.dreb-menu {
+	position: absolute;
+	bottom: 100%;
+	left: 12px;
+	right: 12px;
+	margin-bottom: 4px;
+	max-height: 240px;
+	overflow-y: auto;
+	background: var(--vscode-editorWidget-background, var(--vscode-editor-background));
+	border: 1px solid var(--vscode-panel-border, rgba(128, 128, 128, 0.4));
+	border-radius: 6px;
+	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+.dreb-menu-item {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: 2px;
+	width: 100%;
+	text-align: left;
+	border: none;
+	background: transparent;
+	color: var(--vscode-foreground);
+	padding: 6px 10px;
+	cursor: pointer;
+}
+.dreb-menu-item:hover {
+	background: var(--vscode-list-hoverBackground, rgba(128, 128, 128, 0.15));
+}
+.dreb-menu-name {
+	font-weight: 600;
+}
+.dreb-menu-desc {
+	color: var(--vscode-descriptionForeground);
+	font-size: 0.85em;
+}
+
+button {
+	font-family: inherit;
+	font-size: inherit;
+	color: var(--vscode-button-foreground);
+	background: var(--vscode-button-background);
+	border: 1px solid var(--vscode-button-border, transparent);
+	border-radius: 6px;
+	padding: 6px 12px;
+	cursor: pointer;
+}
+button:hover {
+	background: var(--vscode-button-hoverBackground);
+}
+button.ghost {
+	color: var(--vscode-button-secondaryForeground, var(--vscode-foreground));
+	background: var(--vscode-button-secondaryBackground, transparent);
+	border-color: var(--vscode-panel-border, rgba(128, 128, 128, 0.4));
+}
+.dreb-send.stop {
+	background: var(--vscode-charts-red, #d33);
+}
+
+input[type="text"],
+textarea {
+	font-family: inherit;
+	font-size: inherit;
+	color: var(--vscode-input-foreground);
+	background: var(--vscode-input-background);
+	border: 1px solid var(--vscode-input-border, rgba(128, 128, 128, 0.4));
+	border-radius: 6px;
+	padding: 6px 8px;
+}
+
+/* Spinner ----------------------------------------------------------------- */
+.dreb-spinner {
+	display: inline-block;
+	width: 10px;
+	height: 10px;
+	border: 2px solid var(--vscode-descriptionForeground);
+	border-top-color: transparent;
+	border-radius: 50%;
+	animation: dreb-spin 0.8s linear infinite;
+	vertical-align: middle;
+}
+@keyframes dreb-spin {
+	to {
+		transform: rotate(360deg);
+	}
+}

--- a/packages/vscode/src/webview/vscode-api.ts
+++ b/packages/vscode/src/webview/vscode-api.ts
@@ -1,0 +1,25 @@
+import type { HostToWebview, WebviewToHost } from "../shared/protocol.js";
+
+/**
+ * Thin wrapper around the VS Code webview messaging API. `acquireVsCodeApi` is
+ * injected into the webview global scope by VS Code and may be called only once.
+ */
+interface VsCodeApi {
+	postMessage(message: WebviewToHost): void;
+	getState(): unknown;
+	setState(state: unknown): void;
+}
+
+declare function acquireVsCodeApi(): VsCodeApi;
+
+const api = acquireVsCodeApi();
+
+export function postToHost(message: WebviewToHost): void {
+	api.postMessage(message);
+}
+
+export function onHostMessage(handler: (message: HostToWebview) => void): () => void {
+	const listener = (event: MessageEvent) => handler(event.data as HostToWebview);
+	window.addEventListener("message", listener);
+	return () => window.removeEventListener("message", listener);
+}

--- a/packages/vscode/test/cli-path.test.ts
+++ b/packages/vscode/test/cli-path.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { resolveCliPath } from "../src/host/cli-path.js";
+
+describe("cli-path resolution", () => {
+	it("prefers the configured setting when the file exists", () => {
+		const result = resolveCliPath({
+			configuredPath: "/opt/dreb/dist/cli.js",
+			fileExists: (p) => p === "/opt/dreb/dist/cli.js",
+		});
+		expect(result).toEqual({ ok: true, path: "/opt/dreb/dist/cli.js", source: "setting" });
+	});
+
+	it("errors clearly when the configured setting points nowhere", () => {
+		const result = resolveCliPath({
+			configuredPath: "/nope/cli.js",
+			fileExists: () => false,
+		});
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.error).toContain("/nope/cli.js");
+	});
+
+	it("falls back to dependency resolution when no setting is present", () => {
+		const result = resolveCliPath({
+			configuredPath: "  ",
+			resolveCliDir: () => "/pkgs/coding-agent/dist",
+			fileExists: (p) => p === "/pkgs/coding-agent/dist/cli.js",
+		});
+		expect(result).toEqual({ ok: true, path: "/pkgs/coding-agent/dist/cli.js", source: "dependency" });
+	});
+
+	it("errors when dependency resolution yields nothing", () => {
+		const result = resolveCliPath({
+			resolveCliDir: () => undefined,
+			fileExists: () => false,
+		});
+		expect(result.ok).toBe(false);
+	});
+
+	it("errors when the resolved dependency dir has no cli.js", () => {
+		const result = resolveCliPath({
+			resolveCliDir: () => "/pkgs/coding-agent/dist",
+			fileExists: () => false,
+		});
+		expect(result.ok).toBe(false);
+	});
+});

--- a/packages/vscode/test/projection.test.ts
+++ b/packages/vscode/test/projection.test.ts
@@ -20,6 +20,10 @@ function onlyResponse(state: TranscriptState): ResponseGroup {
 	return group;
 }
 
+function allResponses(state: TranscriptState): ResponseGroup[] {
+	return state.items.filter((i): i is ResponseGroup => i.kind === "response");
+}
+
 describe("projection", () => {
 	it("separates answer text from thinking/tool activity", () => {
 		const state = run([
@@ -135,6 +139,71 @@ describe("projection", () => {
 		expect(state.hostError).toContain("exited");
 		expect(state.streaming).toBe(false);
 		expect(onlyResponse(state).collapsed).toBe(true);
+	});
+
+	it("groups sequential agent runs into distinct responses", () => {
+		const state = run([
+			{ type: "agent_start" },
+			{ type: "message_start", message: { role: "assistant" } },
+			{ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "first" } },
+			{ type: "agent_end" },
+			{ type: "message_start", message: { role: "user", content: "again" } },
+			{ type: "agent_start" },
+			{ type: "message_start", message: { role: "assistant" } },
+			{ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "second" } },
+			{ type: "agent_end" },
+		]);
+
+		const responses = allResponses(state);
+		expect(responses).toHaveLength(2);
+		expect(responses.map((r) => r.answer)).toEqual(["first", "second"]);
+		expect(responses[0].id).not.toBe(responses[1].id);
+		expect(responses.every((r) => r.collapsed && !r.streaming)).toBe(true);
+		// The interleaved user turn sits between the two responses.
+		expect(state.items.map((i) => i.kind)).toEqual(["response", "user", "response"]);
+	});
+
+	it("keeps interleaved concurrent tool calls on their own entries", () => {
+		const state = run([
+			{ type: "agent_start" },
+			{ type: "message_start", message: { role: "assistant" } },
+			{ type: "tool_execution_start", toolCallId: "t1", toolName: "read", args: { path: "a" } },
+			{ type: "tool_execution_start", toolCallId: "t2", toolName: "bash", args: { cmd: "ls" } },
+			{ type: "tool_execution_update", toolCallId: "t2", partialResult: "listing…" },
+			{ type: "tool_execution_update", toolCallId: "t1", partialResult: "reading…" },
+			{ type: "tool_execution_end", toolCallId: "t2", result: "t2 output", isError: false },
+			{ type: "tool_execution_end", toolCallId: "t1", result: "t1 output", isError: true },
+			{ type: "agent_end" },
+		]);
+
+		const tools = onlyResponse(state).activity.filter((a) => a.kind === "tool");
+		expect(tools).toHaveLength(2);
+		expect(tools[0]).toMatchObject({ toolCallId: "t1", toolName: "read", status: "error", resultText: "t1 output" });
+		expect(tools[1]).toMatchObject({ toolCallId: "t2", toolName: "bash", status: "done", resultText: "t2 output" });
+	});
+
+	it("sets and clears the compaction status without clobbering an unrelated status", () => {
+		const state = createTranscriptState();
+		applyEvent(state, { type: "auto_compaction_start" });
+		expect(state.statusText).toBe("compacting context…");
+		applyEvent(state, { type: "auto_compaction_end" });
+		expect(state.statusText).toBeUndefined();
+
+		// If a different status is set after compaction started, the compaction-end
+		// guard must NOT clear it.
+		applyEvent(state, { type: "auto_compaction_start" });
+		applyEvent(state, { type: "auto_retry_start", attempt: 1, maxAttempts: 3 });
+		expect(state.statusText).toBe("retrying (1/3)…");
+		applyEvent(state, { type: "auto_compaction_end" });
+		expect(state.statusText).toBe("retrying (1/3)…");
+	});
+
+	it("sets a numbered retry status and clears it on retry end", () => {
+		const state = createTranscriptState();
+		applyEvent(state, { type: "auto_retry_start", attempt: 2, maxAttempts: 5 });
+		expect(state.statusText).toBe("retrying (2/5)…");
+		applyEvent(state, { type: "auto_retry_end" });
+		expect(state.statusText).toBeUndefined();
 	});
 
 	it("summarizes activity for the collapsed header", () => {

--- a/packages/vscode/test/projection.test.ts
+++ b/packages/vscode/test/projection.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+import {
+	activitySummary,
+	applyEvent,
+	createTranscriptState,
+	type ResponseGroup,
+	type TranscriptState,
+} from "../src/shared/projection.js";
+
+/** Feed a list of events through a fresh state. */
+function run(events: unknown[]): TranscriptState {
+	const state = createTranscriptState();
+	for (const event of events) applyEvent(state, event);
+	return state;
+}
+
+function onlyResponse(state: TranscriptState): ResponseGroup {
+	const group = state.items.find((i): i is ResponseGroup => i.kind === "response");
+	if (!group) throw new Error("no response group");
+	return group;
+}
+
+describe("projection", () => {
+	it("separates answer text from thinking/tool activity", () => {
+		const state = run([
+			{ type: "agent_start" },
+			{ type: "message_start", message: { role: "user", content: "hello" } },
+			{ type: "message_start", message: { role: "assistant" } },
+			{ type: "message_update", assistantMessageEvent: { type: "thinking_start" } },
+			{ type: "message_update", assistantMessageEvent: { type: "thinking_delta", delta: "pondering" } },
+			{ type: "message_update", assistantMessageEvent: { type: "thinking_end", content: "pondering done" } },
+			{ type: "tool_execution_start", toolCallId: "t1", toolName: "read", args: { path: "a.ts" } },
+			{ type: "tool_execution_update", toolCallId: "t1", partialResult: "reading…" },
+			{ type: "tool_execution_end", toolCallId: "t1", result: "file body", isError: false },
+			{ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "Here is " } },
+			{ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "the answer." } },
+			{ type: "agent_end" },
+		]);
+
+		expect(state.items[0]).toEqual({ kind: "user", text: "hello" });
+		const group = onlyResponse(state);
+		expect(group.answer).toBe("Here is the answer.");
+		expect(group.activity).toHaveLength(2);
+		expect(group.activity[0]).toEqual({ kind: "thinking", text: "pondering done" });
+		expect(group.activity[1]).toMatchObject({
+			kind: "tool",
+			toolCallId: "t1",
+			toolName: "read",
+			status: "done",
+			resultText: "file body",
+		});
+	});
+
+	it("marks the run streaming, then collapses activity at agent_end", () => {
+		const state = createTranscriptState();
+		applyEvent(state, { type: "agent_start" });
+		applyEvent(state, { type: "message_update", assistantMessageEvent: { type: "thinking_start" } });
+		let group = onlyResponse(state);
+		expect(state.streaming).toBe(true);
+		expect(group.streaming).toBe(true);
+		expect(group.collapsed).toBe(false);
+
+		applyEvent(state, { type: "agent_end" });
+		group = onlyResponse(state);
+		expect(state.streaming).toBe(false);
+		expect(group.streaming).toBe(false);
+		expect(group.collapsed).toBe(true);
+	});
+
+	it("accumulates streamed text deltas but adopts text_end when no deltas seen", () => {
+		const streamed = run([
+			{ type: "agent_start" },
+			{ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "ab" } },
+			{ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "cd" } },
+		]);
+		expect(onlyResponse(streamed).answer).toBe("abcd");
+
+		const nonStreaming = run([
+			{ type: "agent_start" },
+			{ type: "message_update", assistantMessageEvent: { type: "text_end", content: "whole answer" } },
+		]);
+		expect(onlyResponse(nonStreaming).answer).toBe("whole answer");
+	});
+
+	it("tracks and clears blocking extension-UI requests", () => {
+		const state = createTranscriptState();
+		applyEvent(state, {
+			type: "extension_ui_request",
+			id: "u1",
+			method: "ask",
+			title: "Pick",
+			question: "Which?",
+			options: ["a", "b"],
+			allowFreeText: false,
+			multiSelect: true,
+		});
+		expect(state.uiRequests).toHaveLength(1);
+		expect(state.uiRequests[0]).toMatchObject({
+			id: "u1",
+			method: "ask",
+			question: "Which?",
+			options: ["a", "b"],
+			allowFreeText: false,
+			multiSelect: true,
+		});
+
+		applyEvent(state, { type: "extension_ui_response_handled", id: "u1" });
+		expect(state.uiRequests).toHaveLength(0);
+	});
+
+	it("clears pending UI requests when a new run starts", () => {
+		const state = createTranscriptState();
+		applyEvent(state, { type: "extension_ui_request", id: "u1", method: "confirm", title: "OK?", message: "sure" });
+		expect(state.uiRequests).toHaveLength(1);
+		applyEvent(state, { type: "agent_start" });
+		expect(state.uiRequests).toHaveLength(0);
+	});
+
+	it("surfaces a provider error onto the response", () => {
+		const state = run([
+			{ type: "agent_start" },
+			{ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "partial" } },
+			{ type: "message_end", message: { role: "assistant", stopReason: "error", errorMessage: "rate limited" } },
+			{ type: "agent_end" },
+		]);
+		expect(onlyResponse(state).error).toBe("rate limited");
+	});
+
+	it("records a synthetic host_error and stops streaming", () => {
+		const state = run([
+			{ type: "agent_start" },
+			{ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "hi" } },
+			{ type: "host_error", message: "dreb process exited (code 1, signal null)" },
+		]);
+		expect(state.hostError).toContain("exited");
+		expect(state.streaming).toBe(false);
+		expect(onlyResponse(state).collapsed).toBe(true);
+	});
+
+	it("summarizes activity for the collapsed header", () => {
+		const group: ResponseGroup = {
+			kind: "response",
+			id: 1,
+			activity: [
+				{ kind: "thinking", text: "x" },
+				{ kind: "tool", toolCallId: "t1", toolName: "read", args: {}, status: "done", resultText: "" },
+				{ kind: "tool", toolCallId: "t2", toolName: "bash", args: {}, status: "done", resultText: "" },
+			],
+			answer: "",
+			streaming: false,
+			collapsed: true,
+		};
+		expect(activitySummary(group)).toBe("1 thought · 2 tool calls");
+		expect(activitySummary({ ...group, activity: [] })).toBe("no activity");
+	});
+});

--- a/packages/vscode/test/session-controller.test.ts
+++ b/packages/vscode/test/session-controller.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vitest";
+import { type RpcClientLike, SessionController } from "../src/host/session-controller.js";
+
+/** Fake RpcClient that captures calls and lets a test drive events/exit. */
+class FakeClient implements RpcClientLike {
+	started = false;
+	stopped = 0;
+	aborted = 0;
+	prompts: string[] = [];
+	compactions: Array<string | undefined> = [];
+	uiResponses: unknown[] = [];
+	commandsResult: Array<{ name: string; description?: string }> = [];
+	startError: Error | undefined;
+	private eventListener: ((event: any) => void) | undefined;
+	private exitListener: ((info: any) => void) | undefined;
+
+	async start(): Promise<void> {
+		if (this.startError) throw this.startError;
+		this.started = true;
+	}
+	async stop(): Promise<void> {
+		this.stopped += 1;
+	}
+	async prompt(message: string): Promise<void> {
+		this.prompts.push(message);
+	}
+	async abort(): Promise<void> {
+		this.aborted += 1;
+	}
+	async compact(customInstructions?: string): Promise<unknown> {
+		this.compactions.push(customInstructions);
+		return {};
+	}
+	async getCommands(): Promise<Array<{ name: string; description?: string }>> {
+		return this.commandsResult;
+	}
+	sendExtensionUIResponse(response: unknown): void {
+		this.uiResponses.push(response);
+	}
+	onEvent(listener: (event: any) => void): () => void {
+		this.eventListener = listener;
+		return () => {
+			this.eventListener = undefined;
+		};
+	}
+	onExit(listener: (info: any) => void): () => void {
+		this.exitListener = listener;
+		return () => {
+			this.exitListener = undefined;
+		};
+	}
+	emit(event: unknown): void {
+		this.eventListener?.(event);
+	}
+	emitExit(info: unknown): void {
+		this.exitListener?.(info);
+	}
+}
+
+function makeController(fake: FakeClient, cwd = "/tmp/project") {
+	return new SessionController({ cwd, cliPath: "/cli.js", clientFactory: () => fake });
+}
+
+describe("SessionController", () => {
+	it("starts the client, connects, and merges agent + builtin commands", async () => {
+		const fake = new FakeClient();
+		fake.commandsResult = [{ name: "/review", description: "Review" }];
+		const controller = makeController(fake);
+
+		await controller.start();
+
+		expect(fake.started).toBe(true);
+		expect(controller.getStatus().connected).toBe(true);
+		const names = controller.getCommandList().map((c) => c.name);
+		expect(names).toContain("review"); // slash stripped, from agent
+		expect(names).toContain("compact"); // builtin
+	});
+
+	it("applies events to the transcript and notifies listeners", async () => {
+		const fake = new FakeClient();
+		const controller = makeController(fake);
+		await controller.start();
+
+		const updates: Array<{ kind: string }> = [];
+		controller.onUpdate((u) => updates.push(u));
+
+		fake.emit({ type: "agent_start" });
+		fake.emit({ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "Hi" } });
+		fake.emit({ type: "agent_end" });
+
+		const transcript = controller.getTranscript();
+		expect(transcript.items.some((i) => i.kind === "response" && i.answer === "Hi")).toBe(true);
+		expect(updates.filter((u) => u.kind === "event")).toHaveLength(3);
+	});
+
+	it("routes plain text to prompt and /compact to compact", async () => {
+		const fake = new FakeClient();
+		const controller = makeController(fake);
+		await controller.start();
+
+		await controller.submit("hello");
+		await controller.submit("/compact now");
+
+		expect(fake.prompts).toEqual(["hello"]);
+		expect(fake.compactions).toEqual(["now"]);
+	});
+
+	it("forwards registered agent commands through prompt", async () => {
+		const fake = new FakeClient();
+		fake.commandsResult = [{ name: "review" }];
+		const controller = makeController(fake);
+		await controller.start();
+
+		await controller.submit("/review 42");
+		expect(fake.prompts).toEqual(["/review 42"]);
+	});
+
+	it("surfaces a notice for unwired builtins without calling the client", async () => {
+		const fake = new FakeClient();
+		const controller = makeController(fake);
+		await controller.start();
+
+		await controller.submit("/model");
+
+		expect(fake.prompts).toHaveLength(0);
+		expect(fake.compactions).toHaveLength(0);
+		expect(controller.getTranscript().statusText).toMatch(/model/);
+	});
+
+	it("forwards extension-UI responses with the wire type", async () => {
+		const fake = new FakeClient();
+		const controller = makeController(fake);
+		await controller.start();
+		controller.respondUi({ id: "u1", confirmed: true });
+		expect(fake.uiResponses[0]).toEqual({ type: "extension_ui_response", id: "u1", confirmed: true });
+	});
+
+	it("surfaces a child-process crash into status and the transcript", async () => {
+		const fake = new FakeClient();
+		const controller = makeController(fake);
+		await controller.start();
+
+		const updates: Array<{ kind: string }> = [];
+		controller.onUpdate((u) => updates.push(u));
+
+		fake.emitExit({ code: 1, signal: null });
+
+		expect(controller.getStatus().error).toMatch(/exited/);
+		expect(controller.getTranscript().hostError).toMatch(/exited/);
+		expect(updates.some((u) => u.kind === "status")).toBe(true);
+		expect(updates.some((u) => u.kind === "event")).toBe(true);
+	});
+
+	it("surfaces a start failure and rethrows", async () => {
+		const fake = new FakeClient();
+		fake.startError = new Error("spawn failed");
+		const controller = makeController(fake);
+
+		await expect(controller.start()).rejects.toThrow("spawn failed");
+		expect(controller.getStatus().error).toMatch(/spawn failed/);
+		expect(controller.getTranscript().hostError).toMatch(/spawn failed/);
+	});
+
+	it("stops the client on dispose", async () => {
+		const fake = new FakeClient();
+		const controller = makeController(fake);
+		await controller.start();
+		await controller.dispose();
+		expect(fake.stopped).toBe(1);
+	});
+
+	it("drops a submit with a notice when the client is not started yet", async () => {
+		const fake = new FakeClient();
+		const controller = makeController(fake);
+		// No start() — client is not created yet.
+		await controller.submit("hello");
+		expect(fake.prompts).toHaveLength(0);
+		expect(controller.getTranscript().statusText).toMatch(/starting up/);
+	});
+});

--- a/packages/vscode/test/session-controller.test.ts
+++ b/packages/vscode/test/session-controller.test.ts
@@ -9,8 +9,15 @@ class FakeClient implements RpcClientLike {
 	prompts: string[] = [];
 	compactions: Array<string | undefined> = [];
 	uiResponses: unknown[] = [];
-	commandsResult: Array<{ name: string; description?: string }> = [];
+	commandsResult: Array<{
+		name: string;
+		description?: string;
+		source: "extension" | "prompt" | "skill" | "builtin";
+		dashboard?: boolean;
+	}> = [];
 	startError: Error | undefined;
+	/** When set, the next prompt/compact/abort call rejects with this error. */
+	callError: Error | undefined;
 	private eventListener: ((event: any) => void) | undefined;
 	private exitListener: ((info: any) => void) | undefined;
 
@@ -22,16 +29,26 @@ class FakeClient implements RpcClientLike {
 		this.stopped += 1;
 	}
 	async prompt(message: string): Promise<void> {
+		if (this.callError) throw this.callError;
 		this.prompts.push(message);
 	}
 	async abort(): Promise<void> {
+		if (this.callError) throw this.callError;
 		this.aborted += 1;
 	}
 	async compact(customInstructions?: string): Promise<unknown> {
+		if (this.callError) throw this.callError;
 		this.compactions.push(customInstructions);
 		return {};
 	}
-	async getCommands(): Promise<Array<{ name: string; description?: string }>> {
+	async getCommands(): Promise<
+		Array<{
+			name: string;
+			description?: string;
+			source: "extension" | "prompt" | "skill" | "builtin";
+			dashboard?: boolean;
+		}>
+	> {
 		return this.commandsResult;
 	}
 	sendExtensionUIResponse(response: unknown): void {
@@ -64,7 +81,7 @@ function makeController(fake: FakeClient, cwd = "/tmp/project") {
 describe("SessionController", () => {
 	it("starts the client, connects, and merges agent + builtin commands", async () => {
 		const fake = new FakeClient();
-		fake.commandsResult = [{ name: "/review", description: "Review" }];
+		fake.commandsResult = [{ name: "/review", description: "Review", source: "prompt" }];
 		const controller = makeController(fake);
 
 		await controller.start();
@@ -107,12 +124,67 @@ describe("SessionController", () => {
 
 	it("forwards registered agent commands through prompt", async () => {
 		const fake = new FakeClient();
-		fake.commandsResult = [{ name: "review" }];
+		fake.commandsResult = [{ name: "review", source: "prompt" }];
 		const controller = makeController(fake);
 		await controller.start();
 
 		await controller.submit("/review 42");
 		expect(fake.prompts).toEqual(["/review 42"]);
+	});
+
+	it("intercepts server builtins from get_commands instead of routing them to prompt", async () => {
+		// Regression: builtins advertised by get_commands (source "builtin") must
+		// NOT be forwarded via prompt — the server rejects them and the rejection
+		// is silently dropped, so the user sees nothing. They must be intercepted.
+		const fake = new FakeClient();
+		fake.commandsResult = [
+			{ name: "new", description: "New session", source: "builtin" },
+			{ name: "quit", description: "Quit", source: "builtin", dashboard: false },
+			{ name: "review", source: "extension" },
+		];
+		const controller = makeController(fake);
+		await controller.start();
+
+		// A dashboard-visible builtin appears in the dropdown with source "builtin".
+		const knew = controller.getCommandList().find((c) => c.name === "new");
+		expect(knew?.source).toBe("builtin");
+		// dashboard:false builtins are hidden from the dropdown.
+		expect(controller.getCommandList().some((c) => c.name === "quit")).toBe(false);
+
+		await controller.submit("/new");
+		expect(fake.prompts).toHaveLength(0); // never forwarded to prompt
+		expect(controller.getTranscript().statusText).toMatch(/isn't available yet/);
+	});
+
+	it("blocks submits after a child crash with a reconnect notice", async () => {
+		const fake = new FakeClient();
+		const controller = makeController(fake);
+		await controller.start();
+		fake.emitExit({ code: 1, signal: null });
+
+		await controller.submit("hello after crash");
+
+		expect(fake.prompts).toHaveLength(0);
+		expect(controller.getTranscript().statusText).toMatch(/isn't connected/);
+	});
+
+	it("surfaces a notice instead of leaking a rejected prompt call", async () => {
+		const fake = new FakeClient();
+		const controller = makeController(fake);
+		await controller.start();
+		fake.callError = new Error("stdin pipe broken");
+
+		await expect(controller.submit("hello")).resolves.toBeUndefined();
+		expect(controller.getTranscript().statusText).toMatch(/Request failed: stdin pipe broken/);
+	});
+
+	it("swallows a rejected abort without throwing", async () => {
+		const fake = new FakeClient();
+		const controller = makeController(fake);
+		await controller.start();
+		fake.callError = new Error("abort boom");
+
+		await expect(controller.abort()).resolves.toBeUndefined();
 	});
 
 	it("surfaces a notice for unwired builtins without calling the client", async () => {

--- a/packages/vscode/test/slash-router.test.ts
+++ b/packages/vscode/test/slash-router.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { routeInput, stripSlash } from "../src/host/slash-router.js";
+import type { SlashCommandDto } from "../src/shared/protocol.js";
+
+const agentCommands: SlashCommandDto[] = [
+	{ name: "review", description: "Review a PR", source: "agent" },
+	{ name: "compact", description: "shadowed builtin name", source: "agent" },
+];
+
+describe("slash-router", () => {
+	it("treats plain text as a prompt", () => {
+		expect(routeInput("hello world")).toEqual({ kind: "prompt", message: "hello world" });
+	});
+
+	it("returns empty for blank input", () => {
+		expect(routeInput("   ")).toEqual({ kind: "empty" });
+		expect(routeInput("")).toEqual({ kind: "empty" });
+	});
+
+	it("routes builtins to their command with an optional argument", () => {
+		expect(routeInput("/compact")).toEqual({ kind: "builtin", command: "compact", arg: undefined });
+		expect(routeInput("/compact keep the tests")).toEqual({
+			kind: "builtin",
+			command: "compact",
+			arg: "keep the tests",
+		});
+		expect(routeInput("/model")).toEqual({ kind: "builtin", command: "model", arg: undefined });
+	});
+
+	it("prefers the builtin mapping over a same-named agent command", () => {
+		// A builtin like /compact must map to the RPC method, never be sent as a
+		// prompt, even if get_commands also advertised it.
+		expect(routeInput("/compact", agentCommands)).toEqual({ kind: "builtin", command: "compact", arg: undefined });
+	});
+
+	it("forwards a registered agent command verbatim through prompt", () => {
+		expect(routeInput("/review 42", agentCommands)).toEqual({ kind: "prompt", message: "/review 42" });
+	});
+
+	it("flags an unknown slash command", () => {
+		expect(routeInput("/bogus now")).toEqual({ kind: "unknown-command", name: "bogus" });
+	});
+
+	it("treats a lone slash as prompt text", () => {
+		expect(routeInput("/")).toEqual({ kind: "prompt", message: "/" });
+	});
+
+	it("normalizes command names", () => {
+		expect(stripSlash("/compact")).toBe("compact");
+		expect(stripSlash("compact")).toBe("compact");
+	});
+});

--- a/packages/vscode/test/slash-router.test.ts
+++ b/packages/vscode/test/slash-router.test.ts
@@ -37,6 +37,14 @@ describe("slash-router", () => {
 		expect(routeInput("/review 42", agentCommands)).toEqual({ kind: "prompt", message: "/review 42" });
 	});
 
+	it("intercepts an advertised builtin (not a wired one) instead of prompting", () => {
+		// `/new` is a server builtin (source "builtin") the host doesn't wire yet.
+		// It must be intercepted — never forwarded to prompt (which the server
+		// rejects and silently drops) — so `submit` can surface a notice.
+		const withBuiltin: SlashCommandDto[] = [{ name: "new", description: "New session", source: "builtin" }];
+		expect(routeInput("/new", withBuiltin)).toEqual({ kind: "builtin", command: "new", arg: undefined });
+	});
+
 	it("flags an unknown slash command", () => {
 		expect(routeInput("/bogus now")).toEqual({ kind: "unknown-command", name: "bogus" });
 	});

--- a/packages/vscode/test/webview-bridge.test.ts
+++ b/packages/vscode/test/webview-bridge.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it, vi } from "vitest";
+
+// The bridge imports `vscode` only for the `Disposable` constructor (in
+// `connectWebview`) and `Uri`/`asWebviewUri` (in `getWebviewHtml`, not tested
+// here). A minimal Disposable is enough to exercise the transport wiring.
+vi.mock("vscode", () => {
+	class Disposable {
+		constructor(private readonly fn: () => void) {}
+		dispose(): void {
+			this.fn();
+		}
+	}
+	return { Disposable };
+});
+
+import { type RpcClientLike, SessionController } from "../src/host/session-controller.js";
+import { connectWebview } from "../src/host/webview-bridge.js";
+import type { HostToWebview, WebviewToHost } from "../src/shared/protocol.js";
+
+/** Minimal RpcClient fake that lets a test push events. */
+class BridgeFakeClient implements RpcClientLike {
+	private ev: ((e: any) => void) | undefined;
+	private ex: ((info: any) => void) | undefined;
+	async start(): Promise<void> {}
+	async stop(): Promise<void> {}
+	async prompt(): Promise<void> {}
+	async abort(): Promise<void> {}
+	async compact(): Promise<unknown> {
+		return {};
+	}
+	async getCommands(): Promise<any[]> {
+		return [];
+	}
+	sendExtensionUIResponse(): void {}
+	onEvent(listener: (e: any) => void): () => void {
+		this.ev = listener;
+		return () => {
+			this.ev = undefined;
+		};
+	}
+	onExit(listener: (info: any) => void): () => void {
+		this.ex = listener;
+		return () => {
+			this.ex = undefined;
+		};
+	}
+	emit(event: unknown): void {
+		this.ev?.(event);
+	}
+	emitExit(info: unknown): void {
+		this.ex?.(info);
+	}
+}
+
+/** Fake vscode.Webview capturing posts and exposing the message handler. */
+function makeWebview() {
+	const posted: HostToWebview[] = [];
+	let handler: ((msg: WebviewToHost) => void) | undefined;
+	const webview = {
+		postMessage: (m: HostToWebview) => {
+			posted.push(m);
+			return Promise.resolve(true);
+		},
+		onDidReceiveMessage: (h: (msg: WebviewToHost) => void) => {
+			handler = h;
+			return { dispose() {} };
+		},
+	};
+	return {
+		webview,
+		posted,
+		send: (m: WebviewToHost) => handler?.(m),
+	};
+}
+
+async function makeController(fake: BridgeFakeClient) {
+	const controller = new SessionController({ cwd: "/tmp/p", cliPath: "/cli.js", clientFactory: () => fake });
+	await controller.start();
+	return controller;
+}
+
+describe("connectWebview", () => {
+	it("holds events until ready, then snapshots once and streams live with no duplication", async () => {
+		const fake = new BridgeFakeClient();
+		const controller = await makeController(fake);
+		const { webview, posted, send } = makeWebview();
+		connectWebview(webview as any, controller);
+
+		// Pre-ready events must NOT be streamed to the webview…
+		fake.emit({ type: "agent_start" });
+		fake.emit({ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "pre" } });
+		expect(posted).toHaveLength(0);
+
+		// …but they ARE folded into the authoritative state and delivered once
+		// via the snapshot when the webview announces ready.
+		send({ type: "ready" });
+		const snapshots = posted.filter((m) => m.type === "snapshot");
+		expect(snapshots).toHaveLength(1);
+		const snapshot = snapshots[0] as Extract<HostToWebview, { type: "snapshot" }>;
+		expect(snapshot.state.streaming).toBe(true);
+		const preGroup = snapshot.state.items.find((i) => i.kind === "response");
+		expect(preGroup && preGroup.kind === "response" && preGroup.answer).toBe("pre");
+
+		// Events AFTER ready stream live as `event` messages…
+		fake.emit({ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "post" } });
+		const events = posted.filter((m) => m.type === "event") as Array<Extract<HostToWebview, { type: "event" }>>;
+		expect(events).toHaveLength(1);
+		expect(events[0].event).toMatchObject({ assistantMessageEvent: { delta: "post" } });
+		// …and the pre-ready events are never re-streamed (no snapshot/stream overlap).
+		expect(events.some((e) => (e.event as any)?.assistantMessageEvent?.delta === "pre")).toBe(false);
+	});
+
+	it("streams status updates live after ready", async () => {
+		const fake = new BridgeFakeClient();
+		const controller = await makeController(fake);
+		const { webview, posted, send } = makeWebview();
+		connectWebview(webview as any, controller);
+		send({ type: "ready" });
+
+		// A child crash drives both a host_error event and a status update; both
+		// must reach the webview now that it is live.
+		fake.emitExit({ code: 1, signal: null });
+		expect(posted.some((m) => m.type === "status")).toBe(true);
+		expect(posted.some((m) => m.type === "event" && (m.event as any)?.type === "host_error")).toBe(true);
+	});
+
+	it("dispatches webview messages to the controller", async () => {
+		const fake = new BridgeFakeClient();
+		const controller = await makeController(fake);
+		const submit = vi.spyOn(controller, "submit").mockResolvedValue();
+		const abort = vi.spyOn(controller, "abort").mockResolvedValue();
+		const respondUi = vi.spyOn(controller, "respondUi").mockImplementation(() => {});
+		const refresh = vi.spyOn(controller, "refreshCommands");
+
+		const { webview, send } = makeWebview();
+		connectWebview(webview as any, controller);
+
+		send({ type: "submit", text: "hi there" });
+		send({ type: "abort" });
+		send({ type: "ui-response", response: { id: "u1", confirmed: true } });
+		send({ type: "refresh-commands" });
+
+		expect(submit).toHaveBeenCalledWith("hi there");
+		expect(abort).toHaveBeenCalledTimes(1);
+		expect(respondUi).toHaveBeenCalledWith({ id: "u1", confirmed: true });
+		expect(refresh).toHaveBeenCalled();
+	});
+
+	it("stops streaming to the webview after the disposable is disposed", async () => {
+		const fake = new BridgeFakeClient();
+		const controller = await makeController(fake);
+		const { webview, posted, send } = makeWebview();
+		const disposable = connectWebview(webview as any, controller);
+		send({ type: "ready" });
+		const afterReady = posted.length;
+
+		disposable.dispose();
+		fake.emit({ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "late" } });
+
+		expect(posted.length).toBe(afterReady); // nothing new posted post-dispose
+	});
+});

--- a/packages/vscode/tsconfig.build.json
+++ b/packages/vscode/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"outDir": "./dist",
+		"rootDir": "./src"
+	},
+	"include": ["src/**/*.ts"],
+	"exclude": ["node_modules", "dist", "src/webview", "**/*.d.ts"]
+}

--- a/packages/vscode/tsconfig.webview.json
+++ b/packages/vscode/tsconfig.webview.json
@@ -1,0 +1,13 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"noEmit": true,
+		"module": "ESNext",
+		"moduleResolution": "Bundler",
+		"lib": ["ES2024", "DOM", "DOM.Iterable"],
+		"jsx": "preserve",
+		"jsxImportSource": "solid-js",
+		"types": []
+	},
+	"include": ["src/webview/**/*.ts", "src/webview/**/*.tsx", "src/shared/**/*.ts"]
+}

--- a/packages/vscode/vite.config.mts
+++ b/packages/vscode/vite.config.mts
@@ -1,0 +1,24 @@
+import { resolve } from "node:path";
+import { defineConfig } from "vite";
+import solid from "vite-plugin-solid";
+
+// Builds the SolidJS webview into dist/webview with STABLE asset names
+// (main.js / main.css). The extension host constructs the webview HTML by
+// referencing those fixed filenames through `webview.asWebviewUri`, so we do
+// not rely on hashed names or on parsing a generated index.html.
+export default defineConfig({
+	plugins: [solid()],
+	root: resolve(import.meta.dirname, "src/webview"),
+	base: "./",
+	build: {
+		outDir: resolve(import.meta.dirname, "dist/webview"),
+		emptyOutDir: true,
+		rollupOptions: {
+			output: {
+				entryFileNames: "main.js",
+				assetFileNames: "main[extname]",
+				chunkFileNames: "chunk-[name].js",
+			},
+		},
+	},
+});

--- a/packages/vscode/vitest.config.mts
+++ b/packages/vscode/vitest.config.mts
@@ -1,0 +1,19 @@
+import solid from "vite-plugin-solid";
+import { defineConfig } from "vitest/config";
+
+// Host and shared logic run in the default node environment. Webview component
+// tests can opt into jsdom with a per-file `// @vitest-environment jsdom`
+// docblock; the solid plugin + resolve aliases mirror the dashboard setup so
+// such tests transform correctly.
+export default defineConfig({
+	plugins: [solid()],
+	test: {
+		globals: true,
+		environment: "node",
+		testTimeout: 10000,
+	},
+	resolve: {
+		conditions: ["development", "browser"],
+		alias: [{ find: /^solid-js\/web$/, replacement: "solid-js/web/dist/web.js" }],
+	},
+});

--- a/scripts/sync-version.sh
+++ b/scripts/sync-version.sh
@@ -20,6 +20,9 @@ VERSION=$(node -p "require('./package.json').version")
 echo "Syncing version $VERSION to all packages..."
 
 for pkg in packages/*/package.json; do
+	# The VS Code extension is versioned independently (Marketplace, not npm) and
+	# must never be touched by root version syncing.
+	[ "$pkg" = "packages/vscode/package.json" ] && continue
 	node -e "
 		const fs = require('fs');
 		const pkg = JSON.parse(fs.readFileSync('$pkg', 'utf-8'));
@@ -60,8 +63,11 @@ if [ -f package-lock.json ]; then
 
 		// Top-level workspace packages we just bumped (direct children of packages/).
 		// Mirrors the 'packages/*/package.json' glob above and excludes nested
-		// example extensions, which carry independent versions.
+		// example extensions, which carry independent versions. The vscode
+		// package is also excluded — the VS Code extension is versioned
+		// independently.
 		const dirs = fs.readdirSync('packages').filter((name) => {
+			if (name === 'vscode') return false;
 			try {
 				return fs.statSync('packages/' + name + '/package.json').isFile();
 			} catch {
@@ -110,5 +116,5 @@ fi
 echo "Done. Files to stage for version bump commit:"
 echo "  package.json"
 echo "  package-lock.json"
-for pkg in packages/*/package.json; do echo "  $pkg"; done
+for pkg in packages/*/package.json; do [ "$pkg" = "packages/vscode/package.json" ] && continue; echo "  $pkg"; done
 for pj in packages/*/.claude-plugin/plugin.json; do [ -f "$pj" ] && echo "  $pj"; done

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,5 +26,5 @@
 		}
 	},
 	"include": ["packages/*/src/**/*", "packages/*/test/**/*", "packages/coding-agent/examples/**/*"],
-	"exclude": ["packages/web-ui/**/*", "**/dist/**", "packages/dashboard/src/client/**/*", "packages/dashboard/test/client/**/*", "packages/coding-agent/examples/extensions/sandbox/**"]
+	"exclude": ["packages/web-ui/**/*", "**/dist/**", "packages/dashboard/src/client/**/*", "packages/dashboard/test/client/**/*", "packages/vscode/src/webview/**/*", "packages/coding-agent/examples/extensions/sandbox/**"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
 			"packages/semantic-search",
 			"packages/telegram",
 			"packages/dashboard",
+			"packages/vscode",
 		],
 	},
 });


### PR DESCRIPTION
Closes #13

Bootstraps a new `packages/vscode/` extension — a native webview chat client that drives the dreb agent over RPC (`RpcClient` from `@dreb/coding-agent/rpc`), modeled on `packages/dashboard/`. Delivers the Phase 0 foundation (RPC child lifecycle + per-session controller) and the Phase 1 MVP: streaming chat that separates thinking/tool activity from the final answer, slash commands, and needs-input handling.

Part of the VSCode extension epic #12.

Implementation plan posted as a comment below.
