### PR TITLE
Make default system prompt more focused (less rabbit-hole)

### DIFF
--- a/packages/coding-agent/src/core/memory-prompt.ts
+++ b/packages/coding-agent/src/core/memory-prompt.ts
@@ -58,10 +58,12 @@ If the memory directory or MEMORY.md doesn't exist yet, create them.
 
 ## When to Save
 
-- **user-preferences**: When you learn about the user's role, expertise, or working style
-- **good-practices**: When the user corrects your approach OR confirms a non-obvious approach worked
-- **project**: When you learn who is doing what, why, or by when
-- **navigation**: When you learn about external resources and their purpose
+Memory is available but not a default action. Prefer saving at natural breakpoints or when the user asks — don't interrupt task work to record something. Worth saving:
+
+- **user-preferences**: the user's role, expertise, or working style
+- **good-practices**: when the user corrects your approach OR confirms a non-obvious approach worked
+- **project**: who is doing what, why, or by when
+- **navigation**: external resources and their purpose
 
 If the user explicitly asks you to remember something, save it immediately. If they ask you to forget something, find and remove the relevant entry.
 

--- a/packages/coding-agent/src/core/system-prompt.ts
+++ b/packages/coding-agent/src/core/system-prompt.ts
@@ -291,7 +291,7 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions = {}): strin
 	} else if (hasBash && (hasGrep || hasFind || hasLs)) {
 		if (hasSearch) {
 			addGuideline(
-				"Start with `search` to explore and understand the codebase. Use grep/find/ls for exact text matches and specific file lookups. Prefer all of these over bash.",
+				"Prefer grep/find/ls over bash for file exploration (faster, respects .gitignore). When you know the symbol or exact text, reach for a grep/find needle lookup first; `search` is available for semantic/natural-language lookup when you don't yet know what to grep for.",
 			);
 		} else {
 			addGuideline("Prefer grep/find/ls tools over bash for file exploration (faster, respects .gitignore)");
@@ -305,7 +305,22 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions = {}): strin
 		}
 	}
 
-	// Always include these
+	// Always include these — focus/scope discipline plus baseline conventions
+	addGuideline(
+		"Stay within the scope of the request; don't take significant actions beyond what was asked without checking in with one short question first",
+	);
+	addGuideline(
+		"Prefer the smallest correct change and the most direct path; don't broaden into tangential or \"while I'm here\" work",
+	);
+	addGuideline(
+		"Build context by examining what the task needs, not by exploring broadly; prefer a targeted needle lookup before any broad search",
+	);
+	addGuideline("Decide and act on the most reasonable interpretation; don't over-enumerate options or over-analyze");
+	addGuideline(
+		"Prioritize accuracy over confirming assumptions; when unsure, investigate to verify rather than running with a guess",
+	);
+	addGuideline("Prefer editing existing files over creating new ones");
+	addGuideline("Match response length to task complexity, and lead with the result");
 	addGuideline("Be concise in your responses");
 	addGuideline("Show file paths clearly when working with files");
 

--- a/packages/coding-agent/src/core/tools/search.ts
+++ b/packages/coding-agent/src/core/tools/search.ts
@@ -148,7 +148,7 @@ export function createSearchToolDefinition(cwd: string): ToolDefinition<typeof s
 			"Search the codebase using natural language queries. Returns ranked code/doc results using semantic similarity and keyword matching. First query builds the index (may take a moment); subsequent queries are fast. Supports identifier queries (e.g. 'AuthMiddleware'), natural language (e.g. 'where is rate limiting handled'), and path queries (e.g. 'src/auth/').",
 		promptSnippet: "Semantic codebase search — natural language queries over code and docs",
 		promptGuidelines: [
-			"Use `search` as your default exploration tool — for understanding code, finding where things are, and answering questions about the codebase. Use `grep` when you already know the exact text or pattern you're looking for.",
+			"`search` is available for semantic/natural-language lookup over code and docs — use it when you don't yet know the exact symbol or text. When you already know what you're looking for, prefer `grep`/`find`.",
 			"The first search query builds an index (may take 10-60s). Subsequent queries are fast.",
 		],
 		parameters: searchSchema,

