### PR TITLE
VSCode Phase 2: built-in slash commands + TUI-parity settings & status

### DIFF
--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -4,7 +4,7 @@ A native chat client for the [dreb](https://github.com/aebrer/dreb) coding agent
 
 This package is modeled on `@dreb/dashboard`: an extension **host** owns the RPC child and the authoritative transcript state, and a **webview** renders it. The only transport difference is that the dashboard's HTTP+SSE layer is replaced by VS Code's `postMessage` bridge.
 
-> Status: **Phase 0 + 1** (foundation + MVP chat). See the [tracking issue](https://github.com/Hrovatin/dreb/issues/12) for the roadmap.
+> Status: **Phase 2** (built-in slash commands + TUI-parity status header) on top of the Phase 0 + 1 foundation and MVP chat. See the [tracking issue](https://github.com/Hrovatin/dreb/issues/12) for the roadmap.
 
 ## Architecture
 
@@ -19,12 +19,42 @@ src/
     webview-bridge.ts   postMessage wiring + webview HTML/CSP
     cli-path.ts         resolve the dreb CLI (setting → dependency)
     slash-router.ts     route composer text → prompt vs builtin RPC (pure, tested)
+    session-registry.ts single-live-panel lifecycle (reentrancy-safe, pure, tested)
+    host-ui.ts          native-prompt port (quick pick / input / dialogs); vscode-free
+    vscode-host-ui.ts   the real `HostUi` backed by `vscode.window`
+  shared/
+    format.ts           status-header + `/session` display formatters (pure, tested)
   webview/       # SolidJS UI — bundled with Vite → dist/webview
-    app.tsx             transcript, collapsible activity box, composer, needs-input
+    app.tsx             transcript, collapsible activity box, composer, needs-input,
+                        and the status header (model · thinking · cost · ctx)
 ```
 
 - The host keeps the authoritative `TranscriptState`. On (re)load the webview announces `ready` and receives a full snapshot, so recreating the webview never loses the conversation.
 - Host and webview apply the **same** pure `applyEvent` reducer, so live streaming and the reload snapshot stay consistent.
+- `SessionController` drives native VS Code prompts only through the `HostUi` port, so the controller and its tests stay node-only; `vscode-host-ui.ts` is the sole place that imports `vscode` for prompts.
+
+## Slash commands
+
+Type `/` in the composer to run a built-in command instead of sending a prompt. dreb's server advertises builtins via `get_commands` but rejects them as prompts, so the host intercepts every builtin and routes it to an RPC method or a native VS Code surface:
+
+| Command | Action |
+| --- | --- |
+| `/model` | Native quick pick to switch the active model (session-local). |
+| `/compact` | Summarize and compact the conversation context. |
+| `/new` | Start a new session. |
+| `/reload` | Reload skills, extensions, prompts, and settings. |
+| `/dream` | Consolidate and prune memories. |
+| `/session` | Show session info and stats (messages, tokens, cost, context). |
+| `/name` | Set the session display name (native input box). |
+| `/export` | Export the session to HTML (native save dialog). |
+| `/import` | Import and resume a session from JSONL (native open dialog). |
+| `/quit` | End the session; the panel stays open showing an ended banner. Re-run **dreb: Open Chat** for a fresh session. |
+
+Commands owned by later phases (`/settings`, `/scoped-models`, `/fork`, `/tree`, `/resume`) and terminal-only commands (`/login`, `/logout`, `/copy`, `/hotkeys`, `/buddy`) are recognized but surface a notice rather than running. An unrecognized command (e.g. `/foo`) surfaces an "unknown command" notice.
+
+## Status header
+
+The webview renders a compact header mirroring the TUI: **model · thinking level · cost · context usage**. Cost shows the session total (`$0.123`, `+ (sub)` on a subscription) and, when known, the larger daily total (`, today $1.23`); context usage shows `ctx 42%`. All formatting lives in the pure `shared/format.ts` so the header renders costs consistently.
 
 ## Requirements
 

--- a/packages/vscode/src/host/extension.ts
+++ b/packages/vscode/src/host/extension.ts
@@ -13,6 +13,7 @@ import { homedir } from "node:os";
 import * as vscode from "vscode";
 import { resolveCliPath } from "./cli-path.js";
 import { SessionController } from "./session-controller.js";
+import { SessionRegistry } from "./session-registry.js";
 import { createVscodeHostUi } from "./vscode-host-ui.js";
 import { connectWebview, getWebviewHtml } from "./webview-bridge.js";
 
@@ -22,34 +23,40 @@ interface ChatSession {
 	connection: vscode.Disposable;
 }
 
-let current: ChatSession | undefined;
+/** Enforces the single-live-panel invariant and the reentrancy-safe open /
+ * teardown lifecycle. The vscode-specific operations are injected; the racing
+ * logic itself lives in the vscode-free, unit-tested `session-registry.ts`. */
+const registry = new SessionRegistry<ChatSession>({
+	isDisposed: (s) => s.controller.isDisposed(),
+	reveal: (s) => s.panel.reveal(vscode.ViewColumn.Active),
+	teardown: async (s) => {
+		s.connection.dispose();
+		await s.controller.dispose();
+		s.panel.dispose();
+	},
+});
 
 export function activate(context: vscode.ExtensionContext): void {
 	context.subscriptions.push(
 		vscode.commands.registerCommand("dreb.openChat", () => {
-			openChat(context).catch((err) => {
-				vscode.window.showErrorMessage(`dreb: failed to open chat — ${errorText(err)}`);
-			});
+			registry
+				.open(() => createSession(context))
+				.catch((err) => {
+					vscode.window.showErrorMessage(`dreb: failed to open chat — ${errorText(err)}`);
+				});
 		}),
 	);
 }
 
 export async function deactivate(): Promise<void> {
-	await disposeCurrent();
+	await registry.disposeActive();
 }
 
-async function openChat(context: vscode.ExtensionContext): Promise<void> {
-	if (current) {
-		if (!current.controller.isDisposed()) {
-			current.panel.reveal(vscode.ViewColumn.Active);
-			return;
-		}
-		// The prior session was ended via `/quit` (controller disposed, panel left
-		// open showing the "session ended" banner). Tear down that dead panel and
-		// fall through to build a fresh session instead of revealing the dead one.
-		await disposeCurrent();
-	}
-
+/** Build a fresh chat session: controller, webview panel, and transport wiring.
+ * Called by the registry only when a new session is actually needed. The panel's
+ * `onDidDispose` tears down *this* session specifically (never a newer live one)
+ * via the registry's scoped, idempotent `disposeSession`. */
+function createSession(context: vscode.ExtensionContext): ChatSession {
 	const config = vscode.workspace.getConfiguration("dreb");
 	const cwd = workspaceCwd();
 	const cli = resolveCliPath({ configuredPath: config.get<string>("cliPath") });
@@ -71,32 +78,22 @@ async function openChat(context: vscode.ExtensionContext): Promise<void> {
 	const connection = connectWebview(panel.webview, controller);
 	panel.webview.html = getWebviewHtml(panel.webview, context.extensionUri, makeNonce());
 
-	current = { panel, controller, connection };
+	const session: ChatSession = { panel, controller, connection };
 	panel.onDidDispose(() => {
-		void disposeCurrent();
+		void registry.disposeSession(session);
 	});
 
 	if (!cli.ok) {
 		// Surface an actionable error into the transcript; the webview shows it
 		// once it hydrates. No child is spawned.
 		controller.reportFatal(cli.error);
-		return;
+	} else {
+		// start() surfaces its own host_error + status into the transcript on
+		// failure, so a rejection here is already reflected in the UI.
+		void controller.start().catch(() => {});
 	}
 
-	try {
-		await controller.start();
-	} catch {
-		// start() already surfaced a host_error + status to the transcript.
-	}
-}
-
-async function disposeCurrent(): Promise<void> {
-	if (!current) return;
-	const session = current;
-	current = undefined;
-	session.connection.dispose();
-	await session.controller.dispose();
-	session.panel.dispose();
+	return session;
 }
 
 function workspaceCwd(): string {

--- a/packages/vscode/src/host/extension.ts
+++ b/packages/vscode/src/host/extension.ts
@@ -13,6 +13,7 @@ import { homedir } from "node:os";
 import * as vscode from "vscode";
 import { resolveCliPath } from "./cli-path.js";
 import { SessionController } from "./session-controller.js";
+import { createVscodeHostUi } from "./vscode-host-ui.js";
 import { connectWebview, getWebviewHtml } from "./webview-bridge.js";
 
 interface ChatSession {
@@ -51,6 +52,7 @@ async function openChat(context: vscode.ExtensionContext): Promise<void> {
 		cwd,
 		cliPath: cli.ok ? cli.path : "",
 		args: buildArgs(config),
+		ui: createVscodeHostUi(),
 		logger: (line) => console.warn(`[dreb] ${line}`),
 	});
 

--- a/packages/vscode/src/host/extension.ts
+++ b/packages/vscode/src/host/extension.ts
@@ -40,8 +40,14 @@ export async function deactivate(): Promise<void> {
 
 async function openChat(context: vscode.ExtensionContext): Promise<void> {
 	if (current) {
-		current.panel.reveal(vscode.ViewColumn.Active);
-		return;
+		if (!current.controller.isDisposed()) {
+			current.panel.reveal(vscode.ViewColumn.Active);
+			return;
+		}
+		// The prior session was ended via `/quit` (controller disposed, panel left
+		// open showing the "session ended" banner). Tear down that dead panel and
+		// fall through to build a fresh session instead of revealing the dead one.
+		await disposeCurrent();
 	}
 
 	const config = vscode.workspace.getConfiguration("dreb");

--- a/packages/vscode/src/host/host-ui.ts
+++ b/packages/vscode/src/host/host-ui.ts
@@ -1,0 +1,46 @@
+/**
+ * HostUi — the small port through which the (vscode-free, unit-testable)
+ * SessionController drives native VS Code prompts: quick picks (model / thinking
+ * selection), input boxes (`/name`), and open/save dialogs (`/import`,
+ * `/export`). The real implementation lives in `vscode-host-ui.ts` (which imports
+ * `vscode`); tests inject a fake. This module deliberately imports nothing from
+ * `vscode` so the controller and its tests stay node-only.
+ */
+
+/** One selectable entry in a quick pick; `value` is the opaque payload returned. */
+export interface HostUiPickItem {
+	label: string;
+	description?: string;
+	detail?: string;
+	/** Returned by `quickPick` when this item is chosen. */
+	value: string;
+}
+
+export interface HostUi {
+	/** Show a quick pick; resolves to the chosen item's `value`, or undefined if dismissed. */
+	quickPick(items: HostUiPickItem[], options?: { placeholder?: string }): Promise<string | undefined>;
+	/** Show an input box; resolves to the entered text, or undefined if dismissed. */
+	inputBox(options?: { prompt?: string; value?: string; placeholder?: string }): Promise<string | undefined>;
+	/** Show a save dialog; resolves to the chosen filesystem path, or undefined. */
+	saveDialog(options?: { defaultName?: string; filters?: Record<string, string[]> }): Promise<string | undefined>;
+	/** Show an open dialog (single file); resolves to the chosen path, or undefined. */
+	openDialog(options?: { filters?: Record<string, string[]> }): Promise<string | undefined>;
+}
+
+/** No-op HostUi: every prompt resolves to undefined (as if dismissed). Used as
+ * the default when no UI is injected (tests, headless), so interactive builtins
+ * simply cancel rather than throw. */
+export const noopHostUi: HostUi = {
+	async quickPick() {
+		return undefined;
+	},
+	async inputBox() {
+		return undefined;
+	},
+	async saveDialog() {
+		return undefined;
+	},
+	async openDialog() {
+		return undefined;
+	},
+};

--- a/packages/vscode/src/host/session-controller.ts
+++ b/packages/vscode/src/host/session-controller.ts
@@ -12,9 +12,43 @@
  * events + status changes. The webview bridge adapts those to `postMessage`.
  */
 
+import { formatSessionStats } from "../shared/format.js";
 import { applyEvent, createTranscriptState, type TranscriptState } from "../shared/projection.js";
 import type { HostStatus, SlashCommandDto, UiResponse } from "../shared/protocol.js";
-import { BUILTIN_COMMANDS, routeInput, stripSlash } from "./slash-router.js";
+import { type HostUi, noopHostUi } from "./host-ui.js";
+import { BUILTIN_COMMANDS, DEFERRED_BUILTINS, routeInput, stripSlash, TERMINAL_ONLY_BUILTINS } from "./slash-router.js";
+
+/** Thinking levels offered in the picker. The active model may support a subset;
+ * `set_thinking_level` clamps server-side and we reflect the applied value via a
+ * follow-up state refresh (the valid-per-model list is not exposed over RPC). */
+export const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh"];
+
+/** Structural view of the runtime state fields the controller reads. */
+interface RpcSessionStateLike {
+	model?: { provider: string; id: string; name?: string };
+	thinkingLevel?: string;
+	usingSubscription?: boolean;
+	contextUsage?: { tokens: number | null; contextWindow: number; percent: number | null };
+}
+
+/** Structural view of `getSessionStats()` (superset assignable from SessionStats). */
+interface SessionStatsLike {
+	sessionId?: string;
+	userMessages?: number;
+	assistantMessages?: number;
+	toolCalls?: number;
+	totalMessages?: number;
+	tokens?: { input?: number; output?: number; total?: number };
+	cost?: number;
+	contextUsage?: { tokens: number | null; contextWindow: number; percent: number | null };
+}
+
+/** Structural view of one available model. */
+interface ModelInfoLike {
+	provider: string;
+	id: string;
+	name?: string;
+}
 
 /**
  * Structural view of the parts of `RpcClient` the controller uses. Kept
@@ -40,6 +74,21 @@ export interface RpcClientLike {
 	sendExtensionUIResponse(response: unknown): void;
 	onEvent(listener: (event: any) => void): () => void;
 	onExit(listener: (info: any) => void): () => void;
+	// Runtime status (TUI parity).
+	getState(): Promise<RpcSessionStateLike>;
+	getDailyCost(): Promise<number>;
+	getSessionStats(): Promise<SessionStatsLike>;
+	// Model / thinking selection.
+	getAvailableModels(): Promise<ModelInfoLike[]>;
+	setModel(provider: string, modelId: string): Promise<{ provider: string; id: string }>;
+	setThinkingLevel(level: string): Promise<void>;
+	// Built-in slash commands.
+	newSession(parentSession?: string): Promise<{ cancelled: boolean }>;
+	reload(): Promise<void>;
+	dream(args?: string): Promise<{ message: string }>;
+	setSessionName(name: string): Promise<void>;
+	exportHtml(outputPath?: string): Promise<{ path: string }>;
+	importJsonl(inputPath: string): Promise<{ cancelled: boolean }>;
 }
 
 export type RpcClientFactory = (options: {
@@ -55,10 +104,21 @@ export interface SessionControllerOptions {
 	args?: string[];
 	/** Override the RpcClient constructor (tests inject a fake). */
 	clientFactory?: RpcClientFactory;
+	/** Native prompt port (quick picks / dialogs); defaults to a no-op so the
+	 * controller stays vscode-free and testable. Production injects the
+	 * vscode-backed impl. */
+	ui?: HostUi;
 	logger?: (line: string) => void;
 }
 
-export type ControllerUpdate = { kind: "event"; event: unknown } | { kind: "status"; status: HostStatus };
+export type ControllerUpdate =
+	| { kind: "event"; event: unknown }
+	| { kind: "status"; status: HostStatus }
+	/** The slash-command list changed (e.g. after `/reload`). */
+	| { kind: "commands"; commands: SlashCommandDto[] }
+	/** Transcript was replaced host-side (e.g. `/new`, `/import`); the bridge
+	 * re-sends a fresh snapshot. */
+	| { kind: "resync" };
 
 /** Lazily loads the ESM-only agent runtime so tests with an injected factory
  * never pull it in. */
@@ -76,6 +136,7 @@ export class SessionController {
 	private readonly state: TranscriptState = createTranscriptState();
 	private readonly listeners = new Set<(update: ControllerUpdate) => void>();
 	private readonly factory: RpcClientFactory;
+	private readonly ui: HostUi;
 	private readonly logger: (line: string) => void;
 	private readonly options: SessionControllerOptions;
 	private client: RpcClientLike | undefined;
@@ -84,10 +145,15 @@ export class SessionController {
 	private unsubEvent: (() => void) | undefined;
 	private unsubExit: (() => void) | undefined;
 	private disposed = false;
+	/** Serializes status refreshes: coalesces an overlapping request into one
+	 * trailing re-run so a new turn starting mid-refresh still ends up current. */
+	private statusBusy = false;
+	private statusAgain = false;
 
 	constructor(options: SessionControllerOptions) {
 		this.options = options;
 		this.factory = options.clientFactory ?? defaultClientFactory;
+		this.ui = options.ui ?? noopHostUi;
 		this.logger = options.logger ?? (() => {});
 		this.status = { connected: false, cwd: options.cwd };
 	}
@@ -134,6 +200,7 @@ export class SessionController {
 		}
 		this.setStatus({ ...this.status, connected: true, error: undefined });
 		await this.refreshCommands();
+		await this.refreshStatus(true);
 	}
 
 	/** Fetch the agent's commands and merge with host builtins.
@@ -187,11 +254,7 @@ export class SessionController {
 					await this.client.prompt(decision.message);
 					return;
 				case "builtin":
-					if (decision.command === "compact") {
-						await this.client.compact(decision.arg);
-						return;
-					}
-					this.emitNotice(`The /${decision.command} command isn't available yet in this early build.`);
+					await this.runBuiltin(decision.command, decision.arg);
 					return;
 				case "unknown-command":
 					this.emitNotice(`Unknown command: /${decision.name}`);
@@ -209,6 +272,226 @@ export class SessionController {
 		} catch (err) {
 			this.logger(`abort failed: ${err instanceof Error ? err.message : String(err)}`);
 		}
+	}
+
+	/** Dispatch a built-in slash command to its RPC method / native UI. Invoked
+	 * only from `submit` (which has already verified an active connection), so a
+	 * rejection here is caught by `submit` and surfaced as a notice. */
+	private async runBuiltin(command: string, arg?: string): Promise<void> {
+		const client = this.client;
+		if (!client) return;
+		switch (command) {
+			case "compact":
+				await client.compact(arg);
+				return;
+			case "model":
+				await this.pickModel();
+				return;
+			case "new": {
+				const result = await client.newSession();
+				if (result?.cancelled) {
+					this.emitNotice("New session cancelled.");
+					return;
+				}
+				this.resetTranscriptState();
+				await this.refreshCommands();
+				await this.refreshStatus(true);
+				this.emit({ kind: "resync" });
+				this.emitNotice("Started a new session.");
+				return;
+			}
+			case "reload": {
+				await client.reload();
+				await this.refreshCommands();
+				this.emit({ kind: "commands", commands: this.commands });
+				await this.refreshStatus(false);
+				this.emitNotice("Reloaded skills, extensions, prompts, and settings.");
+				return;
+			}
+			case "dream": {
+				const result = await client.dream(arg);
+				this.emitNotice(result?.message ?? "Memory consolidation complete.");
+				return;
+			}
+			case "session": {
+				const stats = await client.getSessionStats();
+				this.pushSystem(formatSessionStats(stats));
+				return;
+			}
+			case "name": {
+				const name = arg ?? (await this.ui.inputBox({ prompt: "Session name", placeholder: "My session" }));
+				if (!name || name.trim().length === 0) return;
+				await client.setSessionName(name.trim());
+				await this.refreshStatus(false);
+				this.emitNotice(`Renamed session to "${name.trim()}".`);
+				return;
+			}
+			case "export": {
+				const path =
+					arg ?? (await this.ui.saveDialog({ defaultName: "dreb-session.html", filters: { HTML: ["html"] } }));
+				if (!path) return;
+				const result = await client.exportHtml(path);
+				this.emitNotice(`Exported session to ${result.path}.`);
+				return;
+			}
+			case "import": {
+				const path = arg ?? (await this.ui.openDialog({ filters: { "Session JSONL": ["jsonl"] } }));
+				if (!path) return;
+				const result = await client.importJsonl(path);
+				if (result?.cancelled) {
+					this.emitNotice("Import cancelled.");
+					return;
+				}
+				this.resetTranscriptState();
+				await this.refreshCommands();
+				await this.refreshStatus(true);
+				this.emit({ kind: "resync" });
+				this.emitNotice(`Imported session from ${path}.`);
+				return;
+			}
+			case "quit": {
+				// Emit feedback BEFORE dispose (which clears listeners), then tear
+				// down the child. `dispose` unsubscribes first, so stopping the
+				// client does not surface a spurious "process exited" error.
+				this.emitNotice("Session ended — reopen the chat to start a new one.");
+				this.setStatus({ ...this.status, connected: false, error: undefined });
+				await this.dispose();
+				return;
+			}
+			default:
+				if (DEFERRED_BUILTINS.has(command)) {
+					this.emitNotice(`/${command} is coming in a later phase.`);
+				} else if (TERMINAL_ONLY_BUILTINS.has(command)) {
+					this.emitNotice(`/${command} is handled in the terminal UI, not over RPC.`);
+				} else {
+					this.emitNotice(`The /${command} command isn't available yet.`);
+				}
+				return;
+		}
+	}
+
+	/** Open the native model picker and apply the selection. Public so the
+	 * webview header can trigger it via a `pick-model` message. */
+	async pickModel(): Promise<void> {
+		const client = this.client;
+		if (!client || !this.status.connected) {
+			this.emitNotice("dreb isn't connected — reopen the chat to restart it.");
+			return;
+		}
+		try {
+			const models = await client.getAvailableModels();
+			if (models.length === 0) {
+				this.emitNotice("No models are available.");
+				return;
+			}
+			const picked = await this.ui.quickPick(
+				models.map((m) => ({
+					label: m.name && m.name.length > 0 ? m.name : m.id,
+					description: m.provider,
+					detail: `${m.provider}/${m.id}`,
+					value: `${m.provider}\u0000${m.id}`,
+				})),
+				{ placeholder: "Select a model" },
+			);
+			if (!picked) return;
+			const sep = picked.indexOf("\u0000");
+			const provider = picked.slice(0, sep);
+			const modelId = picked.slice(sep + 1);
+			await client.setModel(provider, modelId);
+			await this.refreshStatus(false);
+		} catch (err) {
+			this.emitNotice(`Model selection failed: ${err instanceof Error ? err.message : String(err)}`);
+		}
+	}
+
+	/** Open the native thinking-level picker and apply the selection. Public so
+	 * the webview header can trigger it via a `pick-thinking` message. */
+	async pickThinking(): Promise<void> {
+		const client = this.client;
+		if (!client || !this.status.connected) {
+			this.emitNotice("dreb isn't connected — reopen the chat to restart it.");
+			return;
+		}
+		try {
+			const current = this.status.thinkingLevel;
+			const picked = await this.ui.quickPick(
+				THINKING_LEVELS.map((level) => ({
+					label: level,
+					description: level === current ? "current" : undefined,
+					value: level,
+				})),
+				{ placeholder: "Select thinking level" },
+			);
+			if (!picked) return;
+			await client.setThinkingLevel(picked);
+			await this.refreshStatus(false);
+		} catch (err) {
+			this.emitNotice(`Thinking-level change failed: ${err instanceof Error ? err.message : String(err)}`);
+		}
+	}
+
+	/** Re-read runtime status (model / thinking / cost / context) and emit it.
+	 * Coalesces overlapping calls into a single trailing re-run. Failures are
+	 * logged, never surfaced to the transcript (status is best-effort). */
+	private async refreshStatus(includeDailyCost: boolean): Promise<void> {
+		const client = this.client;
+		if (!client || !this.status.connected) return;
+		if (this.statusBusy) {
+			this.statusAgain = true;
+			return;
+		}
+		this.statusBusy = true;
+		try {
+			const [state, stats, daily] = await Promise.all([
+				client.getState(),
+				client.getSessionStats(),
+				includeDailyCost ? client.getDailyCost() : Promise.resolve<number | undefined>(undefined),
+			]);
+			const model = state.model
+				? { provider: state.model.provider, id: state.model.id, name: state.model.name }
+				: undefined;
+			this.setStatus({
+				...this.status,
+				model,
+				thinkingLevel: state.thinkingLevel,
+				cost: {
+					session: stats.cost ?? 0,
+					daily,
+					usingSubscription: state.usingSubscription ?? false,
+				},
+				contextUsage: state.contextUsage
+					? {
+							tokens: state.contextUsage.tokens,
+							contextWindow: state.contextUsage.contextWindow,
+							percent: state.contextUsage.percent,
+						}
+					: undefined,
+			});
+		} catch (err) {
+			this.logger(`refreshStatus failed: ${err instanceof Error ? err.message : String(err)}`);
+		} finally {
+			this.statusBusy = false;
+			if (this.statusAgain) {
+				this.statusAgain = false;
+				void this.refreshStatus(includeDailyCost);
+			}
+		}
+	}
+
+	/** Clear the transcript in place (properties, not the reference) so `/new`
+	 * and `/import` present a fresh conversation after a `resync`. */
+	private resetTranscriptState(): void {
+		this.state.items = [];
+		this.state.streaming = false;
+		this.state.uiRequests = [];
+		this.state.statusText = undefined;
+		this.state.hostError = undefined;
+		this.state.nextResponseId = 1;
+	}
+
+	/** Append a persistent host-side line to the transcript (e.g. `/session`). */
+	private pushSystem(text: string): void {
+		this.handleEvent({ type: "host_system", text });
 	}
 
 	/** Surface a fatal host-side failure (e.g. the CLI could not be located)
@@ -238,6 +521,9 @@ export class SessionController {
 	private handleEvent(event: unknown): void {
 		applyEvent(this.state, event);
 		this.emit({ kind: "event", event });
+		// After each completed turn, refresh runtime status (cost/context/model)
+		// the way the dashboard does on the streaming→idle transition.
+		if ((event as { type?: unknown })?.type === "agent_end") void this.refreshStatus(true);
 	}
 
 	private handleExit(info: { code?: number | null; signal?: string | null; error?: Error }): void {

--- a/packages/vscode/src/host/session-controller.ts
+++ b/packages/vscode/src/host/session-controller.ts
@@ -146,9 +146,13 @@ export class SessionController {
 	private unsubExit: (() => void) | undefined;
 	private disposed = false;
 	/** Serializes status refreshes: coalesces an overlapping request into one
-	 * trailing re-run so a new turn starting mid-refresh still ends up current. */
+	 * trailing re-run so a new turn starting mid-refresh still ends up current.
+	 * `statusAgainIncludeDaily` accumulates the daily-cost intent of every
+	 * coalesced caller so the trailing re-run doesn't drop a requested daily
+	 * refresh (e.g. an `agent_end` refresh coalesced into a cheaper one). */
 	private statusBusy = false;
 	private statusAgain = false;
+	private statusAgainIncludeDaily = false;
 
 	constructor(options: SessionControllerOptions) {
 		this.options = options;
@@ -438,6 +442,9 @@ export class SessionController {
 		if (!client || !this.status.connected) return;
 		if (this.statusBusy) {
 			this.statusAgain = true;
+			// Preserve the strongest pending intent: if any coalesced caller wants
+			// the daily cost, the trailing re-run must fetch it (finding 2).
+			if (includeDailyCost) this.statusAgainIncludeDaily = true;
 			return;
 		}
 		this.statusBusy = true;
@@ -445,7 +452,9 @@ export class SessionController {
 			const [state, stats, daily] = await Promise.all([
 				client.getState(),
 				client.getSessionStats(),
-				includeDailyCost ? client.getDailyCost() : Promise.resolve<number | undefined>(undefined),
+				// When not refetching, preserve the last-known daily total rather
+				// than wiping the chip on every /name, /reload, or picker (finding 6).
+				includeDailyCost ? client.getDailyCost() : Promise.resolve<number | undefined>(this.status.cost?.daily),
 			]);
 			const model = state.model
 				? { provider: state.model.provider, id: state.model.id, name: state.model.name }
@@ -473,7 +482,11 @@ export class SessionController {
 			this.statusBusy = false;
 			if (this.statusAgain) {
 				this.statusAgain = false;
-				void this.refreshStatus(includeDailyCost);
+				// Serve coalesced callers with their accumulated daily intent, not
+				// this finishing call's parameter (finding 2).
+				const again = this.statusAgainIncludeDaily;
+				this.statusAgainIncludeDaily = false;
+				void this.refreshStatus(again);
 			}
 		}
 	}
@@ -507,6 +520,7 @@ export class SessionController {
 	}
 
 	async dispose(): Promise<void> {
+		if (this.disposed) return;
 		this.disposed = true;
 		this.unsubEvent?.();
 		this.unsubExit?.();
@@ -516,6 +530,12 @@ export class SessionController {
 		} catch (err) {
 			this.logger(`stop failed: ${err instanceof Error ? err.message : String(err)}`);
 		}
+	}
+
+	/** Whether this controller has been torn down (e.g. via `/quit`). A disposed
+	 * controller cannot be restarted; the host must build a fresh one. */
+	isDisposed(): boolean {
+		return this.disposed;
 	}
 
 	private handleEvent(event: unknown): void {

--- a/packages/vscode/src/host/session-registry.ts
+++ b/packages/vscode/src/host/session-registry.ts
@@ -1,0 +1,87 @@
+/**
+ * Single-slot session registry enforcing the "one live chat panel" invariant.
+ *
+ * The extension keeps exactly one {@link https://code.visualstudio.com/api | vscode}
+ * webview panel + `SessionController` at a time. Reopening after `/quit` must
+ * tear the dead session down and build a fresh one; revealing a live session
+ * must not build a second. Both of those paths, plus panel-close teardown, race
+ * against each other because VS Code does not serialize async command handlers.
+ *
+ * This module holds the vscode-free, unit-testable core of that lifecycle so the
+ * concurrency rules can be pinned without a full webview mock. `extension.ts`
+ * injects the vscode-specific operations via {@link SessionOps}.
+ */
+
+/** vscode-specific operations the registry performs on a session object. */
+export interface SessionOps<S extends object> {
+	/** Whether the session's controller has been torn down (e.g. via `/quit`). */
+	isDisposed(session: S): boolean;
+	/** Bring the session's panel to the foreground. */
+	reveal(session: S): void;
+	/** Release the session's resources (webview connection, controller, panel). */
+	teardown(session: S): Promise<void>;
+}
+
+export class SessionRegistry<S extends object> {
+	private current: S | undefined;
+	/** Sessions already torn down, so a panel-close firing after an explicit
+	 * teardown (or vice versa) doesn't double-release resources. */
+	private readonly tornDown = new WeakSet<S>();
+
+	constructor(private readonly ops: SessionOps<S>) {}
+
+	/** The currently registered live session, if any (primarily for tests). */
+	get active(): S | undefined {
+		return this.current;
+	}
+
+	/**
+	 * Reveal the live session, or build a fresh one via `create`.
+	 *
+	 * Reentrancy-safe: a disposed session is torn down first, and because
+	 * `teardown` is awaited, a concurrent `open` may install a new session during
+	 * that gap — in which case we defer to it rather than orphaning it. Crucially
+	 * there is **no `await` between the final decision to build and the `current`
+	 * assignment**, so two concurrent opens can never both construct a session.
+	 *
+	 * `create` is only ever invoked when a new session is actually needed, so it
+	 * may perform expensive side effects (spawning the RPC child, creating the
+	 * panel) without risk of an immediately-discarded construction.
+	 */
+	async open(create: () => S): Promise<void> {
+		if (this.current !== undefined && !this.ops.isDisposed(this.current)) {
+			this.ops.reveal(this.current);
+			return;
+		}
+		if (this.current !== undefined) {
+			// Stale session ended via `/quit` (disposed controller, panel left open
+			// showing its "session ended" banner). Tear it down before rebuilding.
+			await this.disposeSession(this.current);
+			// The await above yielded: a concurrent open() may have installed a new
+			// live session. Defer to it instead of building a duplicate/orphan.
+			if (this.current !== undefined) {
+				this.ops.reveal(this.current);
+				return;
+			}
+		}
+		this.current = create();
+	}
+
+	/**
+	 * Tear down a specific session. Only clears `current` if it still points at
+	 * this session, so closing an older/orphaned panel never disposes a newer
+	 * live session. Idempotent: safe to call from both an explicit `/quit`-driven
+	 * path and the panel's `onDidDispose`.
+	 */
+	async disposeSession(session: S): Promise<void> {
+		if (this.tornDown.has(session)) return;
+		this.tornDown.add(session);
+		if (this.current === session) this.current = undefined;
+		await this.ops.teardown(session);
+	}
+
+	/** Tear down the live session, if any (used on extension deactivate). */
+	async disposeActive(): Promise<void> {
+		if (this.current !== undefined) await this.disposeSession(this.current);
+	}
+}

--- a/packages/vscode/src/host/slash-router.ts
+++ b/packages/vscode/src/host/slash-router.ts
@@ -11,26 +11,41 @@
  * `get_commands` with `source: "builtin"`, but the server *rejects* them when
  * sent through `prompt` (the rejection is silently discarded by the RPC client),
  * so every builtin must be intercepted here and routed to a host handler rather
- * than forwarded as a prompt. Only `/compact` is wired in this early build; the
- * rest surface a "not available yet" notice instead of silently doing nothing.
+ * than forwarded as a prompt. The controller dispatches wired builtins to their
+ * RPC method / native UI; recognized-but-unwired builtins surface a notice.
  * No DOM/vscode/@dreb imports — unit-testable in plain node.
  */
 
 import type { SlashCommandDto } from "../shared/protocol.js";
 
-/** Built-ins the host has a dedicated handler for (the rest emit a notice). */
-export type BuiltinCommand = "compact" | "model" | "tree" | "resume" | "settings";
-
-/** Builtin commands surfaced in the composer dropdown alongside agent commands. */
+/** Builtin commands the host dispatches to an RPC method / native UI. */
 export const BUILTIN_COMMANDS: SlashCommandDto[] = [
-	{ name: "compact", description: "Summarize and compact the conversation context", source: "builtin" },
 	{ name: "model", description: "Switch the active model", source: "builtin" },
-	{ name: "tree", description: "Browse and navigate the session tree", source: "builtin" },
-	{ name: "resume", description: "Resume a previous session", source: "builtin" },
-	{ name: "settings", description: "Open dreb settings", source: "builtin" },
+	{ name: "compact", description: "Summarize and compact the conversation context", source: "builtin" },
+	{ name: "new", description: "Start a new session", source: "builtin" },
+	{ name: "reload", description: "Reload skills, extensions, prompts, and settings", source: "builtin" },
+	{ name: "dream", description: "Consolidate and prune memories", source: "builtin" },
+	{ name: "session", description: "Show session info and stats", source: "builtin" },
+	{ name: "name", description: "Set the session display name", source: "builtin" },
+	{ name: "export", description: "Export the session to HTML", source: "builtin" },
+	{ name: "import", description: "Import and resume a session from JSONL", source: "builtin" },
+	{ name: "quit", description: "End the session", source: "builtin" },
 ];
 
-const BUILTIN_NAMES = new Set<BuiltinCommand>(BUILTIN_COMMANDS.map((c) => c.name as BuiltinCommand));
+/** Builtins recognized but not yet wired — dispatched with a "later phase"
+ * notice. They need UI surfaces owned by later phases (settings/sessions/tree). */
+export const DEFERRED_BUILTINS = new Set(["settings", "scoped-models", "fork", "tree", "resume"]);
+
+/** Builtins with no RPC equivalent — only meaningful in the terminal UI. */
+export const TERMINAL_ONLY_BUILTINS = new Set(["login", "logout", "copy", "hotkeys", "buddy"]);
+
+/** All builtin names the router intercepts even without a server advertisement
+ * (the wired fallback list plus the recognized-but-unwired ones). */
+const BUILTIN_NAMES = new Set<string>([
+	...BUILTIN_COMMANDS.map((c) => c.name),
+	...DEFERRED_BUILTINS,
+	...TERMINAL_ONLY_BUILTINS,
+]);
 
 export type RouteDecision =
 	| { kind: "empty" }
@@ -61,7 +76,7 @@ export function routeInput(input: string, commands: readonly SlashCommandDto[] =
 	// Built-ins are host-handled: forwarding them via `prompt` is rejected
 	// server-side and the rejection is silently swallowed, so intercept every
 	// builtin here (whether advertised by get_commands or a hardcoded fallback).
-	if (advertised?.source === "builtin" || BUILTIN_NAMES.has(name as BuiltinCommand)) {
+	if (advertised?.source === "builtin" || BUILTIN_NAMES.has(name)) {
 		return { kind: "builtin", command: name, arg };
 	}
 

--- a/packages/vscode/src/host/vscode-host-ui.ts
+++ b/packages/vscode/src/host/vscode-host-ui.ts
@@ -1,0 +1,56 @@
+/// <reference types="vscode" />
+
+/**
+ * vscode-backed HostUi — wraps `vscode.window.*` prompts behind the `HostUi`
+ * port so the SessionController stays vscode-free and unit-testable. Only the
+ * extension host constructs this (via `extension.ts`).
+ */
+
+import * as vscode from "vscode";
+import type { HostUi, HostUiPickItem } from "./host-ui.js";
+
+/** A quick-pick item carrying our opaque `value` alongside vscode's fields. */
+interface ValuedQuickPickItem extends vscode.QuickPickItem {
+	value: string;
+}
+
+export function createVscodeHostUi(): HostUi {
+	return {
+		async quickPick(items: HostUiPickItem[], options): Promise<string | undefined> {
+			const picks: ValuedQuickPickItem[] = items.map((item) => ({
+				label: item.label,
+				description: item.description,
+				detail: item.detail,
+				value: item.value,
+			}));
+			const chosen = await vscode.window.showQuickPick(picks, {
+				placeHolder: options?.placeholder,
+				matchOnDescription: true,
+				matchOnDetail: true,
+			});
+			return chosen?.value;
+		},
+		async inputBox(options): Promise<string | undefined> {
+			return vscode.window.showInputBox({
+				prompt: options?.prompt,
+				value: options?.value,
+				placeHolder: options?.placeholder,
+			});
+		},
+		async saveDialog(options): Promise<string | undefined> {
+			const uri = await vscode.window.showSaveDialog({
+				defaultUri: options?.defaultName ? vscode.Uri.file(options.defaultName) : undefined,
+				filters: options?.filters,
+			});
+			return uri?.fsPath;
+		},
+		async openDialog(options): Promise<string | undefined> {
+			const uris = await vscode.window.showOpenDialog({
+				canSelectMany: false,
+				openLabel: "Select",
+				filters: options?.filters,
+			});
+			return uris?.[0]?.fsPath;
+		},
+	};
+}

--- a/packages/vscode/src/host/webview-bridge.ts
+++ b/packages/vscode/src/host/webview-bridge.ts
@@ -57,8 +57,26 @@ export function connectWebview(webview: vscode.Webview, controller: SessionContr
 
 	const unsubscribe = controller.onUpdate((update) => {
 		if (!live) return;
-		if (update.kind === "event") post({ type: "event", event: update.event });
-		else post({ type: "status", status: update.status });
+		switch (update.kind) {
+			case "event":
+				post({ type: "event", event: update.event });
+				break;
+			case "status":
+				post({ type: "status", status: update.status });
+				break;
+			case "commands":
+				post({ type: "commands", commands: update.commands });
+				break;
+			case "resync":
+				// Transcript was replaced host-side (/new, /import) — re-snapshot.
+				post({
+					type: "snapshot",
+					state: structuredClone(controller.getTranscript()),
+					commands: controller.getCommandList(),
+					status: controller.getStatus(),
+				});
+				break;
+		}
 	});
 
 	const messageSub = webview.onDidReceiveMessage((raw: WebviewToHost) => {
@@ -85,6 +103,12 @@ export function connectWebview(webview: vscode.Webview, controller: SessionContr
 				return;
 			case "refresh-commands":
 				pushCommands();
+				return;
+			case "pick-model":
+				void controller.pickModel();
+				return;
+			case "pick-thinking":
+				void controller.pickThinking();
 				return;
 			case "ui-response":
 				controller.respondUi(raw.response);

--- a/packages/vscode/src/shared/format.ts
+++ b/packages/vscode/src/shared/format.ts
@@ -1,0 +1,75 @@
+/**
+ * Pure display formatters for the status header (model · thinking · cost · ctx).
+ *
+ * No DOM, no framework, no `@dreb/coding-agent` import — shared by the webview
+ * and unit-tested in plain node. Centralizes the currency/percentage formatting
+ * the dashboard inlines inconsistently (2/3/4 decimals across call sites) into a
+ * single place so the extension renders cost the same way everywhere.
+ */
+
+import type { ContextUsageStatus, CostStatus, ModelStatus } from "./protocol.js";
+
+/** Model label for the header chip. */
+export function formatModel(model: ModelStatus | undefined): string {
+	if (!model) return "—";
+	return model.name && model.name.length > 0 ? model.name : model.id;
+}
+
+/** Thinking-level label for the header chip. */
+export function formatThinking(level: string | undefined): string {
+	return level && level.length > 0 ? level : "—";
+}
+
+/**
+ * Cost summary string, mirroring the dashboard footer:
+ * `$0.123` (+ ` (sub)` on a subscription) and, when a larger daily total is
+ * known, `, today $1.23`. Returns undefined when there is nothing to show.
+ */
+export function formatCost(cost: CostStatus | undefined): string | undefined {
+	if (!cost) return undefined;
+	const session = cost.session ?? 0;
+	if (session === 0 && !cost.usingSubscription && cost.daily === undefined) return undefined;
+	let text = `$${session.toFixed(3)}${cost.usingSubscription ? " (sub)" : ""}`;
+	if (cost.daily !== undefined && cost.daily > session) text += `, today $${cost.daily.toFixed(2)}`;
+	return text;
+}
+
+/** Percentage label; `?` when the value is unknown (null). */
+export function formatPercent(percent: number | null): string {
+	return percent === null ? "?" : `${percent.toFixed(0)}%`;
+}
+
+/** Context-usage chip (`ctx 42%`); undefined when usage is unknown. */
+export function formatContextUsage(usage: ContextUsageStatus | undefined): string | undefined {
+	if (!usage) return undefined;
+	return `ctx ${formatPercent(usage.percent)}`;
+}
+
+/** Minimal shape of the RPC `getSessionStats()` result the summary needs. */
+export interface SessionStatsSummary {
+	sessionId?: string;
+	userMessages?: number;
+	assistantMessages?: number;
+	toolCalls?: number;
+	totalMessages?: number;
+	tokens?: { input?: number; output?: number; total?: number };
+	cost?: number;
+	contextUsage?: ContextUsageStatus;
+}
+
+/** Multi-line, human-readable session summary shown by `/session`. */
+export function formatSessionStats(stats: SessionStatsSummary): string {
+	const lines: string[] = ["Session stats"];
+	if (stats.sessionId) lines.push(`  id: ${stats.sessionId}`);
+	const msgs = stats.totalMessages ?? 0;
+	lines.push(`  messages: ${msgs} (user ${stats.userMessages ?? 0}, assistant ${stats.assistantMessages ?? 0})`);
+	if (stats.toolCalls !== undefined) lines.push(`  tool calls: ${stats.toolCalls}`);
+	if (stats.tokens) {
+		lines.push(
+			`  tokens: ${stats.tokens.total ?? 0} (in ${stats.tokens.input ?? 0}, out ${stats.tokens.output ?? 0})`,
+		);
+	}
+	if (stats.cost !== undefined) lines.push(`  cost: $${stats.cost.toFixed(4)}`);
+	if (stats.contextUsage) lines.push(`  context: ${formatPercent(stats.contextUsage.percent)}`);
+	return lines.join("\n");
+}

--- a/packages/vscode/src/shared/projection.ts
+++ b/packages/vscode/src/shared/projection.ts
@@ -48,7 +48,13 @@ export interface UserItem {
 	text: string;
 }
 
-export type TranscriptItem = UserItem | ResponseGroup;
+/** Host-emitted informational line kept in the transcript (e.g. `/session` stats). */
+export interface SystemItem {
+	kind: "system";
+	text: string;
+}
+
+export type TranscriptItem = UserItem | ResponseGroup | SystemItem;
 
 /** A pending, blocking extension-UI request the user must answer. */
 export interface UiRequest {
@@ -351,6 +357,12 @@ export function applyEvent(state: TranscriptState, event: any): void {
 			// Synthetic event for host-side, non-fatal feedback (e.g. an unwired
 			// builtin or an unknown command).
 			state.statusText = String(event.message ?? "");
+			break;
+		}
+		case "host_system": {
+			// Synthetic event for host-side output that should persist in the
+			// transcript (e.g. `/session` stats), not a transient status line.
+			state.items.push({ kind: "system", text: String(event.text ?? "") });
 			break;
 		}
 		default:

--- a/packages/vscode/src/shared/protocol.ts
+++ b/packages/vscode/src/shared/protocol.ts
@@ -18,11 +18,44 @@ export interface SlashCommandDto {
 	source: "agent" | "builtin";
 }
 
-/** Connection/identity status the webview shows in its header. */
+/** The active model, as shown in the status header. */
+export interface ModelStatus {
+	provider: string;
+	id: string;
+	name?: string;
+}
+
+/** Cost summary (mirrors the TUI footer): per-session spend plus optional daily. */
+export interface CostStatus {
+	/** Current session cost in USD. */
+	session: number;
+	/** Daily spend in USD across sessions, when known. */
+	daily?: number;
+	/** True when running against a subscription rather than metered API. */
+	usingSubscription: boolean;
+}
+
+/** Context-window usage — the same numbers the TUI footer renders. */
+export interface ContextUsageStatus {
+	/** Estimated context tokens, or null when unknown (e.g. right after compaction). */
+	tokens: number | null;
+	contextWindow: number;
+	/** Usage as a percentage of the context window, or null when unknown. */
+	percent: number | null;
+}
+
+/** Connection/identity + runtime status the webview shows in its header. */
 export interface HostStatus {
 	connected: boolean;
 	cwd: string;
-	model?: string;
+	/** Active model (TUI parity); undefined before the first status refresh. */
+	model?: ModelStatus;
+	/** Active thinking level (off…xhigh). */
+	thinkingLevel?: string;
+	/** Cost summary (session + optional daily). */
+	cost?: CostStatus;
+	/** Context-window usage. */
+	contextUsage?: ContextUsageStatus;
 	error?: string;
 }
 
@@ -46,4 +79,8 @@ export type WebviewToHost =
 	| { type: "submit"; text: string }
 	| { type: "abort" }
 	| { type: "refresh-commands" }
-	| { type: "ui-response"; response: UiResponse };
+	| { type: "ui-response"; response: UiResponse }
+	/** Open the native model picker (header click). */
+	| { type: "pick-model" }
+	/** Open the native thinking-level picker (header click). */
+	| { type: "pick-thinking" };

--- a/packages/vscode/src/webview/app.tsx
+++ b/packages/vscode/src/webview/app.tsx
@@ -1,5 +1,6 @@
 import { createEffect, createMemo, createSignal, For, onCleanup, onMount, Show } from "solid-js";
 import { createStore, produce, reconcile } from "solid-js/store";
+import { formatContextUsage, formatCost, formatModel, formatThinking } from "../shared/format.js";
 import {
 	activitySummary,
 	applyEvent,
@@ -63,6 +64,38 @@ export function App() {
 				<span class="dreb-cwd" title={status().cwd}>
 					{shortPath(status().cwd)}
 				</span>
+				<button
+					type="button"
+					class="dreb-chip"
+					title="Change model"
+					disabled={!status().connected}
+					onClick={() => postToHost({ type: "pick-model" })}
+				>
+					{formatModel(status().model)}
+				</button>
+				<button
+					type="button"
+					class="dreb-chip"
+					title="Change thinking level"
+					disabled={!status().connected}
+					onClick={() => postToHost({ type: "pick-thinking" })}
+				>
+					think: {formatThinking(status().thinkingLevel)}
+				</button>
+				<Show when={formatCost(status().cost)}>
+					{(cost) => (
+						<span class="dreb-chip-static" title="cost">
+							{cost()}
+						</span>
+					)}
+				</Show>
+				<Show when={formatContextUsage(status().contextUsage)}>
+					{(ctx) => (
+						<span class="dreb-chip-static" title="context usage">
+							{ctx()}
+						</span>
+					)}
+				</Show>
 				<span class={`dreb-dot ${status().connected ? "ok" : "off"}`} />
 			</header>
 
@@ -73,7 +106,13 @@ export function App() {
 			<div class="dreb-transcript" ref={scrollEl}>
 				<For each={state.items}>
 					{(item) =>
-						item.kind === "user" ? <div class="dreb-user">{item.text}</div> : <ResponseView group={item} />
+						item.kind === "user" ? (
+							<div class="dreb-user">{item.text}</div>
+						) : item.kind === "system" ? (
+							<pre class="dreb-system">{item.text}</pre>
+						) : (
+							<ResponseView group={item} />
+						)
 					}
 				</For>
 

--- a/packages/vscode/src/webview/styles.css
+++ b/packages/vscode/src/webview/styles.css
@@ -43,6 +43,32 @@ body {
 	flex: 1;
 }
 
+.dreb-chip {
+	font-size: 0.82em;
+	padding: 2px 8px;
+	border-radius: 10px;
+	max-width: 40%;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	color: var(--vscode-foreground);
+	background: var(--vscode-badge-background, rgba(128, 128, 128, 0.18));
+	border: 1px solid var(--vscode-panel-border, rgba(128, 128, 128, 0.35));
+}
+.dreb-chip:hover:not(:disabled) {
+	background: var(--vscode-list-hoverBackground, rgba(128, 128, 128, 0.25));
+}
+.dreb-chip:disabled {
+	opacity: 0.55;
+	cursor: default;
+}
+
+.dreb-chip-static {
+	font-size: 0.82em;
+	color: var(--vscode-descriptionForeground);
+	white-space: nowrap;
+}
+
 .dreb-dot {
 	width: 8px;
 	height: 8px;
@@ -72,6 +98,17 @@ body {
 	border-radius: 10px;
 	background: var(--vscode-input-background);
 	border: 1px solid var(--vscode-input-border, transparent);
+}
+
+.dreb-system {
+	margin: 0;
+	white-space: pre-wrap;
+	word-break: break-word;
+	font-family: var(--vscode-editor-font-family, monospace);
+	font-size: 0.85em;
+	color: var(--vscode-descriptionForeground);
+	border-left: 2px solid var(--vscode-panel-border, rgba(128, 128, 128, 0.4));
+	padding: 4px 0 4px 8px;
 }
 
 .dreb-response {

--- a/packages/vscode/test/format.test.ts
+++ b/packages/vscode/test/format.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import {
+	formatContextUsage,
+	formatCost,
+	formatModel,
+	formatPercent,
+	formatSessionStats,
+	formatThinking,
+} from "../src/shared/format.js";
+
+describe("format", () => {
+	describe("formatModel", () => {
+		it("prefers name, falls back to id, then a dash", () => {
+			expect(formatModel({ provider: "anthropic", id: "claude", name: "Claude" })).toBe("Claude");
+			expect(formatModel({ provider: "anthropic", id: "claude" })).toBe("claude");
+			expect(formatModel({ provider: "x", id: "y", name: "" })).toBe("y");
+			expect(formatModel(undefined)).toBe("—");
+		});
+	});
+
+	describe("formatThinking", () => {
+		it("shows the level or a dash", () => {
+			expect(formatThinking("high")).toBe("high");
+			expect(formatThinking(undefined)).toBe("—");
+			expect(formatThinking("")).toBe("—");
+		});
+	});
+
+	describe("formatCost", () => {
+		it("returns undefined when there is nothing to show", () => {
+			expect(formatCost(undefined)).toBeUndefined();
+			expect(formatCost({ session: 0, usingSubscription: false })).toBeUndefined();
+		});
+
+		it("formats session cost with 3 decimals", () => {
+			expect(formatCost({ session: 0.1234, usingSubscription: false })).toBe("$0.123");
+		});
+
+		it("marks subscription and appends a larger daily total", () => {
+			expect(formatCost({ session: 0, usingSubscription: true })).toBe("$0.000 (sub)");
+			expect(formatCost({ session: 0.12, daily: 1.5, usingSubscription: false })).toBe("$0.120, today $1.50");
+		});
+
+		it("omits daily when it is not larger than the session cost", () => {
+			expect(formatCost({ session: 2, daily: 1, usingSubscription: false })).toBe("$2.000");
+		});
+	});
+
+	describe("formatPercent", () => {
+		it("rounds, or shows ? when unknown", () => {
+			expect(formatPercent(42.6)).toBe("43%");
+			expect(formatPercent(null)).toBe("?");
+		});
+	});
+
+	describe("formatContextUsage", () => {
+		it("renders a ctx chip or undefined", () => {
+			expect(formatContextUsage(undefined)).toBeUndefined();
+			expect(formatContextUsage({ tokens: 100, contextWindow: 1000, percent: 10 })).toBe("ctx 10%");
+			expect(formatContextUsage({ tokens: null, contextWindow: 1000, percent: null })).toBe("ctx ?");
+		});
+	});
+
+	describe("formatSessionStats", () => {
+		it("summarizes messages, tokens, cost, and context", () => {
+			const text = formatSessionStats({
+				sessionId: "abc",
+				userMessages: 3,
+				assistantMessages: 4,
+				toolCalls: 5,
+				totalMessages: 7,
+				tokens: { input: 100, output: 200, total: 300 },
+				cost: 0.5,
+				contextUsage: { tokens: 300, contextWindow: 1000, percent: 30 },
+			});
+			expect(text).toContain("id: abc");
+			expect(text).toContain("messages: 7 (user 3, assistant 4)");
+			expect(text).toContain("tool calls: 5");
+			expect(text).toContain("tokens: 300 (in 100, out 200)");
+			expect(text).toContain("cost: $0.5000");
+			expect(text).toContain("context: 30%");
+		});
+
+		it("tolerates a minimal stats object", () => {
+			const text = formatSessionStats({});
+			expect(text).toContain("Session stats");
+			expect(text).toContain("messages: 0 (user 0, assistant 0)");
+		});
+	});
+});

--- a/packages/vscode/test/projection.test.ts
+++ b/packages/vscode/test/projection.test.ts
@@ -141,6 +141,16 @@ describe("projection", () => {
 		expect(onlyResponse(state).collapsed).toBe(true);
 	});
 
+	it("appends a synthetic host_system line as a persistent transcript item", () => {
+		const state = run([
+			{ type: "message_start", message: { role: "user", content: "hi" } },
+			{ type: "host_system", text: "Session stats\n  cost: $0.0000" },
+		]);
+		expect(state.items.map((i) => i.kind)).toEqual(["user", "system"]);
+		const system = state.items[1];
+		expect(system.kind === "system" && system.text).toContain("Session stats");
+	});
+
 	it("groups sequential agent runs into distinct responses", () => {
 		const state = run([
 			{ type: "agent_start" },

--- a/packages/vscode/test/session-controller.test.ts
+++ b/packages/vscode/test/session-controller.test.ts
@@ -37,6 +37,21 @@ class FakeClient implements RpcClientLike {
 	} = { cost: 0 };
 	getStateCalls = 0;
 	dailyCostCalls = 0;
+	/** Optional gate: when set, `getState` blocks until `releaseState()` is
+	 * called, letting a test hold a refreshStatus() in flight and interleave a
+	 * second (coalesced) refresh before the first resolves. */
+	private stateGate: Promise<void> | undefined;
+	private stateGateResolve: (() => void) | undefined;
+	blockState(): void {
+		this.stateGate = new Promise<void>((resolve) => {
+			this.stateGateResolve = resolve;
+		});
+	}
+	releaseState(): void {
+		this.stateGateResolve?.();
+		this.stateGate = undefined;
+		this.stateGateResolve = undefined;
+	}
 
 	// Model / thinking.
 	availableModels: Array<{ provider: string; id: string; name?: string }> = [];
@@ -97,6 +112,7 @@ class FakeClient implements RpcClientLike {
 	}
 	async getState() {
 		this.getStateCalls += 1;
+		if (this.stateGate) await this.stateGate;
 		return this.state;
 	}
 	async getDailyCost(): Promise<number> {
@@ -234,6 +250,59 @@ describe("SessionController", () => {
 
 		expect(fake.getStateCalls).toBeGreaterThan(afterStart);
 		expect(controller.getStatus().cost?.session).toBe(0.9);
+	});
+
+	it("preserves the last-known daily cost across a non-daily refresh (finding 6)", async () => {
+		const fake = new FakeClient();
+		fake.dailyCost = 2.5;
+		const controller = makeController(fake);
+		await controller.start(); // connect does a full refresh incl. daily
+		expect(controller.getStatus().cost?.daily).toBe(2.5);
+		const dailyCallsAfterConnect = fake.dailyCostCalls;
+
+		// A cheaper refresh (e.g. /reload → refreshStatus(false)) must NOT refetch
+		// the daily cost, and must NOT wipe the previously-known value to undefined.
+		fake.dailyCost = 999; // would be wrong if refetched
+		await controller.submit("/reload");
+
+		expect(controller.getStatus().cost?.daily).toBe(2.5); // preserved, not wiped
+		expect(fake.dailyCostCalls).toBe(dailyCallsAfterConnect); // not refetched
+	});
+
+	it("coalesces an overlapping refresh and honors the strongest daily intent (findings 2, 3)", async () => {
+		const flush = async () => {
+			for (let i = 0; i < 8; i++) await Promise.resolve();
+		};
+		const fake = new FakeClient();
+		fake.dailyCost = 1.0;
+		const controller = makeController(fake);
+		await controller.start(); // daily = 1.0
+		expect(controller.getStatus().cost?.daily).toBe(1.0);
+		const stateCallsAfterConnect = fake.getStateCalls;
+		const dailyCallsAfterConnect = fake.dailyCostCalls;
+
+		// Hold a cheap refresh (includeDailyCost=false) in flight by gating getState.
+		fake.blockState();
+		fake.dailyCost = 5.0; // the value a daily-including refresh should fetch
+		const reloadPromise = controller.submit("/reload"); // → refreshStatus(false), blocks
+		await flush();
+
+		// While the false-refresh is in flight, an agent_end fires a true refresh.
+		// It must coalesce (not run concurrently) but its daily intent must survive.
+		fake.emit({ type: "agent_end" });
+		await flush();
+
+		fake.releaseState();
+		await reloadPromise;
+		await flush();
+
+		// Trailing re-run ran exactly once (finding 3 — not concurrently): one
+		// getState for the in-flight false refresh + one for the trailing re-run.
+		expect(fake.getStateCalls).toBe(stateCallsAfterConnect + 2);
+		// The coalesced agent_end's daily intent was honored: the trailing re-run
+		// fetched the fresh daily cost (finding 2 — not the false call's intent).
+		expect(fake.dailyCostCalls).toBe(dailyCallsAfterConnect + 1);
+		expect(controller.getStatus().cost?.daily).toBe(5.0);
 	});
 
 	it("applies events to the transcript and notifies listeners", async () => {
@@ -408,7 +477,7 @@ describe("SessionController", () => {
 		expect(updates.some((u) => u.kind === "resync")).toBe(true);
 	});
 
-	it("/quit stops the client and reports a disconnected status", async () => {
+	it("/quit stops the client, reports a disconnected status, and disposes idempotently", async () => {
 		const fake = new FakeClient();
 		const controller = makeController(fake);
 		await controller.start();
@@ -419,6 +488,15 @@ describe("SessionController", () => {
 		expect(fake.stopped).toBe(1);
 		expect(controller.getStatus().connected).toBe(false);
 		expect(updates.some((u) => u.kind === "status")).toBe(true);
+		// The host uses isDisposed() to detect an ended session and rebuild a
+		// fresh controller on reopen (finding 1 — otherwise reopen reveals a dead
+		// panel). /quit must mark the controller disposed.
+		expect(controller.isDisposed()).toBe(true);
+
+		// dispose() is idempotent: a later teardown (e.g. panel close after quit)
+		// must not stop the client a second time.
+		await controller.dispose();
+		expect(fake.stopped).toBe(1);
 	});
 
 	it("pickModel lists models, applies the choice, and refreshes status", async () => {
@@ -427,14 +505,34 @@ describe("SessionController", () => {
 			{ provider: "anthropic", id: "claude", name: "Claude" },
 			{ provider: "openai", id: "gpt", name: "GPT" },
 		];
+		fake.state = { model: { provider: "openai", id: "gpt", name: "GPT" } };
 		const ui = new FakeUi();
 		ui.pickReturn = "openai\u0000gpt";
 		const controller = makeController(fake, { ui });
 		await controller.start();
+		const stateCallsBefore = fake.getStateCalls;
 
 		await controller.pickModel();
 		expect(ui.pickItems).toHaveLength(2);
 		expect(fake.setModelCalls).toEqual([{ provider: "openai", modelId: "gpt" }]);
+		// The mandated quickPick→setModel→refresh flow: assert the refresh ran and
+		// the applied model is reflected (finding 5 — otherwise a dropped refresh
+		// would go unnoticed).
+		expect(fake.getStateCalls).toBeGreaterThan(stateCallsBefore);
+		expect(controller.getStatus().model).toEqual({ provider: "openai", id: "gpt", name: "GPT" });
+	});
+
+	it("pickModel surfaces an RPC rejection as a bespoke notice", async () => {
+		const fake = new FakeClient();
+		fake.availableModels = [{ provider: "anthropic", id: "claude", name: "Claude" }];
+		const ui = new FakeUi();
+		ui.pickReturn = "anthropic\u0000claude";
+		fake.callError = new Error("setModel boom");
+		const controller = makeController(fake, { ui });
+		await controller.start();
+
+		await controller.pickModel();
+		expect(controller.getTranscript().statusText).toMatch(/Model selection failed: setModel boom/);
 	});
 
 	it("pickModel does nothing when the picker is dismissed", async () => {
@@ -448,15 +546,55 @@ describe("SessionController", () => {
 		expect(fake.setModelCalls).toHaveLength(0);
 	});
 
-	it("pickThinking applies the selected level", async () => {
+	it("pickModel surfaces a notice and skips the picker when no models are available", async () => {
 		const fake = new FakeClient();
+		fake.availableModels = []; // none
+		const ui = new FakeUi();
+		const controller = makeController(fake, { ui });
+		await controller.start();
+
+		await controller.pickModel();
+		expect(ui.pickItems).toBeUndefined(); // quickPick never invoked
+		expect(fake.setModelCalls).toHaveLength(0);
+		expect(controller.getTranscript().statusText).toMatch(/No models are available/);
+	});
+
+	it("pickThinking applies the selected level and refreshes status", async () => {
+		const fake = new FakeClient();
+		fake.state = { thinkingLevel: "high" };
 		const ui = new FakeUi();
 		ui.pickReturn = "high";
 		const controller = makeController(fake, { ui });
 		await controller.start();
+		const stateCallsBefore = fake.getStateCalls;
 
 		await controller.pickThinking();
 		expect(fake.thinkingLevels).toEqual(["high"]);
+		// Assert the refresh ran and the applied level is reflected (finding 5).
+		expect(fake.getStateCalls).toBeGreaterThan(stateCallsBefore);
+		expect(controller.getStatus().thinkingLevel).toBe("high");
+	});
+
+	it("pickThinking does nothing when the picker is dismissed", async () => {
+		const fake = new FakeClient();
+		const ui = new FakeUi(); // pickReturn undefined
+		const controller = makeController(fake, { ui });
+		await controller.start();
+
+		await controller.pickThinking();
+		expect(fake.thinkingLevels).toHaveLength(0);
+	});
+
+	it("pickThinking surfaces an RPC rejection as a bespoke notice", async () => {
+		const fake = new FakeClient();
+		const ui = new FakeUi();
+		ui.pickReturn = "high";
+		fake.callError = new Error("setThinking boom");
+		const controller = makeController(fake, { ui });
+		await controller.start();
+
+		await controller.pickThinking();
+		expect(controller.getTranscript().statusText).toMatch(/Thinking-level change failed: setThinking boom/);
 	});
 
 	it("dispatching /model opens the model picker", async () => {

--- a/packages/vscode/test/session-controller.test.ts
+++ b/packages/vscode/test/session-controller.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { HostUi, HostUiPickItem } from "../src/host/host-ui.js";
 import { type RpcClientLike, SessionController } from "../src/host/session-controller.js";
 
 /** Fake RpcClient that captures calls and lets a test drive events/exit. */
@@ -16,8 +17,43 @@ class FakeClient implements RpcClientLike {
 		dashboard?: boolean;
 	}> = [];
 	startError: Error | undefined;
-	/** When set, the next prompt/compact/abort call rejects with this error. */
+	/** When set, the next prompt/compact/abort/builtin call rejects with this error. */
 	callError: Error | undefined;
+
+	// Runtime status.
+	state: {
+		model?: { provider: string; id: string; name?: string };
+		thinkingLevel?: string;
+		usingSubscription?: boolean;
+		contextUsage?: { tokens: number | null; contextWindow: number; percent: number | null };
+	} = {};
+	dailyCost = 0;
+	stats: {
+		sessionId?: string;
+		cost?: number;
+		totalMessages?: number;
+		tokens?: { input?: number; output?: number; total?: number };
+		contextUsage?: { tokens: number | null; contextWindow: number; percent: number | null };
+	} = { cost: 0 };
+	getStateCalls = 0;
+	dailyCostCalls = 0;
+
+	// Model / thinking.
+	availableModels: Array<{ provider: string; id: string; name?: string }> = [];
+	setModelCalls: Array<{ provider: string; modelId: string }> = [];
+	thinkingLevels: string[] = [];
+
+	// Builtins.
+	newSessions = 0;
+	newSessionResult: { cancelled: boolean } = { cancelled: false };
+	reloads = 0;
+	dreams: Array<string | undefined> = [];
+	dreamResult: { message: string } = { message: "dreamt" };
+	names: string[] = [];
+	exports: Array<string | undefined> = [];
+	imports: string[] = [];
+	importResult: { cancelled: boolean } = { cancelled: false };
+
 	private eventListener: ((event: any) => void) | undefined;
 	private exitListener: ((info: any) => void) | undefined;
 
@@ -41,14 +77,7 @@ class FakeClient implements RpcClientLike {
 		this.compactions.push(customInstructions);
 		return {};
 	}
-	async getCommands(): Promise<
-		Array<{
-			name: string;
-			description?: string;
-			source: "extension" | "prompt" | "skill" | "builtin";
-			dashboard?: boolean;
-		}>
-	> {
+	async getCommands() {
 		return this.commandsResult;
 	}
 	sendExtensionUIResponse(response: unknown): void {
@@ -66,6 +95,57 @@ class FakeClient implements RpcClientLike {
 			this.exitListener = undefined;
 		};
 	}
+	async getState() {
+		this.getStateCalls += 1;
+		return this.state;
+	}
+	async getDailyCost(): Promise<number> {
+		this.dailyCostCalls += 1;
+		return this.dailyCost;
+	}
+	async getSessionStats() {
+		return this.stats;
+	}
+	async getAvailableModels() {
+		return this.availableModels;
+	}
+	async setModel(provider: string, modelId: string): Promise<{ provider: string; id: string }> {
+		if (this.callError) throw this.callError;
+		this.setModelCalls.push({ provider, modelId });
+		return { provider, id: modelId };
+	}
+	async setThinkingLevel(level: string): Promise<void> {
+		if (this.callError) throw this.callError;
+		this.thinkingLevels.push(level);
+	}
+	async newSession(): Promise<{ cancelled: boolean }> {
+		if (this.callError) throw this.callError;
+		this.newSessions += 1;
+		return this.newSessionResult;
+	}
+	async reload(): Promise<void> {
+		if (this.callError) throw this.callError;
+		this.reloads += 1;
+	}
+	async dream(args?: string): Promise<{ message: string }> {
+		if (this.callError) throw this.callError;
+		this.dreams.push(args);
+		return this.dreamResult;
+	}
+	async setSessionName(name: string): Promise<void> {
+		if (this.callError) throw this.callError;
+		this.names.push(name);
+	}
+	async exportHtml(outputPath?: string): Promise<{ path: string }> {
+		if (this.callError) throw this.callError;
+		this.exports.push(outputPath);
+		return { path: outputPath ?? "/tmp/session.html" };
+	}
+	async importJsonl(inputPath: string): Promise<{ cancelled: boolean }> {
+		if (this.callError) throw this.callError;
+		this.imports.push(inputPath);
+		return this.importResult;
+	}
 	emit(event: unknown): void {
 		this.eventListener?.(event);
 	}
@@ -74,8 +154,35 @@ class FakeClient implements RpcClientLike {
 	}
 }
 
-function makeController(fake: FakeClient, cwd = "/tmp/project") {
-	return new SessionController({ cwd, cliPath: "/cli.js", clientFactory: () => fake });
+/** Fake HostUi with scripted return values. */
+class FakeUi implements HostUi {
+	pickItems: HostUiPickItem[] | undefined;
+	pickReturn: string | undefined;
+	inputReturn: string | undefined;
+	saveReturn: string | undefined;
+	openReturn: string | undefined;
+	async quickPick(items: HostUiPickItem[]): Promise<string | undefined> {
+		this.pickItems = items;
+		return this.pickReturn;
+	}
+	async inputBox(): Promise<string | undefined> {
+		return this.inputReturn;
+	}
+	async saveDialog(): Promise<string | undefined> {
+		return this.saveReturn;
+	}
+	async openDialog(): Promise<string | undefined> {
+		return this.openReturn;
+	}
+}
+
+function makeController(fake: FakeClient, opts: { cwd?: string; ui?: HostUi } = {}) {
+	return new SessionController({
+		cwd: opts.cwd ?? "/tmp/project",
+		cliPath: "/cli.js",
+		clientFactory: () => fake,
+		ui: opts.ui,
+	});
 }
 
 describe("SessionController", () => {
@@ -91,6 +198,42 @@ describe("SessionController", () => {
 		const names = controller.getCommandList().map((c) => c.name);
 		expect(names).toContain("review"); // slash stripped, from agent
 		expect(names).toContain("compact"); // builtin
+	});
+
+	it("populates runtime status (model/thinking/cost/context) on connect", async () => {
+		const fake = new FakeClient();
+		fake.state = {
+			model: { provider: "anthropic", id: "claude", name: "Claude" },
+			thinkingLevel: "medium",
+			usingSubscription: false,
+			contextUsage: { tokens: 100, contextWindow: 1000, percent: 10 },
+		};
+		fake.stats = { cost: 0.25 };
+		fake.dailyCost = 1.5;
+		const controller = makeController(fake);
+
+		await controller.start();
+
+		const status = controller.getStatus();
+		expect(status.model).toEqual({ provider: "anthropic", id: "claude", name: "Claude" });
+		expect(status.thinkingLevel).toBe("medium");
+		expect(status.cost).toEqual({ session: 0.25, daily: 1.5, usingSubscription: false });
+		expect(status.contextUsage).toEqual({ tokens: 100, contextWindow: 1000, percent: 10 });
+	});
+
+	it("refreshes runtime status after each agent_end", async () => {
+		const fake = new FakeClient();
+		const controller = makeController(fake);
+		await controller.start();
+		const afterStart = fake.getStateCalls;
+
+		fake.stats = { cost: 0.9 };
+		fake.emit({ type: "agent_end" });
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(fake.getStateCalls).toBeGreaterThan(afterStart);
+		expect(controller.getStatus().cost?.session).toBe(0.9);
 	});
 
 	it("applies events to the transcript and notifies listeners", async () => {
@@ -132,14 +275,14 @@ describe("SessionController", () => {
 		expect(fake.prompts).toEqual(["/review 42"]);
 	});
 
-	it("intercepts server builtins from get_commands instead of routing them to prompt", async () => {
+	it("intercepts server builtins from get_commands and dispatches /new to newSession", async () => {
 		// Regression: builtins advertised by get_commands (source "builtin") must
 		// NOT be forwarded via prompt — the server rejects them and the rejection
-		// is silently dropped, so the user sees nothing. They must be intercepted.
+		// is silently dropped. They are intercepted and dispatched to RPC.
 		const fake = new FakeClient();
 		fake.commandsResult = [
 			{ name: "new", description: "New session", source: "builtin" },
-			{ name: "quit", description: "Quit", source: "builtin", dashboard: false },
+			{ name: "copy", description: "Copy", source: "builtin", dashboard: false },
 			{ name: "review", source: "extension" },
 		];
 		const controller = makeController(fake);
@@ -149,11 +292,213 @@ describe("SessionController", () => {
 		const knew = controller.getCommandList().find((c) => c.name === "new");
 		expect(knew?.source).toBe("builtin");
 		// dashboard:false builtins are hidden from the dropdown.
-		expect(controller.getCommandList().some((c) => c.name === "quit")).toBe(false);
+		expect(controller.getCommandList().some((c) => c.name === "copy")).toBe(false);
 
+		const updates: Array<{ kind: string }> = [];
+		controller.onUpdate((u) => updates.push(u));
 		await controller.submit("/new");
 		expect(fake.prompts).toHaveLength(0); // never forwarded to prompt
-		expect(controller.getTranscript().statusText).toMatch(/isn't available yet/);
+		expect(fake.newSessions).toBe(1);
+		// /new resets the transcript and re-snapshots via a resync update.
+		expect(updates.some((u) => u.kind === "resync")).toBe(true);
+	});
+
+	it("/new clears the transcript and starts fresh", async () => {
+		const fake = new FakeClient();
+		const controller = makeController(fake);
+		await controller.start();
+		fake.emit({ type: "message_start", message: { role: "user", content: "old" } });
+		expect(controller.getTranscript().items).toHaveLength(1);
+
+		await controller.submit("/new");
+
+		expect(fake.newSessions).toBe(1);
+		expect(controller.getTranscript().items).toHaveLength(0);
+	});
+
+	it("/reload reloads and re-emits the command list", async () => {
+		const fake = new FakeClient();
+		const controller = makeController(fake);
+		await controller.start();
+		const updates: Array<{ kind: string }> = [];
+		controller.onUpdate((u) => updates.push(u));
+
+		await controller.submit("/reload");
+
+		expect(fake.reloads).toBe(1);
+		expect(updates.some((u) => u.kind === "commands")).toBe(true);
+	});
+
+	it("/dream surfaces the returned message", async () => {
+		const fake = new FakeClient();
+		fake.dreamResult = { message: "merged 3 memories" };
+		const controller = makeController(fake);
+		await controller.start();
+
+		await controller.submit("/dream");
+		expect(fake.dreams).toEqual([undefined]);
+		expect(controller.getTranscript().statusText).toBe("merged 3 memories");
+	});
+
+	it("/session appends a persistent stats line", async () => {
+		const fake = new FakeClient();
+		fake.stats = { sessionId: "s1", cost: 0.5, totalMessages: 4 };
+		const controller = makeController(fake);
+		await controller.start();
+
+		await controller.submit("/session");
+		const items = controller.getTranscript().items;
+		const system = items.find((i) => i.kind === "system");
+		expect(system && system.kind === "system" && system.text).toContain("Session stats");
+	});
+
+	it("/name prompts via the HostUi and calls setSessionName", async () => {
+		const fake = new FakeClient();
+		const ui = new FakeUi();
+		ui.inputReturn = "My chat";
+		const controller = makeController(fake, { ui });
+		await controller.start();
+
+		await controller.submit("/name");
+		expect(fake.names).toEqual(["My chat"]);
+	});
+
+	it("/name uses an inline argument without prompting", async () => {
+		const fake = new FakeClient();
+		const ui = new FakeUi(); // inputReturn undefined — must not be used
+		const controller = makeController(fake, { ui });
+		await controller.start();
+
+		await controller.submit("/name Inline Name");
+		expect(fake.names).toEqual(["Inline Name"]);
+	});
+
+	it("/export saves via the HostUi save dialog", async () => {
+		const fake = new FakeClient();
+		const ui = new FakeUi();
+		ui.saveReturn = "/tmp/out.html";
+		const controller = makeController(fake, { ui });
+		await controller.start();
+
+		await controller.submit("/export");
+		expect(fake.exports).toEqual(["/tmp/out.html"]);
+	});
+
+	it("/export does nothing when the save dialog is dismissed", async () => {
+		const fake = new FakeClient();
+		const ui = new FakeUi(); // saveReturn undefined
+		const controller = makeController(fake, { ui });
+		await controller.start();
+
+		await controller.submit("/export");
+		expect(fake.exports).toHaveLength(0);
+	});
+
+	it("/import opens via the HostUi and re-syncs the transcript", async () => {
+		const fake = new FakeClient();
+		const ui = new FakeUi();
+		ui.openReturn = "/tmp/in.jsonl";
+		const controller = makeController(fake, { ui });
+		await controller.start();
+		const updates: Array<{ kind: string }> = [];
+		controller.onUpdate((u) => updates.push(u));
+
+		await controller.submit("/import");
+		expect(fake.imports).toEqual(["/tmp/in.jsonl"]);
+		expect(updates.some((u) => u.kind === "resync")).toBe(true);
+	});
+
+	it("/quit stops the client and reports a disconnected status", async () => {
+		const fake = new FakeClient();
+		const controller = makeController(fake);
+		await controller.start();
+		const updates: Array<{ kind: string }> = [];
+		controller.onUpdate((u) => updates.push(u));
+
+		await controller.submit("/quit");
+		expect(fake.stopped).toBe(1);
+		expect(controller.getStatus().connected).toBe(false);
+		expect(updates.some((u) => u.kind === "status")).toBe(true);
+	});
+
+	it("pickModel lists models, applies the choice, and refreshes status", async () => {
+		const fake = new FakeClient();
+		fake.availableModels = [
+			{ provider: "anthropic", id: "claude", name: "Claude" },
+			{ provider: "openai", id: "gpt", name: "GPT" },
+		];
+		const ui = new FakeUi();
+		ui.pickReturn = "openai\u0000gpt";
+		const controller = makeController(fake, { ui });
+		await controller.start();
+
+		await controller.pickModel();
+		expect(ui.pickItems).toHaveLength(2);
+		expect(fake.setModelCalls).toEqual([{ provider: "openai", modelId: "gpt" }]);
+	});
+
+	it("pickModel does nothing when the picker is dismissed", async () => {
+		const fake = new FakeClient();
+		fake.availableModels = [{ provider: "anthropic", id: "claude" }];
+		const ui = new FakeUi(); // pickReturn undefined
+		const controller = makeController(fake, { ui });
+		await controller.start();
+
+		await controller.pickModel();
+		expect(fake.setModelCalls).toHaveLength(0);
+	});
+
+	it("pickThinking applies the selected level", async () => {
+		const fake = new FakeClient();
+		const ui = new FakeUi();
+		ui.pickReturn = "high";
+		const controller = makeController(fake, { ui });
+		await controller.start();
+
+		await controller.pickThinking();
+		expect(fake.thinkingLevels).toEqual(["high"]);
+	});
+
+	it("dispatching /model opens the model picker", async () => {
+		const fake = new FakeClient();
+		fake.availableModels = [{ provider: "anthropic", id: "claude", name: "Claude" }];
+		const ui = new FakeUi();
+		ui.pickReturn = "anthropic\u0000claude";
+		const controller = makeController(fake, { ui });
+		await controller.start();
+
+		await controller.submit("/model");
+		expect(fake.setModelCalls).toEqual([{ provider: "anthropic", modelId: "claude" }]);
+	});
+
+	it("surfaces a 'later phase' notice for deferred builtins", async () => {
+		const fake = new FakeClient();
+		const controller = makeController(fake);
+		await controller.start();
+
+		await controller.submit("/fork");
+		expect(fake.prompts).toHaveLength(0);
+		expect(controller.getTranscript().statusText).toMatch(/later phase/);
+	});
+
+	it("surfaces a terminal-only notice for /login", async () => {
+		const fake = new FakeClient();
+		const controller = makeController(fake);
+		await controller.start();
+
+		await controller.submit("/login");
+		expect(fake.prompts).toHaveLength(0);
+		expect(controller.getTranscript().statusText).toMatch(/terminal UI/);
+	});
+
+	it("surfaces a notice when a builtin RPC call rejects", async () => {
+		const fake = new FakeClient();
+		const controller = makeController(fake);
+		await controller.start();
+		fake.callError = new Error("newSession boom");
+
+		await controller.submit("/new");
+		expect(controller.getTranscript().statusText).toMatch(/Request failed: newSession boom/);
 	});
 
 	it("blocks submits after a child crash with a reconnect notice", async () => {
@@ -185,18 +530,6 @@ describe("SessionController", () => {
 		fake.callError = new Error("abort boom");
 
 		await expect(controller.abort()).resolves.toBeUndefined();
-	});
-
-	it("surfaces a notice for unwired builtins without calling the client", async () => {
-		const fake = new FakeClient();
-		const controller = makeController(fake);
-		await controller.start();
-
-		await controller.submit("/model");
-
-		expect(fake.prompts).toHaveLength(0);
-		expect(fake.compactions).toHaveLength(0);
-		expect(controller.getTranscript().statusText).toMatch(/model/);
 	});
 
 	it("forwards extension-UI responses with the wire type", async () => {

--- a/packages/vscode/test/session-registry.test.ts
+++ b/packages/vscode/test/session-registry.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+import { type SessionOps, SessionRegistry } from "../src/host/session-registry.js";
+
+/** A fake session with controllable disposed-state and an observable teardown
+ * whose completion a test can gate to simulate slow/racing `/quit` reopen. */
+class FakeSession {
+	disposed = false;
+	revealed = 0;
+	teardownCalls = 0;
+	private teardownGate: Promise<void> | undefined;
+	private teardownRelease: (() => void) | undefined;
+
+	constructor(public readonly id: string) {}
+
+	gateTeardown(): void {
+		this.teardownGate = new Promise<void>((resolve) => {
+			this.teardownRelease = resolve;
+		});
+	}
+	releaseTeardown(): void {
+		this.teardownRelease?.();
+		this.teardownGate = undefined;
+		this.teardownRelease = undefined;
+	}
+	get gate(): Promise<void> | undefined {
+		return this.teardownGate;
+	}
+}
+
+/** Build a registry over FakeSession with observable ops. */
+function makeRegistry() {
+	const ops: SessionOps<FakeSession> = {
+		isDisposed: (s) => s.disposed,
+		reveal: (s) => {
+			s.revealed += 1;
+		},
+		teardown: async (s) => {
+			s.teardownCalls += 1;
+			if (s.gate) await s.gate;
+		},
+	};
+	return new SessionRegistry<FakeSession>(ops);
+}
+
+const flush = async () => {
+	for (let i = 0; i < 8; i++) await Promise.resolve();
+};
+
+describe("SessionRegistry", () => {
+	it("builds a session on first open and reveals (not rebuilds) a live one", async () => {
+		const registry = makeRegistry();
+		let built = 0;
+		const create = () => {
+			built += 1;
+			return new FakeSession(`s${built}`);
+		};
+
+		await registry.open(create);
+		expect(built).toBe(1);
+		const first = registry.active;
+		expect(first?.id).toBe("s1");
+
+		await registry.open(create);
+		expect(built).toBe(1); // not rebuilt
+		expect(registry.active).toBe(first); // same session
+		expect(first?.revealed).toBe(1); // revealed instead
+	});
+
+	it("tears down a disposed session and builds a fresh one on reopen", async () => {
+		const registry = makeRegistry();
+		const sessions: FakeSession[] = [];
+		const create = () => {
+			const s = new FakeSession(`s${sessions.length + 1}`);
+			sessions.push(s);
+			return s;
+		};
+
+		await registry.open(create); // s1 live
+		sessions[0].disposed = true; // ended via /quit
+
+		await registry.open(create); // should tear down s1, build s2
+		expect(sessions).toHaveLength(2);
+		expect(sessions[0].teardownCalls).toBe(1); // dead panel torn down
+		expect(registry.active).toBe(sessions[1]); // fresh session live
+		expect(sessions[1].revealed).toBe(0); // brand new, not revealed
+	});
+
+	it("defers to a concurrent open() instead of orphaning it (reentrancy race)", async () => {
+		const registry = makeRegistry();
+		const sessions: FakeSession[] = [];
+		const create = () => {
+			const s = new FakeSession(`s${sessions.length + 1}`);
+			sessions.push(s);
+			return s;
+		};
+
+		await registry.open(create); // s1 live
+		const s1 = sessions[0];
+		s1.disposed = true; // ended via /quit
+		s1.gateTeardown(); // hold s1's teardown mid-flight
+
+		// Invocation A: sees s1 disposed, starts tearing it down, suspends on the gate.
+		const createSpyBefore = sessions.length;
+		const pA = registry.open(create);
+		await flush();
+		// s1's teardown is in flight; current has been cleared during the await.
+		expect(s1.teardownCalls).toBe(1);
+		expect(registry.active).toBeUndefined();
+		// A has NOT yet built its session (it's suspended before the create call).
+		expect(sessions.length).toBe(createSpyBefore);
+
+		// Invocation B fires while A is suspended: current is undefined, so it
+		// builds a brand-new live session (s2) and installs it.
+		await registry.open(create); // resolves synchronously past the awaits
+		const s2 = registry.active;
+		expect(s2?.id).toBe("s2");
+
+		// Release s1's teardown so A resumes. A must DEFER to s2, not orphan it.
+		s1.releaseTeardown();
+		await pA;
+		await flush();
+
+		expect(registry.active).toBe(s2); // s2 still the one-and-only live session
+		expect(sessions).toHaveLength(2); // A never built a third (orphan) session
+		expect(s2?.revealed).toBe(1); // A revealed the concurrent session instead
+	});
+
+	it("scopes teardown to its own session — closing an old panel never disposes the live one", async () => {
+		const registry = makeRegistry();
+		const live = new FakeSession("live");
+		await registry.open(() => live); // live is current
+
+		// An orphaned/older session's panel closes and fires disposeSession(old).
+		const old = new FakeSession("old");
+		await registry.disposeSession(old);
+
+		expect(old.teardownCalls).toBe(1); // the old session IS torn down…
+		expect(live.teardownCalls).toBe(0); // …but the live one is untouched
+		expect(registry.active).toBe(live); // current not clobbered
+	});
+
+	it("disposeSession is idempotent (explicit /quit + panel onDidDispose)", async () => {
+		const registry = makeRegistry();
+		const s = new FakeSession("s");
+		await registry.open(() => s);
+
+		await registry.disposeSession(s);
+		await registry.disposeSession(s); // e.g. panel.onDidDispose firing after
+		expect(s.teardownCalls).toBe(1); // torn down exactly once
+		expect(registry.active).toBeUndefined();
+	});
+
+	it("disposeActive tears down the live session, if any", async () => {
+		const registry = makeRegistry();
+		await registry.disposeActive(); // no-op when empty
+		const s = new FakeSession("s");
+		await registry.open(() => s);
+
+		await registry.disposeActive();
+		expect(s.teardownCalls).toBe(1);
+		expect(registry.active).toBeUndefined();
+	});
+});

--- a/packages/vscode/test/slash-router.test.ts
+++ b/packages/vscode/test/slash-router.test.ts
@@ -45,6 +45,15 @@ describe("slash-router", () => {
 		expect(routeInput("/new", withBuiltin)).toEqual({ kind: "builtin", command: "new", arg: undefined });
 	});
 
+	it("intercepts wired-fallback, deferred, and terminal-only builtins by name", () => {
+		// Even without a get_commands advertisement, the router recognizes every
+		// builtin name (wired fallback + deferred + terminal-only) and intercepts
+		// it so submit never forwards it to prompt.
+		expect(routeInput("/export a.html")).toEqual({ kind: "builtin", command: "export", arg: "a.html" });
+		expect(routeInput("/fork")).toEqual({ kind: "builtin", command: "fork", arg: undefined });
+		expect(routeInput("/login")).toEqual({ kind: "builtin", command: "login", arg: undefined });
+	});
+
 	it("flags an unknown slash command", () => {
 		expect(routeInput("/bogus now")).toEqual({ kind: "unknown-command", name: "bogus" });
 	});

--- a/packages/vscode/test/webview-bridge.test.ts
+++ b/packages/vscode/test/webview-bridge.test.ts
@@ -44,6 +44,36 @@ class BridgeFakeClient implements RpcClientLike {
 			this.ex = undefined;
 		};
 	}
+	async getState(): Promise<any> {
+		return {};
+	}
+	async getDailyCost(): Promise<number> {
+		return 0;
+	}
+	async getSessionStats(): Promise<any> {
+		return { cost: 0 };
+	}
+	async getAvailableModels(): Promise<any[]> {
+		return [];
+	}
+	async setModel(provider: string, modelId: string): Promise<{ provider: string; id: string }> {
+		return { provider, id: modelId };
+	}
+	async setThinkingLevel(): Promise<void> {}
+	async newSession(): Promise<{ cancelled: boolean }> {
+		return { cancelled: false };
+	}
+	async reload(): Promise<void> {}
+	async dream(): Promise<{ message: string }> {
+		return { message: "" };
+	}
+	async setSessionName(): Promise<void> {}
+	async exportHtml(): Promise<{ path: string }> {
+		return { path: "" };
+	}
+	async importJsonl(): Promise<{ cancelled: boolean }> {
+		return { cancelled: false };
+	}
 	emit(event: unknown): void {
 		this.ev?.(event);
 	}
@@ -144,6 +174,47 @@ describe("connectWebview", () => {
 		expect(abort).toHaveBeenCalledTimes(1);
 		expect(respondUi).toHaveBeenCalledWith({ id: "u1", confirmed: true });
 		expect(refresh).toHaveBeenCalled();
+	});
+
+	it("routes pick-model / pick-thinking messages to the controller", async () => {
+		const fake = new BridgeFakeClient();
+		const controller = await makeController(fake);
+		const pickModel = vi.spyOn(controller, "pickModel").mockResolvedValue();
+		const pickThinking = vi.spyOn(controller, "pickThinking").mockResolvedValue();
+
+		const { webview, send } = makeWebview();
+		connectWebview(webview as any, controller);
+
+		send({ type: "pick-model" });
+		send({ type: "pick-thinking" });
+
+		expect(pickModel).toHaveBeenCalledTimes(1);
+		expect(pickThinking).toHaveBeenCalledTimes(1);
+	});
+
+	it("forwards a commands update as a commands message", async () => {
+		const fake = new BridgeFakeClient();
+		const controller = await makeController(fake);
+		const { webview, posted, send } = makeWebview();
+		connectWebview(webview as any, controller);
+		send({ type: "ready" });
+
+		// /reload triggers a commands update after re-fetching get_commands.
+		await controller.submit("/reload");
+		expect(posted.some((m) => m.type === "commands")).toBe(true);
+	});
+
+	it("re-snapshots on a resync update (e.g. after /new)", async () => {
+		const fake = new BridgeFakeClient();
+		const controller = await makeController(fake);
+		const { webview, posted, send } = makeWebview();
+		connectWebview(webview as any, controller);
+		send({ type: "ready" });
+		const snapshotsBefore = posted.filter((m) => m.type === "snapshot").length;
+
+		await controller.submit("/new");
+		const snapshotsAfter = posted.filter((m) => m.type === "snapshot").length;
+		expect(snapshotsAfter).toBeGreaterThan(snapshotsBefore);
 	});
 
 	it("stops streaming to the webview after the disposable is disposed", async () => {

--- a/test.sh
+++ b/test.sh
@@ -1,6 +1,16 @@
 #!/usr/bin/env bash
 set -e
 
+# Git exports per-invocation env vars (GIT_DIR, GIT_INDEX_FILE, GIT_WORK_TREE,
+# GIT_PREFIX, …) into hook subprocesses. When this harness runs from the husky
+# pre-commit hook, the whole test suite would inherit them and every
+# git-dependent test (git-update, chdir, tools/.gitignore) would target the
+# outer repo's pending-commit index instead of its own temp repos — failing
+# under the hook while passing standalone and in CI. Strip them so `bash
+# test.sh` behaves identically whether invoked directly or from a git hook.
+unset GIT_DIR GIT_INDEX_FILE GIT_WORK_TREE GIT_PREFIX GIT_COMMON_DIR \
+	GIT_OBJECT_DIRECTORY GIT_CONFIG GIT_CONFIG_GLOBAL GIT_CONFIG_SYSTEM
+
 # Skip local LLM tests (ollama, lmstudio) — no local server expected in CI/hooks
 export DREB_NO_LOCAL_LLM=1
 


### PR DESCRIPTION
Closes #15

VSCode extension **Phase 2**: wire up dreb's built-in slash commands (dashboard/RPC parity) and add a TUI-parity status display (model · thinking level · cost · context usage) with runtime **model** and **thinking-level** selection.

Targets the `vscode` integration branch. Implementation plan posted as a comment below.
