### PR TITLE
VSCode extension Phase 3: change review — per-turn snapshot + per-hunk keep/reject

### DIFF
--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -4,7 +4,7 @@ A native chat client for the [dreb](https://github.com/aebrer/dreb) coding agent
 
 This package is modeled on `@dreb/dashboard`: an extension **host** owns the RPC child and the authoritative transcript state, and a **webview** renders it. The only transport difference is that the dashboard's HTTP+SSE layer is replaced by VS Code's `postMessage` bridge.
 
-> Status: **Phase 2** (built-in slash commands + TUI-parity status header) on top of the Phase 0 + 1 foundation and MVP chat. See the [tracking issue](https://github.com/Hrovatin/dreb/issues/12) for the roadmap.
+> Status: **Phase 3** (change review — per-turn git snapshot + per-hunk keep/reject) on top of Phase 2 (built-in slash commands + TUI-parity status header) and the Phase 0 + 1 foundation. See the [tracking issue](https://github.com/Hrovatin/dreb/issues/12) for the roadmap.
 
 ## Architecture
 
@@ -14,7 +14,7 @@ src/
     protocol.ts       host ↔ webview message envelopes (no @dreb import)
     projection.ts     RPC events → transcript render model (pure, tested)
   host/          # extension host (Node, ESM) — compiled with tsgo
-    extension.ts        activate(): registers `dreb.openChat`, owns the panel
+    extension.ts        activate(): registers `dreb.openChat` + review commands
     session-controller.ts  one RpcClient + authoritative transcript per session
     webview-bridge.ts   postMessage wiring + webview HTML/CSP
     cli-path.ts         resolve the dreb CLI (setting → dependency)
@@ -22,11 +22,17 @@ src/
     session-registry.ts single-live-panel lifecycle (reentrancy-safe, pure, tested)
     host-ui.ts          native-prompt port (quick pick / input / dialogs); vscode-free
     vscode-host-ui.ts   the real `HostUi` backed by `vscode.window`
+    git-snapshot.ts     per-turn baseline capture + diff + `git apply -R` (pure node, tested)
+    diff-hunks.ts       unified-diff hunk parsing / slicing (pure, tested)
+    review-model.ts     change-review cycle + accept state (pure, tested)
+    review-ui.ts        SCM / quick-diff / diff-viewer port; vscode-free
+    vscode-review-ui.ts the real `ReviewUi` backed by `vscode.scm`
   shared/
     format.ts           status-header + `/session` display formatters (pure, tested)
   webview/       # SolidJS UI — bundled with Vite → dist/webview
     app.tsx             transcript, collapsible activity box, composer, needs-input,
-                        and the status header (model · thinking · cost · ctx)
+                        the status header (model · thinking · cost · ctx), and the
+                        change-review bar
 ```
 
 - The host keeps the authoritative `TranscriptState`. On (re)load the webview announces `ready` and receives a full snapshot, so recreating the webview never loses the conversation.
@@ -55,6 +61,17 @@ Commands owned by later phases (`/settings`, `/scoped-models`, `/fork`, `/tree`,
 ## Status header
 
 The webview renders a compact header mirroring the TUI: **model · thinking level · cost · context usage**. Cost shows the session total (`$0.123`, `+ (sub)` on a subscription) and, when known, the larger daily total (`, today $1.23`); context usage shows `ctx 42%`. All formatting lives in the pure `shared/format.ts` so the header renders costs consistently.
+
+## Change review
+
+Because the agent runs out-of-process and writes edits straight to disk, the extension can't hold changes in an unsaved overlay. Instead it **snapshots a git baseline before each turn** and reviews the working tree against it (the non-interactive analogue of `git restore -p`):
+
+- **Baseline** — before the first turn of a review cycle, `git-snapshot.ts` captures the working tree into a git tree object via a *throwaway index*, so neither your real index nor working tree is touched. Because it snapshots the tree *as-is* (including your own uncommitted edits), later diffs isolate **only** what the agent changed. Changes **compound** across turns until you accept or revert.
+- **Detection** — after each turn (`agent_end`), a baseline→current tree diff lists the changed files (adds/mods/deletes, git-detected — so `bash`-tool writes count too), shown in a **change-review bar** in the webview and an SCM group **"dreb — pending review"** with inline change gutters (via a `QuickDiffProvider` pointed at the baseline).
+- **Keep / reject** — the `dreb.review.*` commands accept a file (clear its marker — **no commit**), accept/revert all, revert a whole file to baseline, or **reject the hunk at the cursor** (`dreb.review.rejectHunkAtCursor`, which drives `git apply --reverse` on exactly that hunk). Rejecting a hunk restores only that region and never clobbers your own pre-existing edits.
+
+Review is host-authoritative, so it survives webview reload. Outside a git repository it degrades gracefully (disabled, no snapshots). The pure logic (`review-model.ts`, `diff-hunks.ts`) and the git plumbing (`git-snapshot.ts`, against real temp repos) are unit-tested; all `vscode` SCM/diff calls are isolated behind the `ReviewUi` port.
+
 
 ## Requirements
 

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -20,8 +20,81 @@
 				"command": "dreb.openChat",
 				"title": "Open Chat",
 				"category": "dreb"
+			},
+			{
+				"command": "dreb.review.openDiff",
+				"title": "Open Diff",
+				"category": "dreb",
+				"icon": "$(diff)"
+			},
+			{
+				"command": "dreb.review.acceptFile",
+				"title": "Accept Change",
+				"category": "dreb",
+				"icon": "$(check)"
+			},
+			{
+				"command": "dreb.review.revertFile",
+				"title": "Revert Change",
+				"category": "dreb",
+				"icon": "$(discard)"
+			},
+			{
+				"command": "dreb.review.acceptAll",
+				"title": "Accept All Changes",
+				"category": "dreb",
+				"icon": "$(check-all)"
+			},
+			{
+				"command": "dreb.review.revertAll",
+				"title": "Revert All Changes",
+				"category": "dreb",
+				"icon": "$(discard)"
+			},
+			{
+				"command": "dreb.review.rejectHunkAtCursor",
+				"title": "Reject Hunk at Cursor",
+				"category": "dreb"
 			}
 		],
+		"menus": {
+			"scm/title": [
+				{
+					"command": "dreb.review.acceptAll",
+					"when": "scmProvider == drebReview",
+					"group": "navigation@1"
+				},
+				{
+					"command": "dreb.review.revertAll",
+					"when": "scmProvider == drebReview",
+					"group": "navigation@2"
+				}
+			],
+			"scm/resourceState/context": [
+				{
+					"command": "dreb.review.openDiff",
+					"when": "scmProvider == drebReview",
+					"group": "inline@1"
+				},
+				{
+					"command": "dreb.review.acceptFile",
+					"when": "scmProvider == drebReview",
+					"group": "inline@2"
+				},
+				{
+					"command": "dreb.review.revertFile",
+					"when": "scmProvider == drebReview",
+					"group": "inline@3"
+				}
+			],
+			"editor/context": [
+				{
+					"command": "dreb.review.rejectHunkAtCursor",
+					"when": "editorTextFocus",
+					"group": "dreb@1"
+				}
+			]
+		},
 		"configuration": {
 			"title": "dreb",
 			"properties": {

--- a/packages/vscode/src/host/diff-hunks.ts
+++ b/packages/vscode/src/host/diff-hunks.ts
@@ -1,0 +1,97 @@
+/**
+ * Pure parsing of unified `git diff` output into hunks, plus the small helpers
+ * the change-review feature needs: reconstruct a single-hunk patch (so
+ * `git apply --reverse` can undo exactly one hunk) and map an editor line to the
+ * hunk that contains it (so "reject the hunk at my cursor" works).
+ *
+ * No `vscode`, no `node`, no git — this is string work, unit-tested in isolation
+ * (`test/diff-hunks.test.ts`). The git process orchestration that produces the
+ * diffs and applies the reverse patches lives in `git-snapshot.ts`.
+ */
+
+/** One hunk of a unified diff. `lines` includes the `@@` header and its body. */
+export interface Hunk {
+	/** The raw `@@ -a,b +c,d @@ …` header line. */
+	header: string;
+	/** 1-based start line of this hunk in the *new* (current) file. */
+	newStart: number;
+	/** Number of lines this hunk spans in the *new* file. */
+	newLines: number;
+	/** All raw lines of the hunk, header first, in original order. */
+	lines: string[];
+}
+
+/** Parsed unified diff for a single file. */
+export interface ParsedFileDiff {
+	/** Header lines preceding the first hunk (`diff --git`, `index`, `---`, `+++`). */
+	fileHeader: string[];
+	hunks: Hunk[];
+	/** True when git reported a binary difference (no textual hunks available). */
+	binary: boolean;
+}
+
+const HUNK_RE = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/;
+
+/**
+ * Parse a single-file unified diff (the output of `git diff <a> <b> -- <path>`).
+ * Returns the pre-hunk header lines, each hunk, and whether git reported the
+ * file as binary. A trailing newline is ignored; blank input yields no hunks.
+ */
+export function parseFileDiff(diff: string): ParsedFileDiff {
+	const all = diff.split("\n");
+	// Drop a single trailing empty element from a final newline.
+	if (all.length > 0 && all[all.length - 1] === "") all.pop();
+
+	const binary = all.some((l) => l.startsWith("Binary files ") || l === "GIT binary patch");
+
+	const fileHeader: string[] = [];
+	const hunks: Hunk[] = [];
+	let current: Hunk | undefined;
+
+	for (const line of all) {
+		const match = HUNK_RE.exec(line);
+		if (match) {
+			current = {
+				header: line,
+				newStart: Number(match[1]),
+				newLines: match[2] === undefined ? 1 : Number(match[2]),
+				lines: [line],
+			};
+			hunks.push(current);
+			continue;
+		}
+		if (current) {
+			current.lines.push(line);
+		} else {
+			fileHeader.push(line);
+		}
+	}
+
+	return { fileHeader, hunks, binary: binary && hunks.length === 0 };
+}
+
+/**
+ * Reconstruct a minimal, apply-able patch containing only the hunk at `index`
+ * (file header + that one hunk). Feed this to `git apply --reverse` to undo a
+ * single hunk. Returns undefined when the index is out of range.
+ */
+export function sliceHunkPatch(parsed: ParsedFileDiff, index: number): string | undefined {
+	const hunk = parsed.hunks[index];
+	if (!hunk) return undefined;
+	return `${[...parsed.fileHeader, ...hunk.lines].join("\n")}\n`;
+}
+
+/**
+ * Index of the hunk whose *new-file* line range contains `line` (1-based), or
+ * undefined when no hunk covers it. A zero-length hunk (`newLines === 0`, a pure
+ * deletion) matches the line at its `newStart` so a cursor parked there can
+ * still reject it.
+ */
+export function hunkIndexForLine(hunks: readonly Hunk[], line: number): number | undefined {
+	for (let i = 0; i < hunks.length; i++) {
+		const h = hunks[i];
+		const span = Math.max(h.newLines, 1);
+		if (line >= h.newStart && line <= h.newStart + span - 1) return i;
+	}
+	return undefined;
+}

--- a/packages/vscode/src/host/extension.ts
+++ b/packages/vscode/src/host/extension.ts
@@ -72,7 +72,7 @@ export function activate(context: vscode.ExtensionContext): void {
 			const editor = vscode.window.activeTextEditor;
 			const controller = registry.active?.controller;
 			if (!editor || !controller) return;
-			const path = toRepoRelative(controller.cwd, editor.document.uri);
+			const path = toRepoRelative(controller.gitRoot, editor.document.uri);
 			if (path === undefined) {
 				vscode.window.showInformationMessage("dreb: the active file is not under change review.");
 				return;
@@ -93,7 +93,7 @@ function resolveReviewTarget(arg: unknown): { controller: SessionController; pat
 	if (typeof arg === "string") return { controller, path: arg };
 	const uri = (arg as { resourceUri?: vscode.Uri })?.resourceUri;
 	if (!uri) return undefined;
-	const path = toRepoRelative(controller.cwd, uri);
+	const path = toRepoRelative(controller.gitRoot, uri);
 	return path === undefined ? undefined : { controller, path };
 }
 

--- a/packages/vscode/src/host/extension.ts
+++ b/packages/vscode/src/host/extension.ts
@@ -10,17 +10,21 @@
  */
 
 import { homedir } from "node:os";
+import { relative, sep } from "node:path";
 import * as vscode from "vscode";
 import { resolveCliPath } from "./cli-path.js";
+import type { ReviewUi } from "./review-ui.js";
 import { SessionController } from "./session-controller.js";
 import { SessionRegistry } from "./session-registry.js";
 import { createVscodeHostUi } from "./vscode-host-ui.js";
+import { createVscodeReviewUi } from "./vscode-review-ui.js";
 import { connectWebview, getWebviewHtml } from "./webview-bridge.js";
 
 interface ChatSession {
 	panel: vscode.WebviewPanel;
 	controller: SessionController;
 	connection: vscode.Disposable;
+	reviewUi: ReviewUi & vscode.Disposable;
 }
 
 /** Enforces the single-live-panel invariant and the reentrancy-safe open /
@@ -32,6 +36,7 @@ const registry = new SessionRegistry<ChatSession>({
 	teardown: async (s) => {
 		s.connection.dispose();
 		await s.controller.dispose();
+		s.reviewUi.dispose();
 		s.panel.dispose();
 	},
 });
@@ -45,7 +50,60 @@ export function activate(context: vscode.ExtensionContext): void {
 					vscode.window.showErrorMessage(`dreb: failed to open chat — ${errorText(err)}`);
 				});
 		}),
+		vscode.commands.registerCommand("dreb.review.openDiff", (arg?: unknown) => {
+			const resolved = resolveReviewTarget(arg);
+			if (resolved) void resolved.controller.reviewOpenDiff(resolved.path);
+		}),
+		vscode.commands.registerCommand("dreb.review.acceptFile", (arg?: unknown) => {
+			const resolved = resolveReviewTarget(arg);
+			if (resolved) void resolved.controller.reviewAcceptFile(resolved.path);
+		}),
+		vscode.commands.registerCommand("dreb.review.revertFile", (arg?: unknown) => {
+			const resolved = resolveReviewTarget(arg);
+			if (resolved) void resolved.controller.reviewRevertFile(resolved.path);
+		}),
+		vscode.commands.registerCommand("dreb.review.acceptAll", () => {
+			void registry.active?.controller.reviewAcceptAll();
+		}),
+		vscode.commands.registerCommand("dreb.review.revertAll", () => {
+			void registry.active?.controller.reviewRevertAll();
+		}),
+		vscode.commands.registerCommand("dreb.review.rejectHunkAtCursor", async () => {
+			const editor = vscode.window.activeTextEditor;
+			const controller = registry.active?.controller;
+			if (!editor || !controller) return;
+			const path = toRepoRelative(controller.cwd, editor.document.uri);
+			if (path === undefined) {
+				vscode.window.showInformationMessage("dreb: the active file is not under change review.");
+				return;
+			}
+			const line = editor.selection.active.line + 1;
+			const ok = await controller.reviewRejectHunkAtLine(path, line);
+			if (!ok) vscode.window.showInformationMessage("dreb: no reviewable hunk at the cursor.");
+		}),
 	);
+}
+
+/** Resolve a review command argument (a repo-relative path string from the
+ * webview / SCM `command`, or a `SourceControlResourceState` from an SCM menu)
+ * to the active controller + repo-relative path. */
+function resolveReviewTarget(arg: unknown): { controller: SessionController; path: string } | undefined {
+	const controller = registry.active?.controller;
+	if (!controller) return undefined;
+	if (typeof arg === "string") return { controller, path: arg };
+	const uri = (arg as { resourceUri?: vscode.Uri })?.resourceUri;
+	if (!uri) return undefined;
+	const path = toRepoRelative(controller.cwd, uri);
+	return path === undefined ? undefined : { controller, path };
+}
+
+/** A file URI's path relative to `cwd` (forward slashes), or undefined if it is
+ * not under `cwd`. */
+function toRepoRelative(cwd: string, uri: vscode.Uri): string | undefined {
+	if (uri.scheme !== "file") return undefined;
+	const rel = relative(cwd, uri.fsPath);
+	if (rel.length === 0 || rel.startsWith("..")) return undefined;
+	return rel.split(sep).join("/");
 }
 
 export async function deactivate(): Promise<void> {
@@ -61,11 +119,13 @@ function createSession(context: vscode.ExtensionContext): ChatSession {
 	const cwd = workspaceCwd();
 	const cli = resolveCliPath({ configuredPath: config.get<string>("cliPath") });
 
+	const reviewUi = createVscodeReviewUi(cwd);
 	const controller = new SessionController({
 		cwd,
 		cliPath: cli.ok ? cli.path : "",
 		args: buildArgs(config),
 		ui: createVscodeHostUi(),
+		review: reviewUi,
 		logger: (line) => console.warn(`[dreb] ${line}`),
 	});
 
@@ -78,7 +138,7 @@ function createSession(context: vscode.ExtensionContext): ChatSession {
 	const connection = connectWebview(panel.webview, controller);
 	panel.webview.html = getWebviewHtml(panel.webview, context.extensionUri, makeNonce());
 
-	const session: ChatSession = { panel, controller, connection };
+	const session: ChatSession = { panel, controller, connection, reviewUi };
 	panel.onDidDispose(() => {
 		void registry.disposeSession(session);
 	});

--- a/packages/vscode/src/host/git-snapshot.ts
+++ b/packages/vscode/src/host/git-snapshot.ts
@@ -270,15 +270,15 @@ function lstatSafe(p: string): ReturnType<typeof lstatSync> | undefined {
  * (git error, non-blob, or truncated read) — a failed read must never be
  * mistaken for "absent from baseline" and trigger a destructive delete/truncate.
  *
- * The working-tree entry is inspected with `lstat` (never following symlinks)
- * and removed before we recreate it, so `writeFileSync` always creates a fresh
- * regular file rather than writing in place. This matters when the agent's turn
- * replaced the path with a symlink (whose `'w'` write would otherwise follow the
- * link and clobber its target — possibly a file outside the repository) or with
- * a hard link (an in-place `'w'` truncate would corrupt every other name sharing
- * that inode, again possibly outside the repository). In the "absent" branch we
- * likewise remove any lingering entry (including a broken symlink, which
- * `existsSync` would have mis-reported as already gone).
+ * The working-tree entry is inspected with `lstat` (never following symlinks).
+ * We remove it before recreating the file only when leaving it in place would
+ * be unsafe: a symlink (whose `'w'` write would follow the link and clobber its
+ * target — possibly a file outside the repository) or a hard link (`nlink > 1`,
+ * whose in-place `'w'` truncate would corrupt every other name sharing that
+ * inode, again possibly outside the repository). An ordinary, singly-linked
+ * regular file is overwritten in place so its mode bits (e.g. the exec bit) are
+ * preserved. In the "absent" branch we remove any lingering entry (including a
+ * broken symlink, which `existsSync` would have mis-reported as already gone).
  */
 export function revertFile(cwd: string, baselineTree: string, path: string): boolean {
 	const root = findGitRoot(cwd);
@@ -292,10 +292,11 @@ export function revertFile(cwd: string, baselineTree: string, path: string): boo
 			if (entry) unlinkSync(abs);
 			return true;
 		}
-		// Always drop the existing entry first so we write a fresh regular file
-		// in place: this avoids following a symlink to (or truncating a hard link
-		// shared with) a file outside the repository.
-		if (entry) unlinkSync(abs);
+		// Drop the entry first only when writing in place would be unsafe: a
+		// symlink (would follow the link) or a hard link (would truncate a shared
+		// inode). An ordinary single-link regular file is overwritten in place so
+		// its mode bits are preserved.
+		if (entry && (!entry.isFile() || entry.nlink > 1)) unlinkSync(abs);
 		writeFileSync(abs, read.buf);
 		return true;
 	} catch {

--- a/packages/vscode/src/host/git-snapshot.ts
+++ b/packages/vscode/src/host/git-snapshot.ts
@@ -270,12 +270,15 @@ function lstatSafe(p: string): ReturnType<typeof lstatSync> | undefined {
  * (git error, non-blob, or truncated read) — a failed read must never be
  * mistaken for "absent from baseline" and trigger a destructive delete/truncate.
  *
- * The working-tree entry is inspected with `lstat` (never following symlinks):
- * if the agent's turn replaced the path with a symlink, we remove the link
- * itself before writing, so `writeFileSync`'s `'w'` flag can never follow it and
- * clobber the link's target — which could be a file outside the repository. In
- * the "absent" branch we likewise remove any lingering entry (including a broken
- * symlink, which `existsSync` would have mis-reported as already gone).
+ * The working-tree entry is inspected with `lstat` (never following symlinks)
+ * and removed before we recreate it, so `writeFileSync` always creates a fresh
+ * regular file rather than writing in place. This matters when the agent's turn
+ * replaced the path with a symlink (whose `'w'` write would otherwise follow the
+ * link and clobber its target — possibly a file outside the repository) or with
+ * a hard link (an in-place `'w'` truncate would corrupt every other name sharing
+ * that inode, again possibly outside the repository). In the "absent" branch we
+ * likewise remove any lingering entry (including a broken symlink, which
+ * `existsSync` would have mis-reported as already gone).
  */
 export function revertFile(cwd: string, baselineTree: string, path: string): boolean {
 	const root = findGitRoot(cwd);
@@ -289,9 +292,10 @@ export function revertFile(cwd: string, baselineTree: string, path: string): boo
 			if (entry) unlinkSync(abs);
 			return true;
 		}
-		// Never write through a symlink: if the entry is anything other than a
-		// regular file, drop it first so we create a fresh regular file in place.
-		if (entry && !entry.isFile()) unlinkSync(abs);
+		// Always drop the existing entry first so we write a fresh regular file
+		// in place: this avoids following a symlink to (or truncating a hard link
+		// shared with) a file outside the repository.
+		if (entry) unlinkSync(abs);
 		writeFileSync(abs, read.buf);
 		return true;
 	} catch {

--- a/packages/vscode/src/host/git-snapshot.ts
+++ b/packages/vscode/src/host/git-snapshot.ts
@@ -1,0 +1,219 @@
+/**
+ * git-snapshot — host-side git operations backing the change-review feature.
+ *
+ * The dreb agent runs out-of-process and writes edits straight to disk, so the
+ * extension cannot hold changes in an unsaved overlay the way an in-process
+ * editor (e.g. Copilot) can. Instead we snapshot a **baseline tree** *before*
+ * the agent's turn and diff/revert the working tree against it:
+ *
+ *   captureTree()  → a git tree object of the current working tree, taken via a
+ *                    throwaway temp index so neither the user's index nor their
+ *                    working tree is touched. Because it snapshots the working
+ *                    tree *as-is* (including the user's own uncommitted edits),
+ *                    later diffs isolate only what the agent changed.
+ *   changedFiles() → baseline-tree → current-tree name-status.
+ *   fileDiff()     → unified diff for one path (real `a/… b/…` headers so the
+ *                    reverse patch applies to the working file).
+ *   revertHunk()   → `git apply --reverse` of exactly one hunk (the
+ *                    non-interactive equivalent of `git restore -p`).
+ *   revertFile()   → restore a path to its baseline content (or delete it).
+ *
+ * No `vscode` import — pure node + git, exercised against real temp repos in
+ * `test/git-snapshot.test.ts`. Mirrors the `spawnSync("git", …, { env: gitEnv })`
+ * pattern used by `@dreb/coding-agent`'s `git-repo-state.ts`.
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync, statSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { parseFileDiff, sliceHunkPatch } from "./diff-hunks.js";
+import type { ChangedFile } from "./review-model.js";
+
+/** Strip inherited GIT_* env so a hook-set GIT_DIR/GIT_INDEX_FILE can't redirect
+ * us to the wrong repo (mirrors `@dreb/coding-agent`'s `gitEnv`). */
+function gitEnv(): NodeJS.ProcessEnv {
+	const { GIT_DIR: _d, GIT_INDEX_FILE: _i, GIT_WORK_TREE: _w, ...env } = process.env;
+	return env;
+}
+
+/** Walk upward for a `.git` dir/file; returns the repo root or null. */
+export function findGitRoot(cwd: string): string | null {
+	let current = resolve(cwd);
+	while (true) {
+		const gitPath = join(current, ".git");
+		if (existsSync(gitPath)) {
+			try {
+				const st = statSync(gitPath);
+				if (st.isDirectory() || st.isFile()) return current;
+			} catch {
+				// keep walking
+			}
+		}
+		const parent = resolve(current, "..");
+		if (parent === current) return null;
+		current = parent;
+	}
+}
+
+/** Whether `cwd` is inside a git working tree. */
+export function isGitRepo(cwd: string): boolean {
+	return findGitRoot(cwd) !== null;
+}
+
+interface GitResult {
+	status: number | null;
+	stdout: string;
+	stderr: string;
+}
+
+function runGit(cwd: string, args: string[], opts?: { indexFile?: string; input?: string }): GitResult {
+	const env = gitEnv();
+	if (opts?.indexFile) env.GIT_INDEX_FILE = opts.indexFile;
+	const result = spawnSync("git", args, {
+		cwd,
+		encoding: "utf8",
+		timeout: 15000,
+		input: opts?.input,
+		env,
+	});
+	return { status: result.status, stdout: result.stdout ?? "", stderr: result.stderr ?? "" };
+}
+
+/** Read a path's bytes from a tree, or null when the path is absent from it. */
+function readBlob(cwd: string, tree: string, path: string): Buffer | null {
+	const result = spawnSync("git", ["cat-file", "blob", `${tree}:${path}`], {
+		cwd,
+		timeout: 15000,
+		env: gitEnv(),
+		maxBuffer: 64 * 1024 * 1024,
+	});
+	if (result.status !== 0) return null;
+	return result.stdout as Buffer;
+}
+
+/**
+ * Snapshot the current working tree into a git tree object via a throwaway index
+ * (so the user's real index/working tree are untouched). Returns the tree SHA,
+ * or null if the snapshot could not be taken (e.g. not a git repo).
+ */
+export function captureTree(cwd: string): string | null {
+	if (!isGitRepo(cwd)) return null;
+	const dir = mkdtempSync(join(tmpdir(), "dreb-review-"));
+	const indexFile = join(dir, "index");
+	try {
+		const add = runGit(cwd, ["add", "-A"], { indexFile });
+		if (add.status !== 0) return null;
+		const write = runGit(cwd, ["write-tree"], { indexFile });
+		if (write.status !== 0) return null;
+		const tree = write.stdout.trim();
+		return tree.length > 0 ? tree : null;
+	} finally {
+		try {
+			rmSync(dir, { recursive: true, force: true });
+		} catch {
+			// best-effort cleanup
+		}
+	}
+}
+
+function mapStatus(code: string): ChangedFile["status"] {
+	if (code.startsWith("A")) return "added";
+	if (code.startsWith("D")) return "deleted";
+	return "modified";
+}
+
+/**
+ * Files that differ between the baseline tree and the current working tree.
+ * Builds a fresh current-tree snapshot so newly created (untracked) files are
+ * included, then diffs tree-to-tree. Hunk counts come from each file's diff;
+ * binary files report a hunk count of 0 and status "binary".
+ */
+export function changedFiles(cwd: string, baselineTree: string): ChangedFile[] {
+	const currentTree = captureTree(cwd);
+	if (currentTree === null) return [];
+	const res = runGit(cwd, ["diff", "--name-status", "-z", baselineTree, currentTree]);
+	if (res.status !== 0 || res.stdout.length === 0) return [];
+	// `-z` output: STATUS\0PATH\0STATUS\0PATH\0…  (renames add an extra path we
+	// don't request via -M, so plain A/M/D pairs are expected).
+	const parts = res.stdout.split("\0").filter((p) => p.length > 0);
+	const files: ChangedFile[] = [];
+	for (let i = 0; i + 1 < parts.length; i += 2) {
+		const code = parts[i];
+		const path = parts[i + 1];
+		const status = mapStatus(code);
+		const { hunks, binary } = fileDiffAgainst(cwd, baselineTree, currentTree, path);
+		files.push({
+			path,
+			status: binary ? "binary" : status,
+			hunkCount: hunks,
+		});
+	}
+	return files;
+}
+
+/** Internal: parsed diff summary for a path between two known trees. */
+function fileDiffAgainst(
+	cwd: string,
+	baselineTree: string,
+	currentTree: string,
+	path: string,
+): { diff: string; hunks: number; binary: boolean } {
+	const res = runGit(cwd, ["diff", baselineTree, currentTree, "--", path]);
+	const diff = res.stdout;
+	const parsed = parseFileDiff(diff);
+	return { diff, hunks: parsed.hunks.length, binary: parsed.binary };
+}
+
+/**
+ * Unified diff (baseline → current) for a single path, with real `a/… b/…`
+ * headers suitable for `git apply`. Returns the diff text and whether git
+ * reported it binary.
+ */
+export function fileDiff(cwd: string, baselineTree: string, path: string): { diff: string; binary: boolean } {
+	const currentTree = captureTree(cwd);
+	if (currentTree === null) return { diff: "", binary: false };
+	const { diff, binary } = fileDiffAgainst(cwd, baselineTree, currentTree, path);
+	return { diff, binary };
+}
+
+/** The baseline content of a path (for the diff viewer's left side), or null
+ * when the path did not exist in the baseline (a file the agent created). */
+export function baselineContent(cwd: string, baselineTree: string, path: string): string | null {
+	const buf = readBlob(cwd, baselineTree, path);
+	return buf === null ? null : buf.toString("utf8");
+}
+
+/**
+ * Reverse exactly one hunk of a file's baseline→current diff, undoing that hunk
+ * in the working file while leaving the others intact. Returns true on success.
+ */
+export function revertHunk(cwd: string, baselineTree: string, path: string, hunkIndex: number): boolean {
+	const { diff, binary } = fileDiff(cwd, baselineTree, path);
+	if (binary || diff.length === 0) return false;
+	const parsed = parseFileDiff(diff);
+	const patch = sliceHunkPatch(parsed, hunkIndex);
+	if (patch === undefined) return false;
+	const res = runGit(cwd, ["apply", "--reverse", "--recount", "-p1", "-"], { input: patch });
+	return res.status === 0;
+}
+
+/**
+ * Restore a path to its baseline content: rewrite the file with the baseline
+ * bytes, or delete it when it did not exist in the baseline. Returns true on
+ * success (including a no-op delete of an already-absent file).
+ */
+export function revertFile(cwd: string, baselineTree: string, path: string): boolean {
+	const abs = join(cwd, path);
+	const buf = readBlob(cwd, baselineTree, path);
+	try {
+		if (buf === null) {
+			if (existsSync(abs)) unlinkSync(abs);
+			return true;
+		}
+		writeFileSync(abs, buf);
+		return true;
+	} catch {
+		return false;
+	}
+}

--- a/packages/vscode/src/host/git-snapshot.ts
+++ b/packages/vscode/src/host/git-snapshot.ts
@@ -80,31 +80,72 @@ function runGit(cwd: string, args: string[], opts?: { indexFile?: string; input?
 	return { status: result.status, stdout: result.stdout ?? "", stderr: result.stderr ?? "" };
 }
 
-/** Read a path's bytes from a tree, or null when the path is absent from it. */
-function readBlob(cwd: string, tree: string, path: string): Buffer | null {
-	const result = spawnSync("git", ["cat-file", "blob", `${tree}:${path}`], {
-		cwd,
+/**
+ * The outcome of reading a path's baseline content, distinguishing the three
+ * cases that `revertFile` must NOT conflate (a naive "null means absent" read
+ * would delete the working file on any git error):
+ *   content — the path is a blob in the baseline; `buf` is its full bytes.
+ *   absent  — the path genuinely did not exist in the baseline (agent created
+ *             it); reverting means deleting the working file.
+ *   error   — git failed, the object isn't a plain blob, or the read was
+ *             truncated; the caller must leave the working file untouched.
+ */
+type BlobRead = { kind: "content"; buf: Buffer } | { kind: "absent" } | { kind: "error" };
+
+/**
+ * Read a path's baseline bytes, cleanly separating genuine absence from a git
+ * failure or a short/truncated read. Presence and the exact blob size come from
+ * `ls-tree` (empty output = absent, non-zero exit = error); the bytes then come
+ * from `cat-file blob`, and we require the byte count to match the advertised
+ * size so a `maxBuffer`/pipe truncation surfaces as an error rather than
+ * silently corrupting the file on restore.
+ */
+function readBaselineBlob(root: string, tree: string, path: string): BlobRead {
+	const meta = spawnSync("git", ["ls-tree", "-l", "-z", tree, "--", path], {
+		cwd: root,
+		encoding: "utf8",
 		timeout: 15000,
 		env: gitEnv(),
-		maxBuffer: 64 * 1024 * 1024,
 	});
-	if (result.status !== 0) return null;
-	return result.stdout as Buffer;
+	if (meta.error || meta.status !== 0) return { kind: "error" };
+	const line = meta.stdout ?? "";
+	if (line.length === 0) return { kind: "absent" };
+	// `-l -z` line: "<mode> <type> <sha> <size>\t<path>\0" (size right-aligned;
+	// a non-blob subtree reports size "-").
+	const match = /^\S+ +\S+ +\S+ +(\d+)\t/.exec(line);
+	if (!match) return { kind: "error" };
+	const size = Number(match[1]);
+	const res = spawnSync("git", ["cat-file", "blob", `${tree}:${path}`], {
+		cwd: root,
+		timeout: 15000,
+		env: gitEnv(),
+		maxBuffer: 512 * 1024 * 1024,
+	});
+	if (res.error || res.status !== 0) return { kind: "error" };
+	const buf = res.stdout as Buffer;
+	if (buf.length !== size) return { kind: "error" };
+	return { kind: "content", buf };
 }
 
 /**
  * Snapshot the current working tree into a git tree object via a throwaway index
  * (so the user's real index/working tree are untouched). Returns the tree SHA,
  * or null if the snapshot could not be taken (e.g. not a git repo).
+ *
+ * All git operations run from the repository root (resolved via `findGitRoot`),
+ * so the resulting tree — and every path derived from diffing it — is
+ * repo-root-relative, regardless of whether the VS Code workspace is the repo
+ * root or a subdirectory of it.
  */
 export function captureTree(cwd: string): string | null {
-	if (!isGitRepo(cwd)) return null;
+	const root = findGitRoot(cwd);
+	if (root === null) return null;
 	const dir = mkdtempSync(join(tmpdir(), "dreb-review-"));
 	const indexFile = join(dir, "index");
 	try {
-		const add = runGit(cwd, ["add", "-A"], { indexFile });
+		const add = runGit(root, ["add", "-A"], { indexFile });
 		if (add.status !== 0) return null;
-		const write = runGit(cwd, ["write-tree"], { indexFile });
+		const write = runGit(root, ["write-tree"], { indexFile });
 		if (write.status !== 0) return null;
 		const tree = write.stdout.trim();
 		return tree.length > 0 ? tree : null;
@@ -130,19 +171,24 @@ function mapStatus(code: string): ChangedFile["status"] {
  * binary files report a hunk count of 0 and status "binary".
  */
 export function changedFiles(cwd: string, baselineTree: string): ChangedFile[] {
-	const currentTree = captureTree(cwd);
+	const root = findGitRoot(cwd);
+	if (root === null) return [];
+	const currentTree = captureTree(root);
 	if (currentTree === null) return [];
-	const res = runGit(cwd, ["diff", "--name-status", "-z", baselineTree, currentTree]);
+	// `--no-renames` keeps the `-z` stream to clean STATUS\0PATH pairs. Without
+	// it, git's default rename detection (diff.renames, on since 2.9) emits a
+	// three-token `R###\0old\0new` record that would desync the pair-wise parse
+	// below and garble every subsequent entry.
+	const res = runGit(root, ["diff", "--no-renames", "--name-status", "-z", baselineTree, currentTree]);
 	if (res.status !== 0 || res.stdout.length === 0) return [];
-	// `-z` output: STATUS\0PATH\0STATUS\0PATH\0…  (renames add an extra path we
-	// don't request via -M, so plain A/M/D pairs are expected).
+	// `-z` output: STATUS\0PATH\0STATUS\0PATH\0…
 	const parts = res.stdout.split("\0").filter((p) => p.length > 0);
 	const files: ChangedFile[] = [];
 	for (let i = 0; i + 1 < parts.length; i += 2) {
 		const code = parts[i];
 		const path = parts[i + 1];
 		const status = mapStatus(code);
-		const { hunks, binary } = fileDiffAgainst(cwd, baselineTree, currentTree, path);
+		const { hunks, binary } = fileDiffAgainst(root, baselineTree, currentTree, path);
 		files.push({
 			path,
 			status: binary ? "binary" : status,
@@ -152,14 +198,15 @@ export function changedFiles(cwd: string, baselineTree: string): ChangedFile[] {
 	return files;
 }
 
-/** Internal: parsed diff summary for a path between two known trees. */
+/** Internal: parsed diff summary for a path between two known trees. `root` must
+ * be the repository root so the repo-root-relative `path` pathspec resolves. */
 function fileDiffAgainst(
-	cwd: string,
+	root: string,
 	baselineTree: string,
 	currentTree: string,
 	path: string,
 ): { diff: string; hunks: number; binary: boolean } {
-	const res = runGit(cwd, ["diff", baselineTree, currentTree, "--", path]);
+	const res = runGit(root, ["diff", "--no-renames", baselineTree, currentTree, "--", path]);
 	const diff = res.stdout;
 	const parsed = parseFileDiff(diff);
 	return { diff, hunks: parsed.hunks.length, binary: parsed.binary };
@@ -171,17 +218,22 @@ function fileDiffAgainst(
  * reported it binary.
  */
 export function fileDiff(cwd: string, baselineTree: string, path: string): { diff: string; binary: boolean } {
-	const currentTree = captureTree(cwd);
+	const root = findGitRoot(cwd);
+	if (root === null) return { diff: "", binary: false };
+	const currentTree = captureTree(root);
 	if (currentTree === null) return { diff: "", binary: false };
-	const { diff, binary } = fileDiffAgainst(cwd, baselineTree, currentTree, path);
+	const { diff, binary } = fileDiffAgainst(root, baselineTree, currentTree, path);
 	return { diff, binary };
 }
 
 /** The baseline content of a path (for the diff viewer's left side), or null
- * when the path did not exist in the baseline (a file the agent created). */
+ * when the path did not exist in the baseline (a file the agent created) or
+ * could not be read. */
 export function baselineContent(cwd: string, baselineTree: string, path: string): string | null {
-	const buf = readBlob(cwd, baselineTree, path);
-	return buf === null ? null : buf.toString("utf8");
+	const root = findGitRoot(cwd);
+	if (root === null) return null;
+	const read = readBaselineBlob(root, baselineTree, path);
+	return read.kind === "content" ? read.buf.toString("utf8") : null;
 }
 
 /**
@@ -189,29 +241,36 @@ export function baselineContent(cwd: string, baselineTree: string, path: string)
  * in the working file while leaving the others intact. Returns true on success.
  */
 export function revertHunk(cwd: string, baselineTree: string, path: string, hunkIndex: number): boolean {
-	const { diff, binary } = fileDiff(cwd, baselineTree, path);
+	const root = findGitRoot(cwd);
+	if (root === null) return false;
+	const { diff, binary } = fileDiff(root, baselineTree, path);
 	if (binary || diff.length === 0) return false;
 	const parsed = parseFileDiff(diff);
 	const patch = sliceHunkPatch(parsed, hunkIndex);
 	if (patch === undefined) return false;
-	const res = runGit(cwd, ["apply", "--reverse", "--recount", "-p1", "-"], { input: patch });
+	const res = runGit(root, ["apply", "--reverse", "--recount", "-p1", "-"], { input: patch });
 	return res.status === 0;
 }
 
 /**
  * Restore a path to its baseline content: rewrite the file with the baseline
  * bytes, or delete it when it did not exist in the baseline. Returns true on
- * success (including a no-op delete of an already-absent file).
+ * success, false without touching the working file when the baseline read fails
+ * (git error, non-blob, or truncated read) — a failed read must never be
+ * mistaken for "absent from baseline" and trigger a destructive delete/truncate.
  */
 export function revertFile(cwd: string, baselineTree: string, path: string): boolean {
-	const abs = join(cwd, path);
-	const buf = readBlob(cwd, baselineTree, path);
+	const root = findGitRoot(cwd);
+	if (root === null) return false;
+	const read = readBaselineBlob(root, baselineTree, path);
+	if (read.kind === "error") return false;
+	const abs = join(root, path);
 	try {
-		if (buf === null) {
+		if (read.kind === "absent") {
 			if (existsSync(abs)) unlinkSync(abs);
 			return true;
 		}
-		writeFileSync(abs, buf);
+		writeFileSync(abs, read.buf);
 		return true;
 	} catch {
 		return false;

--- a/packages/vscode/src/host/git-snapshot.ts
+++ b/packages/vscode/src/host/git-snapshot.ts
@@ -24,7 +24,7 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, rmSync, statSync, unlinkSync, writeFileSync } from "node:fs";
+import { existsSync, lstatSync, mkdtempSync, rmSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { parseFileDiff, sliceHunkPatch } from "./diff-hunks.js";
@@ -252,12 +252,30 @@ export function revertHunk(cwd: string, baselineTree: string, path: string, hunk
 	return res.status === 0;
 }
 
+/** `lstatSync` that returns undefined instead of throwing on a missing entry.
+ * Uses `lstat` (not `stat`) so a symlink — including a broken/dangling one — is
+ * reported as a present entry rather than being followed or mistaken for absent. */
+function lstatSafe(p: string): ReturnType<typeof lstatSync> | undefined {
+	try {
+		return lstatSync(p);
+	} catch {
+		return undefined;
+	}
+}
+
 /**
  * Restore a path to its baseline content: rewrite the file with the baseline
  * bytes, or delete it when it did not exist in the baseline. Returns true on
  * success, false without touching the working file when the baseline read fails
  * (git error, non-blob, or truncated read) — a failed read must never be
  * mistaken for "absent from baseline" and trigger a destructive delete/truncate.
+ *
+ * The working-tree entry is inspected with `lstat` (never following symlinks):
+ * if the agent's turn replaced the path with a symlink, we remove the link
+ * itself before writing, so `writeFileSync`'s `'w'` flag can never follow it and
+ * clobber the link's target — which could be a file outside the repository. In
+ * the "absent" branch we likewise remove any lingering entry (including a broken
+ * symlink, which `existsSync` would have mis-reported as already gone).
  */
 export function revertFile(cwd: string, baselineTree: string, path: string): boolean {
 	const root = findGitRoot(cwd);
@@ -266,10 +284,14 @@ export function revertFile(cwd: string, baselineTree: string, path: string): boo
 	if (read.kind === "error") return false;
 	const abs = join(root, path);
 	try {
+		const entry = lstatSafe(abs);
 		if (read.kind === "absent") {
-			if (existsSync(abs)) unlinkSync(abs);
+			if (entry) unlinkSync(abs);
 			return true;
 		}
+		// Never write through a symlink: if the entry is anything other than a
+		// regular file, drop it first so we create a fresh regular file in place.
+		if (entry && !entry.isFile()) unlinkSync(abs);
 		writeFileSync(abs, read.buf);
 		return true;
 	} catch {

--- a/packages/vscode/src/host/review-model.ts
+++ b/packages/vscode/src/host/review-model.ts
@@ -1,0 +1,74 @@
+/**
+ * ReviewModel — the pure, vscode-free state machine for a change-review cycle.
+ *
+ * A *cycle* begins when the agent first edits files while the review set is
+ * empty: the host captures a baseline snapshot (a git tree ref) and hands it
+ * here. Changes then *compound* across turns until the user accepts or reverts.
+ * This module owns only the review bookkeeping — the baseline ref and which
+ * files the user has explicitly accepted — and derives the "pending review"
+ * list from the git-computed changed files. All git I/O (capture, diff, revert)
+ * lives in `git-snapshot.ts`; all editor UI lives behind the `ReviewUi` port.
+ *
+ * Unit-tested in `test/review-model.test.ts` with no git or vscode.
+ */
+
+import type { ReviewFileDto } from "../shared/protocol.js";
+
+/** A file that differs from the baseline, as computed by `git-snapshot`. */
+export interface ChangedFile {
+	path: string;
+	status: ReviewFileDto["status"];
+	hunkCount: number;
+}
+
+export class ReviewModel {
+	/** The baseline git tree ref for the active cycle, or undefined when idle. */
+	private baseline: string | undefined;
+	/** Files the user accepted this cycle — excluded from the pending list until
+	 * the cycle resets (documented limitation: a later edit to an accepted file
+	 * re-surfaces only after the next accept-all / empty-set reset). */
+	private readonly accepted = new Set<string>();
+
+	/** Whether a review cycle is currently active (a baseline is held). */
+	hasCycle(): boolean {
+		return this.baseline !== undefined;
+	}
+
+	/** The active baseline ref, or undefined when idle. */
+	baselineRef(): string | undefined {
+		return this.baseline;
+	}
+
+	/** Start a cycle with the given baseline ref. No-op if one is already active
+	 * (changes compound against the original baseline). */
+	beginCycle(ref: string): void {
+		if (this.baseline === undefined) this.baseline = ref;
+	}
+
+	/** Derive the pending-review list: changed files minus explicitly accepted
+	 * ones, in stable path order. Empty when no cycle is active. */
+	pending(changed: readonly ChangedFile[]): ReviewFileDto[] {
+		if (this.baseline === undefined) return [];
+		return changed
+			.filter((c) => !this.accepted.has(c.path))
+			.map((c) => ({ path: c.path, status: c.status, hunkCount: c.hunkCount }))
+			.sort((a, b) => a.path.localeCompare(b.path));
+	}
+
+	/** Mark a file accepted (stops showing it in review, no commit). */
+	accept(path: string): void {
+		this.accepted.add(path);
+	}
+
+	/** Undo a prior per-file accept (used when the user reverts that file). */
+	unaccept(path: string): void {
+		this.accepted.delete(path);
+	}
+
+	/** End the cycle entirely: drop the baseline and all accept markers. The next
+	 * agent edit starts a fresh cycle with a new baseline. */
+	reset(): void {
+		this.baseline = undefined;
+		this.accepted.clear();
+	}
+}

--- a/packages/vscode/src/host/review-ui.ts
+++ b/packages/vscode/src/host/review-ui.ts
@@ -1,0 +1,34 @@
+/**
+ * ReviewUi — the vscode-free port through which the (node-only, testable)
+ * SessionController drives the native change-review surface: the quick-diff
+ * baseline provider, the SCM "pending review" group, and the diff viewer. The
+ * real implementation lives in `vscode-review-ui.ts` (which imports `vscode`);
+ * tests and headless use inject the no-op below.
+ *
+ * The controller owns *what* is under review (baseline content + the pending
+ * file list) and pushes it here; this port owns only *how* it is shown.
+ */
+
+import type { ReviewFileDto } from "../shared/protocol.js";
+
+export interface ReviewUi {
+	/** Register/replace the baseline content for a path (left side of the diff /
+	 * quick-diff gutter). `content === null` means the path is new in this cycle
+	 * (baseline is empty). */
+	setBaseline(path: string, content: string | null): void;
+	/** Replace the pending-review file list shown in the SCM group. */
+	setPending(files: ReviewFileDto[]): void;
+	/** Open the baseline↔current diff for a path in the editor. */
+	openDiff(path: string): Promise<void>;
+	/** Clear all review UI (baselines + SCM group), e.g. on accept-all / dispose. */
+	clear(): void;
+}
+
+/** No-op ReviewUi: every call is inert. Default when no UI is injected (tests,
+ * headless), so review logic runs without a vscode surface. */
+export const noopReviewUi: ReviewUi = {
+	setBaseline() {},
+	setPending() {},
+	async openDiff() {},
+	clear() {},
+};

--- a/packages/vscode/src/host/session-controller.ts
+++ b/packages/vscode/src/host/session-controller.ts
@@ -21,7 +21,7 @@ import {
 	captureTree,
 	changedFiles,
 	fileDiff,
-	isGitRepo,
+	findGitRoot,
 	revertFile,
 	revertHunk,
 } from "./git-snapshot.js";
@@ -158,6 +158,11 @@ export class SessionController {
 	private readonly reviewModel = new ReviewModel();
 	/** Whether change review is active for this cwd (false outside a git repo). */
 	private reviewEnabled = false;
+	/** The git repository root backing change review. All review git operations
+	 * and path joins are anchored here (not `options.cwd`) so a workspace opened
+	 * at a subdirectory of the repo still produces correct repo-root-relative
+	 * paths. Falls back to `options.cwd` when outside a repo (review disabled). */
+	private reviewRoot: string;
 	/** Last-published review state (held so the bridge can include it in the
 	 * reload snapshot — review survives webview recreation). */
 	private reviewState: ReviewStateDto = { enabled: false, files: [] };
@@ -185,10 +190,18 @@ export class SessionController {
 		this.reviewUi = options.review ?? noopReviewUi;
 		this.logger = options.logger ?? (() => {});
 		this.status = { connected: false, cwd: options.cwd };
+		this.reviewRoot = options.cwd;
 	}
 
 	get cwd(): string {
 		return this.options.cwd;
+	}
+
+	/** The git repository root backing change review (repo root, or the workspace
+	 * cwd when review is disabled). Used by the extension to map editor URIs to
+	 * the repo-root-relative paths the review model speaks. */
+	get gitRoot(): string {
+		return this.reviewRoot;
 	}
 
 	getTranscript(): TranscriptState {
@@ -234,8 +247,14 @@ export class SessionController {
 			throw err;
 		}
 		this.setStatus({ ...this.status, connected: true, error: undefined });
-		this.reviewEnabled = isGitRepo(this.options.cwd);
+		const root = findGitRoot(this.options.cwd);
+		this.reviewEnabled = root !== null;
+		this.reviewRoot = root ?? this.options.cwd;
 		this.reviewState = { enabled: this.reviewEnabled, files: [] };
+		// Publish the (possibly disabled) review state so the webview can show a
+		// clear "change review unavailable" notice when this isn't a git repo
+		// (acceptance criterion: degrade gracefully with a clear notice).
+		this.emit({ kind: "review", review: this.reviewState });
 		await this.refreshCommands();
 		await this.refreshStatus(true);
 	}
@@ -557,7 +576,7 @@ export class SessionController {
 	/** Capture the pre-turn baseline once per review cycle. */
 	private maybeCaptureBaseline(): void {
 		if (!this.reviewEnabled || this.reviewModel.hasCycle()) return;
-		const tree = captureTree(this.options.cwd);
+		const tree = captureTree(this.reviewRoot);
 		if (tree) this.reviewModel.beginCycle(tree);
 	}
 
@@ -571,10 +590,10 @@ export class SessionController {
 			this.publishReview([]);
 			return;
 		}
-		const changed = changedFiles(this.options.cwd, ref);
+		const changed = changedFiles(this.reviewRoot, ref);
 		const pending = this.reviewModel.pending(changed);
 		for (const f of pending) {
-			this.reviewUi.setBaseline(f.path, baselineContent(this.options.cwd, ref, f.path));
+			this.reviewUi.setBaseline(f.path, baselineContent(this.reviewRoot, ref, f.path));
 		}
 		this.reviewUi.setPending(pending);
 		this.publishReview(pending);
@@ -611,19 +630,30 @@ export class SessionController {
 	async reviewRevertFile(path: string): Promise<void> {
 		const ref = this.reviewModel.baselineRef();
 		if (!ref) return;
-		revertFile(this.options.cwd, ref, path);
-		this.reviewModel.unaccept(path);
+		const ok = revertFile(this.reviewRoot, ref, path);
+		if (ok) this.reviewModel.unaccept(path);
+		else this.emitNotice(`Could not revert ${path}.`);
+		// refreshReview recomputes from the working tree, so a file that failed to
+		// revert stays listed rather than being silently dropped.
 		await this.refreshReview();
 	}
 
-	/** Revert every pending file to baseline, then end the cycle. */
+	/** Revert every pending file to baseline, then end the cycle. Files that fail
+	 * to revert remain pending (surfaced via `refreshReview`) and are reported,
+	 * rather than being silently cleared while their edits persist on disk. */
 	async reviewRevertAll(): Promise<void> {
 		const ref = this.reviewModel.baselineRef();
 		if (!ref) return;
-		for (const f of this.reviewState.files) revertFile(this.options.cwd, ref, f.path);
-		this.reviewModel.reset();
-		this.reviewUi.clear();
-		this.publishReview([]);
+		const failures: string[] = [];
+		for (const f of this.reviewState.files) {
+			if (revertFile(this.reviewRoot, ref, f.path)) this.reviewModel.unaccept(f.path);
+			else failures.push(f.path);
+		}
+		if (failures.length > 0) {
+			const noun = failures.length === 1 ? "file" : "files";
+			this.emitNotice(`Could not revert ${failures.length} ${noun}: ${failures.join(", ")}`);
+		}
+		await this.refreshReview();
 	}
 
 	/** Reject exactly the hunk containing `line` (1-based, in the current file)
@@ -632,11 +662,11 @@ export class SessionController {
 	async reviewRejectHunkAtLine(path: string, line: number): Promise<boolean> {
 		const ref = this.reviewModel.baselineRef();
 		if (!ref) return false;
-		const { diff, binary } = fileDiff(this.options.cwd, ref, path);
+		const { diff, binary } = fileDiff(this.reviewRoot, ref, path);
 		if (binary || diff.length === 0) return false;
 		const index = hunkIndexForLine(parseFileDiff(diff).hunks, line);
 		if (index === undefined) return false;
-		const ok = revertHunk(this.options.cwd, ref, path, index);
+		const ok = revertHunk(this.reviewRoot, ref, path, index);
 		await this.refreshReview();
 		return ok;
 	}

--- a/packages/vscode/src/host/session-controller.ts
+++ b/packages/vscode/src/host/session-controller.ts
@@ -190,7 +190,16 @@ export class SessionController {
 		this.reviewUi = options.review ?? noopReviewUi;
 		this.logger = options.logger ?? (() => {});
 		this.status = { connected: false, cwd: options.cwd };
-		this.reviewRoot = options.cwd;
+		// Resolve the git-repo state synchronously up front (findGitRoot is a cheap
+		// upward directory walk) so `getReviewState()` returns the correct enabled
+		// flag the instant the webview announces `ready` — which can happen before
+		// the slow `start()` RPC handshake completes. Deferring this to `start()`
+		// would answer that early `ready` with a stale `enabled: false` and flash a
+		// spurious "change review unavailable" notice in an ordinary git repo.
+		const root = findGitRoot(options.cwd);
+		this.reviewEnabled = root !== null;
+		this.reviewRoot = root ?? options.cwd;
+		this.reviewState = { enabled: this.reviewEnabled, files: [] };
 	}
 
 	get cwd(): string {
@@ -247,13 +256,11 @@ export class SessionController {
 			throw err;
 		}
 		this.setStatus({ ...this.status, connected: true, error: undefined });
-		const root = findGitRoot(this.options.cwd);
-		this.reviewEnabled = root !== null;
-		this.reviewRoot = root ?? this.options.cwd;
-		this.reviewState = { enabled: this.reviewEnabled, files: [] };
-		// Publish the (possibly disabled) review state so the webview can show a
-		// clear "change review unavailable" notice when this isn't a git repo
-		// (acceptance criterion: degrade gracefully with a clear notice).
+		// Review enablement was resolved synchronously in the constructor (see
+		// there); re-publish it now so any webview that went live before this
+		// point receives the authoritative state via the push path too. Outside a
+		// git repo this drives the "change review unavailable" notice (acceptance
+		// criterion: degrade gracefully with a clear notice).
 		this.emit({ kind: "review", review: this.reviewState });
 		await this.refreshCommands();
 		await this.refreshStatus(true);

--- a/packages/vscode/src/host/session-controller.ts
+++ b/packages/vscode/src/host/session-controller.ts
@@ -14,8 +14,20 @@
 
 import { formatSessionStats } from "../shared/format.js";
 import { applyEvent, createTranscriptState, type TranscriptState } from "../shared/projection.js";
-import type { HostStatus, SlashCommandDto, UiResponse } from "../shared/protocol.js";
+import type { HostStatus, ReviewFileDto, ReviewStateDto, SlashCommandDto, UiResponse } from "../shared/protocol.js";
+import { hunkIndexForLine, parseFileDiff } from "./diff-hunks.js";
+import {
+	baselineContent,
+	captureTree,
+	changedFiles,
+	fileDiff,
+	isGitRepo,
+	revertFile,
+	revertHunk,
+} from "./git-snapshot.js";
 import { type HostUi, noopHostUi } from "./host-ui.js";
+import { ReviewModel } from "./review-model.js";
+import { noopReviewUi, type ReviewUi } from "./review-ui.js";
 import { BUILTIN_COMMANDS, DEFERRED_BUILTINS, routeInput, stripSlash, TERMINAL_ONLY_BUILTINS } from "./slash-router.js";
 
 /** Thinking levels offered in the picker. The active model may support a subset;
@@ -108,6 +120,9 @@ export interface SessionControllerOptions {
 	 * controller stays vscode-free and testable. Production injects the
 	 * vscode-backed impl. */
 	ui?: HostUi;
+	/** Native change-review surface (SCM group + quick-diff + diff viewer);
+	 * defaults to a no-op so the controller stays vscode-free and testable. */
+	review?: ReviewUi;
 	logger?: (line: string) => void;
 }
 
@@ -116,6 +131,8 @@ export type ControllerUpdate =
 	| { kind: "status"; status: HostStatus }
 	/** The slash-command list changed (e.g. after `/reload`). */
 	| { kind: "commands"; commands: SlashCommandDto[] }
+	/** The change-review set changed (per-turn detection, accept/revert). */
+	| { kind: "review"; review: ReviewStateDto }
 	/** Transcript was replaced host-side (e.g. `/new`, `/import`); the bridge
 	 * re-sends a fresh snapshot. */
 	| { kind: "resync" };
@@ -137,6 +154,13 @@ export class SessionController {
 	private readonly listeners = new Set<(update: ControllerUpdate) => void>();
 	private readonly factory: RpcClientFactory;
 	private readonly ui: HostUi;
+	private readonly reviewUi: ReviewUi;
+	private readonly reviewModel = new ReviewModel();
+	/** Whether change review is active for this cwd (false outside a git repo). */
+	private reviewEnabled = false;
+	/** Last-published review state (held so the bridge can include it in the
+	 * reload snapshot — review survives webview recreation). */
+	private reviewState: ReviewStateDto = { enabled: false, files: [] };
 	private readonly logger: (line: string) => void;
 	private readonly options: SessionControllerOptions;
 	private client: RpcClientLike | undefined;
@@ -158,6 +182,7 @@ export class SessionController {
 		this.options = options;
 		this.factory = options.clientFactory ?? defaultClientFactory;
 		this.ui = options.ui ?? noopHostUi;
+		this.reviewUi = options.review ?? noopReviewUi;
 		this.logger = options.logger ?? (() => {});
 		this.status = { connected: false, cwd: options.cwd };
 	}
@@ -172,6 +197,12 @@ export class SessionController {
 
 	getStatus(): HostStatus {
 		return this.status;
+	}
+
+	/** The current change-review state (pending files); included by the bridge in
+	 * the reload snapshot so review survives webview recreation. */
+	getReviewState(): ReviewStateDto {
+		return this.reviewState;
 	}
 
 	getCommandList(): SlashCommandDto[] {
@@ -203,6 +234,8 @@ export class SessionController {
 			throw err;
 		}
 		this.setStatus({ ...this.status, connected: true, error: undefined });
+		this.reviewEnabled = isGitRepo(this.options.cwd);
+		this.reviewState = { enabled: this.reviewEnabled, files: [] };
 		await this.refreshCommands();
 		await this.refreshStatus(true);
 	}
@@ -519,6 +552,95 @@ export class SessionController {
 		this.client?.sendExtensionUIResponse({ type: "extension_ui_response", ...response });
 	}
 
+	// ── Change review ──────────────────────────────────────────────────────
+
+	/** Capture the pre-turn baseline once per review cycle. */
+	private maybeCaptureBaseline(): void {
+		if (!this.reviewEnabled || this.reviewModel.hasCycle()) return;
+		const tree = captureTree(this.options.cwd);
+		if (tree) this.reviewModel.beginCycle(tree);
+	}
+
+	/** Recompute the pending-review set from the baseline, push baseline content
+	 * to the review surface, and publish. When nothing remains pending (all
+	 * reverted or accepted), end the cycle so the next edit re-baselines. */
+	private async refreshReview(): Promise<void> {
+		if (!this.reviewEnabled) return;
+		const ref = this.reviewModel.baselineRef();
+		if (!ref) {
+			this.publishReview([]);
+			return;
+		}
+		const changed = changedFiles(this.options.cwd, ref);
+		const pending = this.reviewModel.pending(changed);
+		for (const f of pending) {
+			this.reviewUi.setBaseline(f.path, baselineContent(this.options.cwd, ref, f.path));
+		}
+		this.reviewUi.setPending(pending);
+		this.publishReview(pending);
+		if (pending.length === 0) {
+			this.reviewModel.reset();
+			this.reviewUi.clear();
+		}
+	}
+
+	private publishReview(files: ReviewFileDto[]): void {
+		this.reviewState = { enabled: this.reviewEnabled, files };
+		this.emit({ kind: "review", review: this.reviewState });
+	}
+
+	/** Open the baseline↔current diff for a reviewed file. */
+	async reviewOpenDiff(path: string): Promise<void> {
+		await this.reviewUi.openDiff(path);
+	}
+
+	/** Accept a single file (clear its review marker; no commit). */
+	async reviewAcceptFile(path: string): Promise<void> {
+		this.reviewModel.accept(path);
+		await this.refreshReview();
+	}
+
+	/** Accept every pending change at once (clear the cycle; no commit). */
+	async reviewAcceptAll(): Promise<void> {
+		this.reviewModel.reset();
+		this.reviewUi.clear();
+		this.publishReview([]);
+	}
+
+	/** Revert a whole file to its baseline content, discarding the turn's edits. */
+	async reviewRevertFile(path: string): Promise<void> {
+		const ref = this.reviewModel.baselineRef();
+		if (!ref) return;
+		revertFile(this.options.cwd, ref, path);
+		this.reviewModel.unaccept(path);
+		await this.refreshReview();
+	}
+
+	/** Revert every pending file to baseline, then end the cycle. */
+	async reviewRevertAll(): Promise<void> {
+		const ref = this.reviewModel.baselineRef();
+		if (!ref) return;
+		for (const f of this.reviewState.files) revertFile(this.options.cwd, ref, f.path);
+		this.reviewModel.reset();
+		this.reviewUi.clear();
+		this.publishReview([]);
+	}
+
+	/** Reject exactly the hunk containing `line` (1-based, in the current file)
+	 * — the non-interactive equivalent of `git restore -p`. Returns true when a
+	 * hunk was found and reverted. */
+	async reviewRejectHunkAtLine(path: string, line: number): Promise<boolean> {
+		const ref = this.reviewModel.baselineRef();
+		if (!ref) return false;
+		const { diff, binary } = fileDiff(this.options.cwd, ref, path);
+		if (binary || diff.length === 0) return false;
+		const index = hunkIndexForLine(parseFileDiff(diff).hunks, line);
+		if (index === undefined) return false;
+		const ok = revertHunk(this.options.cwd, ref, path, index);
+		await this.refreshReview();
+		return ok;
+	}
+
 	async dispose(): Promise<void> {
 		if (this.disposed) return;
 		this.disposed = true;
@@ -541,9 +663,17 @@ export class SessionController {
 	private handleEvent(event: unknown): void {
 		applyEvent(this.state, event);
 		this.emit({ kind: "event", event });
+		const type = (event as { type?: unknown })?.type;
+		// Snapshot a baseline before the first turn of a review cycle (changes
+		// then compound against it until accepted/reverted).
+		if (type === "turn_start") this.maybeCaptureBaseline();
 		// After each completed turn, refresh runtime status (cost/context/model)
-		// the way the dashboard does on the streaming→idle transition.
-		if ((event as { type?: unknown })?.type === "agent_end") void this.refreshStatus(true);
+		// the way the dashboard does on the streaming→idle transition, and
+		// recompute the change-review set from the baseline.
+		if (type === "agent_end") {
+			void this.refreshStatus(true);
+			void this.refreshReview();
+		}
 	}
 
 	private handleExit(info: { code?: number | null; signal?: string | null; error?: Error }): void {

--- a/packages/vscode/src/host/vscode-review-ui.ts
+++ b/packages/vscode/src/host/vscode-review-ui.ts
@@ -19,6 +19,7 @@
 import { isAbsolute, join, relative, sep } from "node:path";
 import * as vscode from "vscode";
 import type { ReviewFileDto } from "../shared/protocol.js";
+import { findGitRoot } from "./git-snapshot.js";
 import type { ReviewUi } from "./review-ui.js";
 
 export const BASELINE_SCHEME = "dreb-baseline";
@@ -30,6 +31,11 @@ function baselineUri(path: string): vscode.Uri {
 }
 
 export function createVscodeReviewUi(cwd: string): ReviewUi & vscode.Disposable {
+	// Change-review paths are repo-root-relative (they come from diffing git tree
+	// objects), so every path join / URI must be anchored to the repository root,
+	// not the workspace cwd — otherwise a workspace opened at a subdirectory of
+	// the repo would build wrong file URIs and quick-diff would never match.
+	const root = findGitRoot(cwd) ?? cwd;
 	const baselines = new Map<string, string>();
 	const changeEmitter = new vscode.EventEmitter<vscode.Uri>();
 
@@ -42,13 +48,13 @@ export function createVscodeReviewUi(cwd: string): ReviewUi & vscode.Disposable 
 
 	const quickDiff: vscode.QuickDiffProvider = {
 		provideOriginalResource(uri) {
-			const rel = toRepoRelative(cwd, uri);
+			const rel = toRepoRelative(root, uri);
 			if (rel === undefined || !baselines.has(rel)) return undefined;
 			return baselineUri(rel);
 		},
 	};
 
-	const scm = vscode.scm.createSourceControl("drebReview", "dreb — pending review", vscode.Uri.file(cwd));
+	const scm = vscode.scm.createSourceControl("drebReview", "dreb — pending review", vscode.Uri.file(root));
 	scm.quickDiffProvider = quickDiff;
 	const group = scm.createResourceGroup("pending", "Pending review");
 
@@ -61,7 +67,7 @@ export function createVscodeReviewUi(cwd: string): ReviewUi & vscode.Disposable 
 		},
 		setPending(files: ReviewFileDto[]) {
 			group.resourceStates = files.map((f) => {
-				const resourceUri = vscode.Uri.file(join(cwd, f.path));
+				const resourceUri = vscode.Uri.file(join(root, f.path));
 				return {
 					resourceUri,
 					decorations: {
@@ -79,7 +85,7 @@ export function createVscodeReviewUi(cwd: string): ReviewUi & vscode.Disposable 
 		},
 		async openDiff(path) {
 			const left = baselineUri(path);
-			const right = vscode.Uri.file(join(cwd, path));
+			const right = vscode.Uri.file(join(root, path));
 			await vscode.commands.executeCommand("vscode.diff", left, right, `${path} (dreb review)`);
 		},
 		clear() {

--- a/packages/vscode/src/host/vscode-review-ui.ts
+++ b/packages/vscode/src/host/vscode-review-ui.ts
@@ -1,0 +1,114 @@
+/// <reference types="vscode" />
+
+/**
+ * vscode-backed ReviewUi — the native change-review surface.
+ *
+ * Three vscode pieces, all owned here so the controller stays vscode-free:
+ *  - a `TextDocumentContentProvider` on the `dreb-baseline:` scheme that serves
+ *    each reviewed file's baseline content (the left/original side of a diff and
+ *    the quick-diff gutter reference);
+ *  - a `QuickDiffProvider` on an SCM `SourceControl` ("dreb — pending review")
+ *    whose resource group lists the pending files, so VS Code draws inline
+ *    change gutters against our baseline for free;
+ *  - `openDiff`, which opens the built-in diff editor (baseline ↔ working file).
+ *
+ * The per-hunk *revert* itself is NOT done here — the controller performs it via
+ * git (`git apply --reverse`); this surface only visualizes and lists.
+ */
+
+import { isAbsolute, join, relative, sep } from "node:path";
+import * as vscode from "vscode";
+import type { ReviewFileDto } from "../shared/protocol.js";
+import type { ReviewUi } from "./review-ui.js";
+
+export const BASELINE_SCHEME = "dreb-baseline";
+
+/** Build the `dreb-baseline:` URI that mirrors a working-tree path. The working
+ * path rides in the query so the content provider can look up its baseline. */
+function baselineUri(path: string): vscode.Uri {
+	return vscode.Uri.from({ scheme: BASELINE_SCHEME, path: `/${path}`, query: path });
+}
+
+export function createVscodeReviewUi(cwd: string): ReviewUi & vscode.Disposable {
+	const baselines = new Map<string, string>();
+	const changeEmitter = new vscode.EventEmitter<vscode.Uri>();
+
+	const contentProvider: vscode.TextDocumentContentProvider = {
+		onDidChange: changeEmitter.event,
+		provideTextDocumentContent(uri) {
+			return baselines.get(uri.query) ?? "";
+		},
+	};
+
+	const quickDiff: vscode.QuickDiffProvider = {
+		provideOriginalResource(uri) {
+			const rel = toRepoRelative(cwd, uri);
+			if (rel === undefined || !baselines.has(rel)) return undefined;
+			return baselineUri(rel);
+		},
+	};
+
+	const scm = vscode.scm.createSourceControl("drebReview", "dreb — pending review", vscode.Uri.file(cwd));
+	scm.quickDiffProvider = quickDiff;
+	const group = scm.createResourceGroup("pending", "Pending review");
+
+	const providerReg = vscode.workspace.registerTextDocumentContentProvider(BASELINE_SCHEME, contentProvider);
+
+	const ui: ReviewUi & vscode.Disposable = {
+		setBaseline(path, content) {
+			baselines.set(path, content ?? "");
+			changeEmitter.fire(baselineUri(path));
+		},
+		setPending(files: ReviewFileDto[]) {
+			group.resourceStates = files.map((f) => {
+				const resourceUri = vscode.Uri.file(join(cwd, f.path));
+				return {
+					resourceUri,
+					decorations: {
+						tooltip: describe(f),
+						strikeThrough: f.status === "deleted",
+					},
+					command: {
+						command: "dreb.review.openDiff",
+						title: "Open Diff",
+						arguments: [f.path],
+					},
+				} satisfies vscode.SourceControlResourceState;
+			});
+			scm.count = files.length;
+		},
+		async openDiff(path) {
+			const left = baselineUri(path);
+			const right = vscode.Uri.file(join(cwd, path));
+			await vscode.commands.executeCommand("vscode.diff", left, right, `${path} (dreb review)`);
+		},
+		clear() {
+			baselines.clear();
+			group.resourceStates = [];
+			scm.count = 0;
+		},
+		dispose() {
+			changeEmitter.dispose();
+			group.dispose();
+			scm.dispose();
+			providerReg.dispose();
+		},
+	};
+
+	return ui;
+}
+
+/** Resolve a working-tree URI to its repo-relative path, or undefined if it is
+ * not under `cwd`. */
+function toRepoRelative(cwd: string, uri: vscode.Uri): string | undefined {
+	if (uri.scheme !== "file") return undefined;
+	const rel = relative(cwd, uri.fsPath);
+	if (rel.length === 0 || rel.startsWith("..") || isAbsolute(rel)) return undefined;
+	return rel.split(sep).join("/");
+}
+
+function describe(f: ReviewFileDto): string {
+	const kind = f.status === "binary" ? "binary change" : f.status;
+	const hunks = f.hunkCount > 0 ? ` · ${f.hunkCount} hunk${f.hunkCount === 1 ? "" : "s"}` : "";
+	return `${kind}${hunks} — pending dreb review`;
+}

--- a/packages/vscode/src/host/webview-bridge.ts
+++ b/packages/vscode/src/host/webview-bridge.ts
@@ -67,6 +67,9 @@ export function connectWebview(webview: vscode.Webview, controller: SessionContr
 			case "commands":
 				post({ type: "commands", commands: update.commands });
 				break;
+			case "review":
+				post({ type: "review", review: update.review });
+				break;
 			case "resync":
 				// Transcript was replaced host-side (/new, /import) — re-snapshot.
 				post({
@@ -75,6 +78,7 @@ export function connectWebview(webview: vscode.Webview, controller: SessionContr
 					commands: controller.getCommandList(),
 					status: controller.getStatus(),
 				});
+				post({ type: "review", review: controller.getReviewState() });
 				break;
 		}
 	});
@@ -92,6 +96,7 @@ export function connectWebview(webview: vscode.Webview, controller: SessionContr
 					status: controller.getStatus(),
 				});
 				live = true;
+				post({ type: "review", review: controller.getReviewState() });
 				pushCommands();
 				return;
 			}
@@ -109,6 +114,9 @@ export function connectWebview(webview: vscode.Webview, controller: SessionContr
 				return;
 			case "pick-thinking":
 				void controller.pickThinking();
+				return;
+			case "review-open-diff":
+				void controller.reviewOpenDiff(raw.path);
 				return;
 			case "ui-response":
 				controller.respondUi(raw.response);

--- a/packages/vscode/src/shared/protocol.ts
+++ b/packages/vscode/src/shared/protocol.ts
@@ -66,12 +66,30 @@ export type UiResponse =
 	| { id: string; selected: string[]; customText?: string }
 	| { id: string; cancelled: true };
 
+/** One file pending change-review, shown in the webview indicator + SCM group. */
+export interface ReviewFileDto {
+	/** Repo-relative path. */
+	path: string;
+	status: "modified" | "added" | "deleted" | "binary";
+	/** Number of textual hunks (0 for binary/whole-file changes). */
+	hunkCount: number;
+}
+
+/** Change-review state mirrored to the webview. `enabled` is false outside a git
+ * repo (review degrades to a notice); `files` is empty when nothing is pending. */
+export interface ReviewStateDto {
+	enabled: boolean;
+	files: ReviewFileDto[];
+}
+
 /** Messages sent from the host to the webview. */
 export type HostToWebview =
 	| { type: "snapshot"; state: TranscriptState; commands: SlashCommandDto[]; status: HostStatus }
 	| { type: "event"; event: unknown }
 	| { type: "commands"; commands: SlashCommandDto[] }
-	| { type: "status"; status: HostStatus };
+	| { type: "status"; status: HostStatus }
+	/** Change-review set changed (per-turn detection, accept/revert). */
+	| { type: "review"; review: ReviewStateDto };
 
 /** Messages sent from the webview to the host. */
 export type WebviewToHost =
@@ -83,4 +101,6 @@ export type WebviewToHost =
 	/** Open the native model picker (header click). */
 	| { type: "pick-model" }
 	/** Open the native thinking-level picker (header click). */
-	| { type: "pick-thinking" };
+	| { type: "pick-thinking" }
+	/** Open the baseline→current diff for a reviewed file (indicator click). */
+	| { type: "review-open-diff"; path: string };

--- a/packages/vscode/src/webview/app.tsx
+++ b/packages/vscode/src/webview/app.tsx
@@ -18,7 +18,10 @@ export function App() {
 	const [state, setState] = createStore<TranscriptState>(createTranscriptState());
 	const [commands, setCommands] = createSignal<SlashCommandDto[]>([]);
 	const [status, setStatus] = createSignal<HostStatus>({ connected: false, cwd: "" });
-	const [review, setReview] = createSignal<ReviewStateDto>({ enabled: false, files: [] });
+	// Optimistic pre-hydration default so a git repo doesn't briefly flash the
+	// "unavailable" notice before the first review message arrives; the host
+	// publishes the authoritative enabled/files state on connect and on reload.
+	const [review, setReview] = createSignal<ReviewStateDto>({ enabled: true, files: [] });
 	const [tick, setTick] = createSignal(0);
 
 	let scrollEl: HTMLDivElement | undefined;
@@ -107,24 +110,36 @@ export function App() {
 				<div class="dreb-banner error">{state.hostError}</div>
 			</Show>
 
-			<Show when={review().files.length > 0}>
-				<div class="dreb-review-bar">
-					<span class="dreb-review-title">
-						{review().files.length} change{review().files.length === 1 ? "" : "s"} pending review
-					</span>
-					<For each={review().files}>
-						{(file) => (
-							<button
-								type="button"
-								class="dreb-review-file"
-								title={`${file.status}${file.hunkCount > 0 ? ` · ${file.hunkCount} hunk${file.hunkCount === 1 ? "" : "s"}` : ""} — open diff`}
-								onClick={() => postToHost({ type: "review-open-diff", path: file.path })}
-							>
-								{shortPath(file.path)}
-							</button>
-						)}
-					</For>
-				</div>
+			<Show when={review().files.length > 0 || !review().enabled}>
+				<Show
+					when={review().enabled}
+					fallback={
+						<div class="dreb-review-bar dreb-review-unavailable">
+							<span class="dreb-review-title">
+								Change review unavailable — open a folder that is a Git repository to review and revert agent
+								edits.
+							</span>
+						</div>
+					}
+				>
+					<div class="dreb-review-bar">
+						<span class="dreb-review-title">
+							{review().files.length} change{review().files.length === 1 ? "" : "s"} pending review
+						</span>
+						<For each={review().files}>
+							{(file) => (
+								<button
+									type="button"
+									class="dreb-review-file"
+									title={`${file.status}${file.hunkCount > 0 ? ` · ${file.hunkCount} hunk${file.hunkCount === 1 ? "" : "s"}` : ""} — open diff`}
+									onClick={() => postToHost({ type: "review-open-diff", path: file.path })}
+								>
+									{shortPath(file.path)}
+								</button>
+							)}
+						</For>
+					</div>
+				</Show>
 			</Show>
 
 			<div class="dreb-transcript" ref={scrollEl}>

--- a/packages/vscode/src/webview/app.tsx
+++ b/packages/vscode/src/webview/app.tsx
@@ -10,7 +10,7 @@ import {
 	type TranscriptState,
 	type UiRequest,
 } from "../shared/projection.js";
-import type { HostStatus, SlashCommandDto, UiResponse } from "../shared/protocol.js";
+import type { HostStatus, ReviewStateDto, SlashCommandDto, UiResponse } from "../shared/protocol.js";
 import { renderMarkdown } from "./markdown.js";
 import { onHostMessage, postToHost } from "./vscode-api.js";
 
@@ -18,6 +18,7 @@ export function App() {
 	const [state, setState] = createStore<TranscriptState>(createTranscriptState());
 	const [commands, setCommands] = createSignal<SlashCommandDto[]>([]);
 	const [status, setStatus] = createSignal<HostStatus>({ connected: false, cwd: "" });
+	const [review, setReview] = createSignal<ReviewStateDto>({ enabled: false, files: [] });
 	const [tick, setTick] = createSignal(0);
 
 	let scrollEl: HTMLDivElement | undefined;
@@ -41,6 +42,9 @@ export function App() {
 					break;
 				case "status":
 					setStatus(msg.status);
+					break;
+				case "review":
+					setReview(msg.review);
 					break;
 			}
 			setTick((t) => t + 1);
@@ -101,6 +105,26 @@ export function App() {
 
 			<Show when={state.hostError}>
 				<div class="dreb-banner error">{state.hostError}</div>
+			</Show>
+
+			<Show when={review().files.length > 0}>
+				<div class="dreb-review-bar">
+					<span class="dreb-review-title">
+						{review().files.length} change{review().files.length === 1 ? "" : "s"} pending review
+					</span>
+					<For each={review().files}>
+						{(file) => (
+							<button
+								type="button"
+								class="dreb-review-file"
+								title={`${file.status}${file.hunkCount > 0 ? ` · ${file.hunkCount} hunk${file.hunkCount === 1 ? "" : "s"}` : ""} — open diff`}
+								onClick={() => postToHost({ type: "review-open-diff", path: file.path })}
+							>
+								{shortPath(file.path)}
+							</button>
+						)}
+					</For>
+				</div>
 			</Show>
 
 			<div class="dreb-transcript" ref={scrollEl}>

--- a/packages/vscode/src/webview/styles.css
+++ b/packages/vscode/src/webview/styles.css
@@ -261,6 +261,11 @@ body {
 .dreb-review-file:hover {
 	background: var(--vscode-toolbar-hoverBackground, rgba(128, 128, 128, 0.2));
 }
+.dreb-review-unavailable .dreb-review-title {
+	font-weight: 400;
+	font-style: italic;
+	margin-right: 0;
+}
 
 
 .dreb-status-line {

--- a/packages/vscode/src/webview/styles.css
+++ b/packages/vscode/src/webview/styles.css
@@ -232,6 +232,37 @@ body {
 	color: var(--vscode-foreground);
 }
 
+/* Change-review bar ------------------------------------------------------- */
+.dreb-review-bar {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 6px;
+	padding: 6px 12px;
+	border-bottom: 1px solid var(--vscode-panel-border, rgba(128, 128, 128, 0.25));
+	background: var(--vscode-editorWidget-background, rgba(128, 128, 128, 0.08));
+}
+.dreb-review-title {
+	font-size: 0.8em;
+	font-weight: 600;
+	color: var(--vscode-descriptionForeground);
+	margin-right: 4px;
+}
+.dreb-review-file {
+	font-family: var(--vscode-editor-font-family, monospace);
+	font-size: 0.8em;
+	padding: 1px 6px;
+	border-radius: 4px;
+	border: 1px solid var(--vscode-panel-border, rgba(128, 128, 128, 0.3));
+	background: var(--vscode-button-secondaryBackground, transparent);
+	color: var(--vscode-foreground);
+	cursor: pointer;
+}
+.dreb-review-file:hover {
+	background: var(--vscode-toolbar-hoverBackground, rgba(128, 128, 128, 0.2));
+}
+
+
 .dreb-status-line {
 	color: var(--vscode-descriptionForeground);
 	font-size: 0.85em;

--- a/packages/vscode/test/diff-hunks.test.ts
+++ b/packages/vscode/test/diff-hunks.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { hunkIndexForLine, parseFileDiff, sliceHunkPatch } from "../src/host/diff-hunks.js";
+
+const TWO_HUNK_DIFF = `diff --git a/file.txt b/file.txt
+index 1111111..2222222 100644
+--- a/file.txt
++++ b/file.txt
+@@ -1,3 +1,3 @@
+ line1
+-line2
++CHANGED2
+ line3
+@@ -8,3 +8,4 @@
+ line8
+ line9
++INSERTED
+ line10
+`;
+
+const NEW_FILE_DIFF = `diff --git a/new.txt b/new.txt
+new file mode 100644
+index 0000000..3333333
+--- /dev/null
++++ b/new.txt
+@@ -0,0 +1,2 @@
++alpha
++beta
+`;
+
+const BINARY_DIFF = `diff --git a/img.png b/img.png
+index 1111111..2222222 100644
+Binary files a/img.png and b/img.png differ
+`;
+
+describe("parseFileDiff", () => {
+	it("splits a multi-hunk diff into header + hunks", () => {
+		const parsed = parseFileDiff(TWO_HUNK_DIFF);
+		expect(parsed.binary).toBe(false);
+		expect(parsed.hunks).toHaveLength(2);
+		expect(parsed.fileHeader).toEqual([
+			"diff --git a/file.txt b/file.txt",
+			"index 1111111..2222222 100644",
+			"--- a/file.txt",
+			"+++ b/file.txt",
+		]);
+		// New-file line range comes from the `+c,d` side of the @@ header.
+		expect(parsed.hunks[0]).toMatchObject({ newStart: 1, newLines: 3 });
+		expect(parsed.hunks[1]).toMatchObject({ newStart: 8, newLines: 4 });
+		expect(parsed.hunks[0].lines[0]).toBe("@@ -1,3 +1,3 @@");
+	});
+
+	it("parses a single-count hunk header (@@ -a +c @@) as one line", () => {
+		const parsed = parseFileDiff(`--- a/x\n+++ b/x\n@@ -5 +5 @@\n-old\n+new\n`);
+		expect(parsed.hunks).toHaveLength(1);
+		expect(parsed.hunks[0]).toMatchObject({ newStart: 5, newLines: 1 });
+	});
+
+	it("treats a new file as a single whole-file hunk", () => {
+		const parsed = parseFileDiff(NEW_FILE_DIFF);
+		expect(parsed.hunks).toHaveLength(1);
+		expect(parsed.hunks[0]).toMatchObject({ newStart: 1, newLines: 2 });
+	});
+
+	it("flags binary diffs and yields no hunks", () => {
+		const parsed = parseFileDiff(BINARY_DIFF);
+		expect(parsed.binary).toBe(true);
+		expect(parsed.hunks).toHaveLength(0);
+	});
+
+	it("returns nothing for an empty diff", () => {
+		const parsed = parseFileDiff("");
+		expect(parsed.hunks).toHaveLength(0);
+		expect(parsed.binary).toBe(false);
+	});
+});
+
+describe("sliceHunkPatch", () => {
+	it("reconstructs an apply-able patch with only the chosen hunk", () => {
+		const parsed = parseFileDiff(TWO_HUNK_DIFF);
+		const patch = sliceHunkPatch(parsed, 1);
+		expect(patch).toBeDefined();
+		// Header preserved; only the second hunk's body present.
+		expect(patch).toContain("diff --git a/file.txt b/file.txt");
+		expect(patch).toContain("@@ -8,3 +8,4 @@");
+		expect(patch).toContain("+INSERTED");
+		expect(patch).not.toContain("+CHANGED2");
+		expect(patch?.endsWith("\n")).toBe(true);
+	});
+
+	it("returns undefined for an out-of-range index", () => {
+		const parsed = parseFileDiff(TWO_HUNK_DIFF);
+		expect(sliceHunkPatch(parsed, 5)).toBeUndefined();
+	});
+});
+
+describe("hunkIndexForLine", () => {
+	it("finds the hunk whose new-file range contains the line", () => {
+		const { hunks } = parseFileDiff(TWO_HUNK_DIFF);
+		expect(hunkIndexForLine(hunks, 2)).toBe(0); // within 1..3
+		expect(hunkIndexForLine(hunks, 9)).toBe(1); // within 8..11
+	});
+
+	it("returns undefined when no hunk covers the line", () => {
+		const { hunks } = parseFileDiff(TWO_HUNK_DIFF);
+		expect(hunkIndexForLine(hunks, 5)).toBeUndefined();
+	});
+
+	it("matches a zero-length (pure-deletion) hunk at its start line", () => {
+		const { hunks } = parseFileDiff(`--- a/x\n+++ b/x\n@@ -3,1 +3,0 @@\n-gone\n`);
+		expect(hunkIndexForLine(hunks, 3)).toBe(0);
+	});
+});

--- a/packages/vscode/test/git-snapshot.test.ts
+++ b/packages/vscode/test/git-snapshot.test.ts
@@ -7,6 +7,7 @@
 
 import { spawnSync } from "node:child_process";
 import {
+	chmodSync,
 	existsSync,
 	linkSync,
 	lstatSync,
@@ -307,6 +308,26 @@ describe("git-snapshot", () => {
 		} finally {
 			rmSync(outsideDir, { recursive: true, force: true });
 		}
+	});
+
+	it("preserves the mode bits (e.g. the exec bit) when reverting an ordinary file", () => {
+		const script = join(repo, "script.sh");
+		writeFileSync(script, "#!/bin/sh\necho hi\n");
+		chmodSync(script, 0o755);
+		git(["add", "script.sh"], repo);
+		git(["commit", "-m", "add script"], repo);
+		const base = captureTree(repo) as string;
+		// The agent edited only the script's content; the working-tree mode is
+		// unchanged (755) and the entry is an ordinary single-link regular file.
+		writeFileSync(script, "#!/bin/sh\necho AGENT\n");
+		expect(lstatSync(script).mode & 0o777).toBe(0o755);
+
+		expect(revertFile(repo, base, "script.sh")).toBe(true);
+		// Content is restored AND the exec bit is not silently stripped: an
+		// ordinary file must be overwritten in place, not unlinked-then-recreated
+		// (which would reset the mode to the umask default).
+		expect(readFileSync(script, "utf-8")).toBe("#!/bin/sh\necho hi\n");
+		expect(lstatSync(script).mode & 0o777).toBe(0o755);
 	});
 
 	it("revertFile removes a dangling symlink when reverting an agent-created path", () => {

--- a/packages/vscode/test/git-snapshot.test.ts
+++ b/packages/vscode/test/git-snapshot.test.ts
@@ -6,7 +6,17 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	lstatSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	renameSync,
+	rmSync,
+	symlinkSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -248,5 +258,41 @@ describe("git-snapshot", () => {
 		expect(existsSync(join(repo, "file.txt"))).toBe(true);
 		// baselineContent likewise reports null (not "") on a genuine read error.
 		expect(baselineContent(repo, bogusTree, "file.txt")).toBeNull();
+	});
+
+	it("revertFile does not write through a symlink to a file outside the repo", () => {
+		const base = captureTree(repo) as string;
+		// A file outside the repo whose content must never be touched by a revert.
+		const outsideDir = mkdtempSync(join(tmpdir(), "dreb-outside-"));
+		const outside = join(outsideDir, "victim.txt");
+		writeFileSync(outside, "OUTSIDE-DATA");
+		try {
+			// The agent's turn replaced the tracked file with a symlink to that
+			// outside file (surfaces as a type change → "modified" in the review set).
+			rmSync(join(repo, "file.txt"));
+			symlinkSync(outside, join(repo, "file.txt"));
+
+			expect(revertFile(repo, base, "file.txt")).toBe(true);
+			// The tracked path is restored as a REGULAR file with baseline content…
+			expect(lstatSync(join(repo, "file.txt")).isSymbolicLink()).toBe(false);
+			expect(read(repo, "file.txt")).toEqual(lines());
+			// …and the outside file was NOT clobbered by writing through the link.
+			expect(readFileSync(outside, "utf-8")).toBe("OUTSIDE-DATA");
+		} finally {
+			rmSync(outsideDir, { recursive: true, force: true });
+		}
+	});
+
+	it("revertFile removes a dangling symlink when reverting an agent-created path", () => {
+		const base = captureTree(repo) as string;
+		// The agent created `link.txt` (absent from baseline) as a broken symlink.
+		// `existsSync` follows symlinks and would report a broken link as absent,
+		// skipping cleanup; the lstat-based check must still remove it.
+		symlinkSync(join(repo, "no-such-target"), join(repo, "link.txt"));
+		expect(lstatSync(join(repo, "link.txt")).isSymbolicLink()).toBe(true);
+
+		expect(revertFile(repo, base, "link.txt")).toBe(true);
+		// The dangling link is gone from disk (lstat throws ENOENT).
+		expect(() => lstatSync(join(repo, "link.txt"))).toThrow();
 	});
 });

--- a/packages/vscode/test/git-snapshot.test.ts
+++ b/packages/vscode/test/git-snapshot.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -163,5 +163,90 @@ describe("git-snapshot", () => {
 
 		expect(revertFile(repo, base, "created.txt")).toBe(true);
 		expect(existsSync(join(repo, "created.txt"))).toBe(false);
+	});
+
+	it("does not garble the changed set when a file is renamed (rename detection off)", () => {
+		// A second tracked file so any pair-wise desync from a 3-token rename
+		// record would corrupt this entry too.
+		write(repo, "other.txt", ["keep1", "keep2", "keep3"]);
+		git(["add", "other.txt"], repo);
+		git(["commit", "-m", "add other"], repo);
+
+		const base = captureTree(repo) as string;
+		// Rename file.txt → renamed.txt (content-identical → git would call it a
+		// rename with detection on) and independently modify other.txt.
+		renameSync(join(repo, "file.txt"), join(repo, "renamed.txt"));
+		write(repo, "other.txt", ["keep1", "CHANGED", "keep3"]);
+
+		const changed = changedFiles(repo, base).sort((a, b) => a.path.localeCompare(b.path));
+		// With --no-renames the rename degrades to a clean delete + add, and the
+		// unrelated modification is parsed correctly (no status/path swap).
+		expect(changed).toEqual([
+			{ path: "file.txt", status: "deleted", hunkCount: expect.any(Number) },
+			{ path: "other.txt", status: "modified", hunkCount: 1 },
+			{ path: "renamed.txt", status: "added", hunkCount: expect.any(Number) },
+		]);
+	});
+
+	it("works when cwd is a subdirectory of the repo (paths stay repo-root-relative)", () => {
+		mkdirSync(join(repo, "sub"), { recursive: true });
+		write(repo, "sub/nested.txt", lines());
+		git(["add", "sub/nested.txt"], repo);
+		git(["commit", "-m", "add nested"], repo);
+
+		const sub = join(repo, "sub");
+		expect(isGitRepo(sub)).toBe(true);
+		const base = captureTree(sub) as string;
+		expect(base).not.toBeNull();
+
+		const body = lines();
+		body[2] = "AGENT3";
+		write(repo, "sub/nested.txt", body);
+
+		// Changed-file paths are repo-root-relative even though cwd is the subdir.
+		const changed = changedFiles(sub, base);
+		expect(changed).toEqual([{ path: "sub/nested.txt", status: "modified", hunkCount: 1 }]);
+
+		// fileDiff, baselineContent, and revertFile all resolve against the repo
+		// root — not the subdir — so they operate on the real file.
+		expect(fileDiff(sub, base, "sub/nested.txt").diff).toContain("AGENT3");
+		expect(baselineContent(sub, base, "sub/nested.txt")).toBe(`${lines().join("\n")}\n`);
+		expect(revertFile(sub, base, "sub/nested.txt")).toBe(true);
+		expect(read(repo, "sub/nested.txt")).toEqual(lines());
+	});
+
+	it("revertHunk reverts a subdir file's hunk when cwd is that subdir", () => {
+		mkdirSync(join(repo, "sub"), { recursive: true });
+		write(repo, "sub/nested.txt", lines());
+		git(["add", "sub/nested.txt"], repo);
+		git(["commit", "-m", "add nested"], repo);
+
+		const sub = join(repo, "sub");
+		const base = captureTree(sub) as string;
+		const body = lines();
+		body[2] = "AGENT3";
+		body[15] = "AGENT16";
+		write(repo, "sub/nested.txt", body);
+
+		expect(revertHunk(sub, base, "sub/nested.txt", 0)).toBe(true);
+		const after = read(repo, "sub/nested.txt");
+		expect(after[2]).toBe("line3"); // first hunk reverted
+		expect(after[15]).toBe("AGENT16"); // second preserved
+	});
+
+	it("revertFile refuses (returns false) and leaves the file untouched on a bad baseline ref", () => {
+		// A failed baseline read must never be mistaken for "absent from baseline"
+		// and trigger a destructive delete.
+		const body = lines();
+		body[4] = "AGENT5";
+		write(repo, "file.txt", body);
+		const bogusTree = "0000000000000000000000000000000000000000";
+
+		expect(revertFile(repo, bogusTree, "file.txt")).toBe(false);
+		// The working file is left exactly as it was (NOT deleted, NOT truncated).
+		expect(read(repo, "file.txt")).toEqual(body);
+		expect(existsSync(join(repo, "file.txt"))).toBe(true);
+		// baselineContent likewise reports null (not "") on a genuine read error.
+		expect(baselineContent(repo, bogusTree, "file.txt")).toBeNull();
 	});
 });

--- a/packages/vscode/test/git-snapshot.test.ts
+++ b/packages/vscode/test/git-snapshot.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Real-git integration tests for the change-review snapshot engine. Each test
+ * runs against a throwaway temp repo (mirroring `coding-agent`'s
+ * `git-update.test.ts`), exercising the actual git plumbing: temp-index tree
+ * capture, tree-to-tree change detection, and `git apply --reverse` per hunk.
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	baselineContent,
+	captureTree,
+	changedFiles,
+	fileDiff,
+	isGitRepo,
+	revertFile,
+	revertHunk,
+} from "../src/host/git-snapshot.js";
+
+function git(args: string[], cwd: string): string {
+	const result = spawnSync("git", args, { cwd, encoding: "utf-8" });
+	if (result.status !== 0) throw new Error(`git ${args.join(" ")} failed:\n${result.stderr}`);
+	return result.stdout.trim();
+}
+
+function initRepo(dir: string): void {
+	git(["init", "--initial-branch=main"], dir);
+	git(["config", "--local", "user.email", "t@t.com"], dir);
+	git(["config", "--local", "user.name", "Test"], dir);
+	git(["config", "--local", "commit.gpgsign", "false"], dir);
+}
+
+/** A deterministic 20-line file body; edit specific lines to force hunks. */
+function lines(n = 20): string[] {
+	return Array.from({ length: n }, (_, i) => `line${i + 1}`);
+}
+
+function write(dir: string, name: string, body: string[]): void {
+	writeFileSync(join(dir, name), `${body.join("\n")}\n`);
+}
+
+function read(dir: string, name: string): string[] {
+	return readFileSync(join(dir, name), "utf-8").replace(/\n$/, "").split("\n");
+}
+
+describe("git-snapshot", () => {
+	let repo: string;
+
+	beforeEach(() => {
+		repo = mkdtempSync(join(tmpdir(), "dreb-snap-"));
+		initRepo(repo);
+		write(repo, "file.txt", lines());
+		git(["add", "file.txt"], repo);
+		git(["commit", "-m", "init"], repo);
+	});
+
+	afterEach(() => {
+		rmSync(repo, { recursive: true, force: true });
+	});
+
+	it("detects a git repo and rejects a non-repo dir", () => {
+		expect(isGitRepo(repo)).toBe(true);
+		const plain = mkdtempSync(join(tmpdir(), "dreb-plain-"));
+		try {
+			expect(isGitRepo(plain)).toBe(false);
+			expect(captureTree(plain)).toBeNull();
+		} finally {
+			rmSync(plain, { recursive: true, force: true });
+		}
+	});
+
+	it("captureTree does not touch the user's real index", () => {
+		const before = git(["status", "--porcelain"], repo);
+		expect(captureTree(repo)).toMatch(/^[0-9a-f]{40}$/);
+		expect(git(["status", "--porcelain"], repo)).toBe(before);
+		expect(git(["diff", "--cached", "--name-only"], repo)).toBe("");
+	});
+
+	it("lists a modified file with its hunk count", () => {
+		const base = captureTree(repo);
+		expect(base).not.toBeNull();
+		const body = lines();
+		body[2] = "AGENT3";
+		write(repo, "file.txt", body);
+		const changed = changedFiles(repo, base as string);
+		expect(changed).toEqual([{ path: "file.txt", status: "modified", hunkCount: 1 }]);
+	});
+
+	it("classifies added and deleted files", () => {
+		const base = captureTree(repo) as string;
+		write(repo, "created.txt", ["hello"]);
+		rmSync(join(repo, "file.txt"));
+		const changed = changedFiles(repo, base).sort((a, b) => a.path.localeCompare(b.path));
+		expect(changed.map((c) => ({ path: c.path, status: c.status }))).toEqual([
+			{ path: "created.txt", status: "added" },
+			{ path: "file.txt", status: "deleted" },
+		]);
+	});
+
+	it("baselineContent returns baseline text, null for a newly-created file", () => {
+		const base = captureTree(repo) as string;
+		write(repo, "created.txt", ["new"]);
+		expect(baselineContent(repo, base, "file.txt")).toBe(`${lines().join("\n")}\n`);
+		expect(baselineContent(repo, base, "created.txt")).toBeNull();
+	});
+
+	it("reverts exactly one hunk, leaving the other agent change intact", () => {
+		const base = captureTree(repo) as string;
+		const body = lines();
+		body[2] = "AGENT3"; // hunk near line 3
+		body[15] = "AGENT16"; // hunk near line 16 (well separated → two hunks)
+		write(repo, "file.txt", body);
+
+		const { diff } = fileDiff(repo, base, "file.txt");
+		expect(diff).toContain("AGENT3");
+		expect(diff).toContain("AGENT16");
+
+		// Reject the first hunk only.
+		expect(revertHunk(repo, base, "file.txt", 0)).toBe(true);
+		const after = read(repo, "file.txt");
+		expect(after[2]).toBe("line3"); // first change reverted
+		expect(after[15]).toBe("AGENT16"); // second change preserved
+	});
+
+	it("does NOT clobber the user's pre-existing dirty edit when reverting an agent hunk", () => {
+		// User edits line 3 and leaves it uncommitted…
+		const userBody = lines();
+		userBody[2] = "USER3";
+		write(repo, "file.txt", userBody);
+
+		// …baseline is captured AFTER the user's edit, so it includes USER3.
+		const base = captureTree(repo) as string;
+
+		// Agent then edits a far-away line.
+		const agentBody = [...userBody];
+		agentBody[15] = "AGENT16";
+		write(repo, "file.txt", agentBody);
+
+		// The diff is only the agent's change (USER3 is in the baseline).
+		const { diff } = fileDiff(repo, base, "file.txt");
+		expect(diff).toContain("AGENT16");
+		expect(diff).not.toContain("USER3");
+
+		// Rejecting the agent hunk restores line 16 but preserves the user's USER3.
+		expect(revertHunk(repo, base, "file.txt", 0)).toBe(true);
+		const after = read(repo, "file.txt");
+		expect(after[2]).toBe("USER3");
+		expect(after[15]).toBe("line16");
+	});
+
+	it("revertFile restores a modified file and deletes a newly-created one", () => {
+		const base = captureTree(repo) as string;
+		const body = lines();
+		body[4] = "AGENT5";
+		write(repo, "file.txt", body);
+		write(repo, "created.txt", ["remove me"]);
+
+		expect(revertFile(repo, base, "file.txt")).toBe(true);
+		expect(read(repo, "file.txt")).toEqual(lines());
+
+		expect(revertFile(repo, base, "created.txt")).toBe(true);
+		expect(existsSync(join(repo, "created.txt"))).toBe(false);
+	});
+});

--- a/packages/vscode/test/git-snapshot.test.ts
+++ b/packages/vscode/test/git-snapshot.test.ts
@@ -8,6 +8,7 @@
 import { spawnSync } from "node:child_process";
 import {
 	existsSync,
+	linkSync,
 	lstatSync,
 	mkdirSync,
 	mkdtempSync,
@@ -277,6 +278,31 @@ describe("git-snapshot", () => {
 			expect(lstatSync(join(repo, "file.txt")).isSymbolicLink()).toBe(false);
 			expect(read(repo, "file.txt")).toEqual(lines());
 			// …and the outside file was NOT clobbered by writing through the link.
+			expect(readFileSync(outside, "utf-8")).toBe("OUTSIDE-DATA");
+		} finally {
+			rmSync(outsideDir, { recursive: true, force: true });
+		}
+	});
+
+	it("does not truncate a hard link's shared inode outside the repo", () => {
+		const base = captureTree(repo) as string;
+		const outsideDir = mkdtempSync(join(tmpdir(), "dreb-outside-"));
+		const outside = join(outsideDir, "victim.txt");
+		writeFileSync(outside, "OUTSIDE-DATA");
+		try {
+			// The agent's turn replaced the tracked file with a HARD LINK to that
+			// outside file. lstat reports it as a regular file (isFile() === true),
+			// so an in-place `writeFileSync` would truncate the shared inode and
+			// corrupt the outside file.
+			rmSync(join(repo, "file.txt"));
+			linkSync(outside, join(repo, "file.txt"));
+			expect(lstatSync(join(repo, "file.txt")).nlink).toBe(2);
+
+			expect(revertFile(repo, base, "file.txt")).toBe(true);
+			// The tracked path is a fresh, unshared regular file with baseline content…
+			expect(read(repo, "file.txt")).toEqual(lines());
+			expect(lstatSync(join(repo, "file.txt")).nlink).toBe(1);
+			// …and the outside file it used to share an inode with is untouched.
 			expect(readFileSync(outside, "utf-8")).toBe("OUTSIDE-DATA");
 		} finally {
 			rmSync(outsideDir, { recursive: true, force: true });

--- a/packages/vscode/test/review-model.test.ts
+++ b/packages/vscode/test/review-model.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { type ChangedFile, ReviewModel } from "../src/host/review-model.js";
+
+const changed = (path: string, status: ChangedFile["status"] = "modified", hunkCount = 1): ChangedFile => ({
+	path,
+	status,
+	hunkCount,
+});
+
+describe("ReviewModel", () => {
+	it("starts idle with no cycle", () => {
+		const m = new ReviewModel();
+		expect(m.hasCycle()).toBe(false);
+		expect(m.baselineRef()).toBeUndefined();
+		expect(m.pending([changed("a.ts")])).toEqual([]);
+	});
+
+	it("beginCycle records the baseline and is idempotent (changes compound)", () => {
+		const m = new ReviewModel();
+		m.beginCycle("tree1");
+		expect(m.hasCycle()).toBe(true);
+		expect(m.baselineRef()).toBe("tree1");
+		// A second begin does not replace the baseline — later turns compound.
+		m.beginCycle("tree2");
+		expect(m.baselineRef()).toBe("tree1");
+	});
+
+	it("derives pending as changed-minus-accepted, sorted by path", () => {
+		const m = new ReviewModel();
+		m.beginCycle("t");
+		const files = [changed("b.ts", "modified", 2), changed("a.ts", "added", 1)];
+		expect(m.pending(files).map((f) => f.path)).toEqual(["a.ts", "b.ts"]);
+		expect(m.pending(files)[0]).toEqual({ path: "a.ts", status: "added", hunkCount: 1 });
+	});
+
+	it("accept hides a file from the pending list", () => {
+		const m = new ReviewModel();
+		m.beginCycle("t");
+		m.accept("a.ts");
+		const pending = m.pending([changed("a.ts"), changed("b.ts")]);
+		expect(pending.map((f) => f.path)).toEqual(["b.ts"]);
+	});
+
+	it("unaccept re-shows a previously accepted file", () => {
+		const m = new ReviewModel();
+		m.beginCycle("t");
+		m.accept("a.ts");
+		m.unaccept("a.ts");
+		expect(m.pending([changed("a.ts")]).map((f) => f.path)).toEqual(["a.ts"]);
+	});
+
+	it("reset ends the cycle and clears accept markers", () => {
+		const m = new ReviewModel();
+		m.beginCycle("t");
+		m.accept("a.ts");
+		m.reset();
+		expect(m.hasCycle()).toBe(false);
+		expect(m.baselineRef()).toBeUndefined();
+		// After reset, a fresh cycle shows the file again (accept markers gone).
+		m.beginCycle("t2");
+		expect(m.pending([changed("a.ts")]).map((f) => f.path)).toEqual(["a.ts"]);
+	});
+});

--- a/packages/vscode/test/session-controller-review.test.ts
+++ b/packages/vscode/test/session-controller-review.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -129,6 +129,15 @@ async function startController(
 const flush = async () => {
 	for (let i = 0; i < 8; i++) await Promise.resolve();
 };
+
+/** Extract host_notice messages from captured controller updates. */
+function hostNotices(updates: ControllerUpdate[]): string[] {
+	return updates
+		.filter((u): u is Extract<ControllerUpdate, { kind: "event" }> => u.kind === "event")
+		.map((u) => u.event as { type?: unknown; message?: unknown })
+		.filter((e) => e?.type === "host_notice")
+		.map((e) => String(e.message ?? ""));
+}
 
 describe("SessionController change review", () => {
 	let repo: string;
@@ -276,5 +285,91 @@ describe("SessionController change review", () => {
 		expect(readFileSync(join(repo, "file.txt"), "utf-8")).toBe(editedA);
 		expect(git(["rev-parse", "HEAD"], repo)).toBe(headBefore);
 		expect(git(["status", "--porcelain"], repo)).not.toBe(""); // still uncommitted
+	});
+
+	it("reports a notice and keeps the file pending when reviewRevertFile fails", async () => {
+		const review = new RecordingReviewUi();
+		const { controller, client, updates } = await startController(repo, review);
+
+		client.emit({ type: "turn_start" });
+		writeFileSync(join(repo, "file.txt"), body().replace("line3", "AGENT3"));
+		client.emit({ type: "agent_end", messages: [] });
+		await flush();
+		expect(controller.getReviewState().files).toHaveLength(1);
+
+		// Replace the working-tree file with a directory so revertFile's write
+		// throws (EISDIR) and returns false — deterministically forcing the
+		// failure branch regardless of the test user's permissions.
+		rmSync(join(repo, "file.txt"));
+		mkdirSync(join(repo, "file.txt"));
+
+		await controller.reviewRevertFile("file.txt");
+
+		// The failed file is NOT silently dropped — it stays pending…
+		expect(controller.getReviewState().files.map((f) => f.path)).toContain("file.txt");
+		// …and a host_notice was emitted.
+		expect(hostNotices(updates).some((m) => /could not revert/i.test(m))).toBe(true);
+	});
+
+	it("reverts what it can, keeps failures pending, and notices them on a partial reviewRevertAll", async () => {
+		writeFileSync(join(repo, "file2.txt"), body());
+		git(["add", "file2.txt"], repo);
+		git(["commit", "-m", "add file2"], repo);
+
+		const review = new RecordingReviewUi();
+		const { controller, client, updates } = await startController(repo, review);
+
+		client.emit({ type: "turn_start" });
+		writeFileSync(join(repo, "file.txt"), body().replace("line3", "AGENT3"));
+		writeFileSync(join(repo, "file2.txt"), body().replace("line5", "AGENT5"));
+		client.emit({ type: "agent_end", messages: [] });
+		await flush();
+		expect(controller.getReviewState().files).toHaveLength(2);
+
+		// Sabotage only file2.txt's revert (directory → EISDIR on write).
+		rmSync(join(repo, "file2.txt"));
+		mkdirSync(join(repo, "file2.txt"));
+
+		await controller.reviewRevertAll();
+
+		// file.txt reverted successfully and dropped out; file2.txt failed and
+		// remains pending (not silently cleared while its edit persists on disk).
+		expect(readFileSync(join(repo, "file.txt"), "utf-8")).toBe(body());
+		expect(controller.getReviewState().files.map((f) => f.path)).toEqual(["file2.txt"]);
+		// The failure was surfaced to the user.
+		expect(hostNotices(updates).some((m) => /could not revert.*file2\.txt/i.test(m))).toBe(true);
+	});
+
+	it("reports review enabled synchronously at construction (before start) in a git repo", () => {
+		// getReviewState() must reflect the real git state immediately — before the
+		// slow start() handshake — so an early webview `ready` isn't answered with a
+		// spurious "change review unavailable" notice.
+		const controller = new SessionController({ cwd: repo, cliPath: "unused", clientFactory: () => new MiniClient() });
+		expect(controller.getReviewState()).toEqual({ enabled: true, files: [] });
+	});
+
+	it("reports review disabled synchronously at construction outside a git repo", () => {
+		const plain = mkdtempSync(join(tmpdir(), "dreb-ctrl-plain-ctor-"));
+		try {
+			const controller = new SessionController({
+				cwd: plain,
+				cliPath: "unused",
+				clientFactory: () => new MiniClient(),
+			});
+			expect(controller.getReviewState()).toEqual({ enabled: false, files: [] });
+		} finally {
+			rmSync(plain, { recursive: true, force: true });
+		}
+	});
+
+	it("emits the review state during start() so a webview live before start is updated", async () => {
+		const review = new RecordingReviewUi();
+		const { updates } = await startController(repo, review);
+		const reviewUpdate = updates.find((u) => u.kind === "review");
+		expect(reviewUpdate).toBeDefined();
+		expect((reviewUpdate as Extract<ControllerUpdate, { kind: "review" }>).review).toEqual({
+			enabled: true,
+			files: [],
+		});
 	});
 });

--- a/packages/vscode/test/session-controller-review.test.ts
+++ b/packages/vscode/test/session-controller-review.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Controller-level change-review wiring, exercised against a real temp git repo.
+ * Verifies the turn_start → capture, agent_end → detect flow, the emitted
+ * `review` updates, and the accept/revert methods — with a recording ReviewUi
+ * fake standing in for the native SCM surface.
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { ReviewUi } from "../src/host/review-ui.js";
+import { type ControllerUpdate, type RpcClientLike, SessionController } from "../src/host/session-controller.js";
+import type { ReviewFileDto } from "../src/shared/protocol.js";
+
+/** Minimal RpcClient fake: connects, streams events, returns benign status. */
+class MiniClient implements RpcClientLike {
+	private ev: ((e: any) => void) | undefined;
+	async start(): Promise<void> {}
+	async stop(): Promise<void> {}
+	async prompt(): Promise<void> {}
+	async abort(): Promise<void> {}
+	async compact(): Promise<unknown> {
+		return {};
+	}
+	async getCommands() {
+		return [];
+	}
+	sendExtensionUIResponse(): void {}
+	onEvent(listener: (event: any) => void): () => void {
+		this.ev = listener;
+		return () => {
+			this.ev = undefined;
+		};
+	}
+	onExit(): () => void {
+		return () => {};
+	}
+	async getState() {
+		return {};
+	}
+	async getDailyCost(): Promise<number> {
+		return 0;
+	}
+	async getSessionStats() {
+		return { cost: 0 };
+	}
+	async getAvailableModels() {
+		return [];
+	}
+	async setModel(provider: string, modelId: string) {
+		return { provider, id: modelId };
+	}
+	async setThinkingLevel(): Promise<void> {}
+	async newSession() {
+		return { cancelled: false };
+	}
+	async reload(): Promise<void> {}
+	async dream() {
+		return { message: "" };
+	}
+	async setSessionName(): Promise<void> {}
+	async exportHtml() {
+		return { path: "" };
+	}
+	async importJsonl() {
+		return { cancelled: false };
+	}
+	emit(event: unknown): void {
+		this.ev?.(event);
+	}
+}
+
+/** Recording ReviewUi. */
+class RecordingReviewUi implements ReviewUi {
+	baselines = new Map<string, string | null>();
+	pending: ReviewFileDto[] = [];
+	opened: string[] = [];
+	clears = 0;
+	setBaseline(path: string, content: string | null): void {
+		this.baselines.set(path, content);
+	}
+	setPending(files: ReviewFileDto[]): void {
+		this.pending = files;
+	}
+	async openDiff(path: string): Promise<void> {
+		this.opened.push(path);
+	}
+	clear(): void {
+		this.clears += 1;
+		this.pending = [];
+	}
+}
+
+function git(args: string[], cwd: string): void {
+	const r = spawnSync("git", args, { cwd, encoding: "utf-8" });
+	if (r.status !== 0) throw new Error(`git ${args.join(" ")}: ${r.stderr}`);
+}
+
+function initRepo(dir: string): void {
+	git(["init", "--initial-branch=main"], dir);
+	git(["config", "--local", "user.email", "t@t.com"], dir);
+	git(["config", "--local", "user.name", "Test"], dir);
+	git(["config", "--local", "commit.gpgsign", "false"], dir);
+}
+
+const body = (n = 20) => `${Array.from({ length: n }, (_, i) => `line${i + 1}`).join("\n")}\n`;
+
+async function startController(
+	cwd: string,
+	review: ReviewUi,
+): Promise<{ controller: SessionController; client: MiniClient; updates: ControllerUpdate[] }> {
+	const client = new MiniClient();
+	const controller = new SessionController({
+		cwd,
+		cliPath: "unused",
+		clientFactory: () => client,
+		review,
+	});
+	const updates: ControllerUpdate[] = [];
+	controller.onUpdate((u) => updates.push(u));
+	await controller.start();
+	return { controller, client, updates };
+}
+
+/** Let queued microtasks (the async status refresh) settle. */
+const flush = async () => {
+	for (let i = 0; i < 8; i++) await Promise.resolve();
+};
+
+describe("SessionController change review", () => {
+	let repo: string;
+
+	beforeEach(() => {
+		repo = mkdtempSync(join(tmpdir(), "dreb-ctrl-review-"));
+		initRepo(repo);
+		writeFileSync(join(repo, "file.txt"), body());
+		git(["add", "file.txt"], repo);
+		git(["commit", "-m", "init"], repo);
+	});
+
+	afterEach(() => {
+		rmSync(repo, { recursive: true, force: true });
+	});
+
+	it("captures on turn_start and publishes the changed file on agent_end", async () => {
+		const review = new RecordingReviewUi();
+		const { controller, client, updates } = await startController(repo, review);
+
+		client.emit({ type: "turn_start" });
+		// Agent edits a file mid-turn.
+		const edited = body().replace("line3", "AGENT3");
+		writeFileSync(join(repo, "file.txt"), edited);
+		client.emit({ type: "agent_end", messages: [] });
+		await flush();
+
+		const reviewUpdate = updates.filter((u) => u.kind === "review").at(-1);
+		expect(reviewUpdate).toBeDefined();
+		expect(controller.getReviewState().files).toEqual([{ path: "file.txt", status: "modified", hunkCount: 1 }]);
+		expect(review.pending.map((f) => f.path)).toEqual(["file.txt"]);
+		expect(review.baselines.get("file.txt")).toBe(body());
+	});
+
+	it("reverting the file discards the change and clears the pending set", async () => {
+		const review = new RecordingReviewUi();
+		const { controller, client } = await startController(repo, review);
+
+		client.emit({ type: "turn_start" });
+		writeFileSync(join(repo, "file.txt"), body().replace("line3", "AGENT3"));
+		client.emit({ type: "agent_end", messages: [] });
+		await flush();
+		expect(controller.getReviewState().files).toHaveLength(1);
+
+		await controller.reviewRevertFile("file.txt");
+		expect(readFileSync(join(repo, "file.txt"), "utf-8")).toBe(body());
+		expect(controller.getReviewState().files).toEqual([]);
+	});
+
+	it("acceptAll clears review state and the surface without touching the file", async () => {
+		const review = new RecordingReviewUi();
+		const { controller, client } = await startController(repo, review);
+
+		client.emit({ type: "turn_start" });
+		const edited = body().replace("line3", "AGENT3");
+		writeFileSync(join(repo, "file.txt"), edited);
+		client.emit({ type: "agent_end", messages: [] });
+		await flush();
+
+		await controller.reviewAcceptAll();
+		expect(controller.getReviewState().files).toEqual([]);
+		expect(review.clears).toBeGreaterThanOrEqual(1);
+		// Accept keeps the change on disk (no commit, no revert).
+		expect(readFileSync(join(repo, "file.txt"), "utf-8")).toBe(edited);
+	});
+
+	it("rejectHunkAtLine reverts only the hunk at that line", async () => {
+		const review = new RecordingReviewUi();
+		const { controller, client } = await startController(repo, review);
+
+		client.emit({ type: "turn_start" });
+		const edited = body().replace("line3", "AGENT3").replace("line16", "AGENT16");
+		writeFileSync(join(repo, "file.txt"), edited);
+		client.emit({ type: "agent_end", messages: [] });
+		await flush();
+
+		// Line 3 is in the first hunk.
+		expect(await controller.reviewRejectHunkAtLine("file.txt", 3)).toBe(true);
+		const after = readFileSync(join(repo, "file.txt"), "utf-8").split("\n");
+		expect(after[2]).toBe("line3"); // reverted
+		expect(after[15]).toBe("AGENT16"); // preserved
+	});
+
+	it("disables review outside a git repo", async () => {
+		const plain = mkdtempSync(join(tmpdir(), "dreb-ctrl-plain-"));
+		try {
+			const review = new RecordingReviewUi();
+			const { controller, client } = await startController(plain, review);
+			client.emit({ type: "turn_start" });
+			writeFileSync(join(plain, "file.txt"), "x");
+			client.emit({ type: "agent_end", messages: [] });
+			await flush();
+			expect(controller.getReviewState().enabled).toBe(false);
+			expect(controller.getReviewState().files).toEqual([]);
+			expect(review.pending).toEqual([]);
+			expect(existsSync(join(plain, "file.txt"))).toBe(true);
+		} finally {
+			rmSync(plain, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/vscode/test/session-controller-review.test.ts
+++ b/packages/vscode/test/session-controller-review.test.ts
@@ -93,9 +93,10 @@ class RecordingReviewUi implements ReviewUi {
 	}
 }
 
-function git(args: string[], cwd: string): void {
+function git(args: string[], cwd: string): string {
 	const r = spawnSync("git", args, { cwd, encoding: "utf-8" });
 	if (r.status !== 0) throw new Error(`git ${args.join(" ")}: ${r.stderr}`);
+	return (r.stdout ?? "").trim();
 }
 
 function initRepo(dir: string): void {
@@ -227,5 +228,53 @@ describe("SessionController change review", () => {
 		} finally {
 			rmSync(plain, { recursive: true, force: true });
 		}
+	});
+
+	it("revertAll restores every file of a multi-file turn and clears the cycle", async () => {
+		// Add a second tracked file so the turn spans two files.
+		writeFileSync(join(repo, "file2.txt"), body());
+		git(["add", "file2.txt"], repo);
+		git(["commit", "-m", "add file2"], repo);
+
+		const review = new RecordingReviewUi();
+		const { controller, client } = await startController(repo, review);
+
+		client.emit({ type: "turn_start" });
+		writeFileSync(join(repo, "file.txt"), body().replace("line3", "AGENT3"));
+		writeFileSync(join(repo, "file2.txt"), body().replace("line5", "AGENT5"));
+		client.emit({ type: "agent_end", messages: [] });
+		await flush();
+		expect(controller.getReviewState().files).toHaveLength(2);
+
+		await controller.reviewRevertAll();
+		expect(readFileSync(join(repo, "file.txt"), "utf-8")).toBe(body());
+		expect(readFileSync(join(repo, "file2.txt"), "utf-8")).toBe(body());
+		expect(controller.getReviewState().files).toEqual([]);
+	});
+
+	it("acceptFile hides one file while the other stays pending, without commit or revert", async () => {
+		writeFileSync(join(repo, "file2.txt"), body());
+		git(["add", "file2.txt"], repo);
+		git(["commit", "-m", "add file2"], repo);
+		const headBefore = git(["rev-parse", "HEAD"], repo);
+
+		const review = new RecordingReviewUi();
+		const { controller, client } = await startController(repo, review);
+
+		client.emit({ type: "turn_start" });
+		const editedA = body().replace("line3", "AGENT3");
+		writeFileSync(join(repo, "file.txt"), editedA);
+		writeFileSync(join(repo, "file2.txt"), body().replace("line5", "AGENT5"));
+		client.emit({ type: "agent_end", messages: [] });
+		await flush();
+		expect(controller.getReviewState().files).toHaveLength(2);
+
+		await controller.reviewAcceptFile("file.txt");
+		// file.txt drops out of the pending set; file2.txt remains.
+		expect(controller.getReviewState().files.map((f) => f.path)).toEqual(["file2.txt"]);
+		// Accept neither reverts (file content still the edited version) nor commits.
+		expect(readFileSync(join(repo, "file.txt"), "utf-8")).toBe(editedA);
+		expect(git(["rev-parse", "HEAD"], repo)).toBe(headBefore);
+		expect(git(["status", "--porcelain"], repo)).not.toBe(""); // still uncommitted
 	});
 });

--- a/packages/vscode/test/webview-bridge.test.ts
+++ b/packages/vscode/test/webview-bridge.test.ts
@@ -230,4 +230,66 @@ describe("connectWebview", () => {
 
 		expect(posted.length).toBe(afterReady); // nothing new posted post-dispose
 	});
+
+	it("posts the current review state on ready (so review survives reload)", async () => {
+		const fake = new BridgeFakeClient();
+		const controller = await makeController(fake);
+		vi.spyOn(controller, "getReviewState").mockReturnValue({
+			enabled: true,
+			files: [{ path: "src/a.ts", status: "modified", hunkCount: 2 }],
+		});
+		const { webview, posted, send } = makeWebview();
+		connectWebview(webview as any, controller);
+		send({ type: "ready" });
+
+		const review = posted.find((m) => m.type === "review") as Extract<HostToWebview, { type: "review" }> | undefined;
+		expect(review).toBeDefined();
+		expect(review?.review).toEqual({
+			enabled: true,
+			files: [{ path: "src/a.ts", status: "modified", hunkCount: 2 }],
+		});
+	});
+
+	it("forwards a review update as a review message when live", async () => {
+		const fake = new BridgeFakeClient();
+		const controller = await makeController(fake);
+		const { webview, posted, send } = makeWebview();
+		connectWebview(webview as any, controller);
+		send({ type: "ready" });
+		const before = posted.filter((m) => m.type === "review").length;
+
+		(controller as any).emit({
+			kind: "review",
+			review: { enabled: true, files: [{ path: "x.ts", status: "added", hunkCount: 1 }] },
+		});
+
+		const reviews = posted.filter((m) => m.type === "review") as Array<Extract<HostToWebview, { type: "review" }>>;
+		expect(reviews.length).toBe(before + 1);
+		expect(reviews.at(-1)?.review.files).toEqual([{ path: "x.ts", status: "added", hunkCount: 1 }]);
+	});
+
+	it("re-posts review state on a resync update", async () => {
+		const fake = new BridgeFakeClient();
+		const controller = await makeController(fake);
+		const { webview, posted, send } = makeWebview();
+		connectWebview(webview as any, controller);
+		send({ type: "ready" });
+		const before = posted.filter((m) => m.type === "review").length;
+
+		await controller.submit("/new");
+		const after = posted.filter((m) => m.type === "review").length;
+		expect(after).toBeGreaterThan(before);
+	});
+
+	it("routes a review-open-diff message to the controller", async () => {
+		const fake = new BridgeFakeClient();
+		const controller = await makeController(fake);
+		const openDiff = vi.spyOn(controller, "reviewOpenDiff").mockResolvedValue();
+		const { webview, send } = makeWebview();
+		connectWebview(webview as any, controller);
+		send({ type: "ready" });
+
+		send({ type: "review-open-diff", path: "src/a.ts" });
+		expect(openDiff).toHaveBeenCalledWith("src/a.ts");
+	});
 });


### PR DESCRIPTION
Closes #17

VSCode extension **Phase 3** — change review: per-turn git snapshot baseline, native diff/SCM visualization, and per-hunk keep/reject (revert performed by us via git's diff/apply, the non-interactive equivalent of `git restore -p`).

Targets the `vscode` integration branch (builds on merged Phase 0+1 and Phase 2). Independent `dreb-vscode` versioning; root version/tag/release deferred to the eventual `vscode` → master merge.

Implementation plan posted as a comment below.