--- a/packages/coding-agent/src/core/tools/tasks.ts
+++ b/packages/coding-agent/src/core/tools/tasks.ts
@@ -100,11 +100,12 @@ export function createTasksToolDefinition(
 		promptSnippet: "Create or update session task list for multi-step work",
 
 		promptGuidelines: [
-			"For work requiring 3 or more steps, use tasks_update to organize your plan and show progress",
+			"For genuinely multi-step work, use tasks_update to organize your plan and show progress; skip it for simple one- or two-step tasks",
 			"Send the complete task list each time (full replacement, not a patch)",
 			"At most one task can be in_progress at a time",
 			"Keep task lists concise: typically 3-10 items. Never exceed 20 tasks.",
 			'Use short, action-oriented titles (e.g. "Read existing tests", "Fix auth handler")',
+			"Don't add tasks mid-run that go beyond the agreed scope of the work",
 		],
 
 		async execute(_toolCallId, { tasks }: TasksToolInput, _signal?, _onUpdate?, _ctx?) {

--- a/packages/coding-agent/test/memory.test.ts
+++ b/packages/coding-agent/test/memory.test.ts
@@ -261,6 +261,17 @@ describe("getMemoryInstructions", () => {
 		});
 		expect(instructions).toContain(".dreb/CONTEXT.md");
 	});
+
+	test("frames saving as opt-in restraint while preserving explicit-save line", () => {
+		const instructions = getMemoryInstructions({
+			globalMemoryDir: "/home/user/.dreb/memory",
+			projectMemoryDir: "/project/.dreb/memory",
+		});
+		expect(instructions).toContain("Memory is available but not a default action");
+		expect(instructions).toContain("don't interrupt task work to record something");
+		expect(instructions).toContain("If the user explicitly asks you to remember something, save it immediately.");
+		expect(instructions).not.toContain("When you learn about the user's role");
+	});
 });
 
 describe("encodeClaudeProjectPath", () => {

--- a/packages/coding-agent/test/memory.test.ts
+++ b/packages/coding-agent/test/memory.test.ts
@@ -261,17 +261,6 @@ describe("getMemoryInstructions", () => {
 		});
 		expect(instructions).toContain(".dreb/CONTEXT.md");
 	});
-
-	test("frames saving as opt-in restraint while preserving explicit-save line", () => {
-		const instructions = getMemoryInstructions({
-			globalMemoryDir: "/home/user/.dreb/memory",
-			projectMemoryDir: "/project/.dreb/memory",
-		});
-		expect(instructions).toContain("Memory is available but not a default action");
-		expect(instructions).toContain("don't interrupt task work to record something");
-		expect(instructions).toContain("If the user explicitly asks you to remember something, save it immediately.");
-		expect(instructions).not.toContain("When you learn about the user's role");
-	});
 });
 
 describe("encodeClaudeProjectPath", () => {

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -111,18 +111,34 @@ describe("buildSystemPrompt", () => {
 			expect(prompt).toContain("Specialized agents may perform the broader work");
 			expect(prompt).not.toContain("Use `subagent` to delegate focused, independent tasks to child agents");
 		});
+
+		test("preserves mach6-critical subagent mechanics (background-notify, end-turn-to-await)", () => {
+			const prompt = buildSystemPrompt({
+				selectedTools: ["subagent"],
+				toolSnippets: { subagent: subagentToolDefinition.promptSnippet! },
+				promptGuidelines: subagentToolDefinition.promptGuidelines,
+				contextFiles: [],
+				skills: [],
+			});
+
+			expect(prompt).toContain("All subagents run in background");
+			expect(prompt).toContain("end your current turn with no tool calls");
+			expect(prompt).toContain("delegation is optional, not an unconditional default");
+		});
 	});
 
 	describe("exploration guidelines", () => {
-		test("includes search-first guidance when search tool is available", () => {
+		test("includes needle-first search guidance when search tool is available", () => {
 			const prompt = buildSystemPrompt({
 				selectedTools: ["bash", "grep", "find", "ls", "search"],
 				contextFiles: [],
 				skills: [],
 			});
 
-			expect(prompt).toContain("Start with `search`");
-			expect(prompt).not.toContain("Prefer grep/find/ls tools over bash");
+			expect(prompt).toContain("reach for a grep/find needle lookup first");
+			expect(prompt).toContain("`search` is available for semantic/natural-language lookup");
+			expect(prompt).not.toContain("Start with `search`");
+			expect(prompt).not.toContain("default exploration tool");
 		});
 
 		test("falls back to grep/find guidance when search is not available", () => {
@@ -133,7 +149,22 @@ describe("buildSystemPrompt", () => {
 			});
 
 			expect(prompt).toContain("Prefer grep/find/ls tools over bash");
-			expect(prompt).not.toContain("Start with `search`");
+			expect(prompt).not.toContain("needle lookup first");
+		});
+	});
+
+	describe("focus and scope discipline", () => {
+		test("always includes focus/scope guidelines regardless of tools", () => {
+			const prompt = buildSystemPrompt({
+				selectedTools: [],
+				contextFiles: [],
+				skills: [],
+			});
+
+			expect(prompt).toContain("Stay within the scope of the request");
+			expect(prompt).toContain("Prefer the smallest correct change");
+			expect(prompt).toContain("Prefer editing existing files over creating new ones");
+			expect(prompt).toContain("Match response length to task complexity");
 		});
 	});
 

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -111,20 +111,6 @@ describe("buildSystemPrompt", () => {
 			expect(prompt).toContain("Specialized agents may perform the broader work");
 			expect(prompt).not.toContain("Use `subagent` to delegate focused, independent tasks to child agents");
 		});
-
-		test("preserves mach6-critical subagent mechanics (background-notify, end-turn-to-await)", () => {
-			const prompt = buildSystemPrompt({
-				selectedTools: ["subagent"],
-				toolSnippets: { subagent: subagentToolDefinition.promptSnippet! },
-				promptGuidelines: subagentToolDefinition.promptGuidelines,
-				contextFiles: [],
-				skills: [],
-			});
-
-			expect(prompt).toContain("All subagents run in background");
-			expect(prompt).toContain("end your current turn with no tool calls");
-			expect(prompt).toContain("delegation is optional, not an unconditional default");
-		});
 	});
 
 	describe("exploration guidelines", () => {
@@ -150,21 +136,6 @@ describe("buildSystemPrompt", () => {
 
 			expect(prompt).toContain("Prefer grep/find/ls tools over bash");
 			expect(prompt).not.toContain("needle lookup first");
-		});
-	});
-
-	describe("focus and scope discipline", () => {
-		test("always includes focus/scope guidelines regardless of tools", () => {
-			const prompt = buildSystemPrompt({
-				selectedTools: [],
-				contextFiles: [],
-				skills: [],
-			});
-
-			expect(prompt).toContain("Stay within the scope of the request");
-			expect(prompt).toContain("Prefer the smallest correct change");
-			expect(prompt).toContain("Prefer editing existing files over creating new ones");
-			expect(prompt).toContain("Match response length to task complexity");
 		});
 	});
 


### PR DESCRIPTION
Make dreb's default system prompt more focused and less prone to going down rabbit holes, while keeping all tools, memory, and subagents fully available.

## Summary

The default prompt currently over-advertises dreb's own capabilities (subagent has 17 guideline bullets, search is framed as the "default exploration tool", tasks triggers at "3+ steps"), and the always-on base guidelines say nothing about staying in scope. This PR reframes tool guidance from imperative-push to "available but optional", adds a focus/scope-discipline block modeled on a merge of opencode's Claude + general prompts, and softens Memory's "when to save" proactivity — without removing or gating any capability.

Implementation plan posted as a comment below.
