### PR TITLE
VSCode extension Phase 4: tag editor selection into current chat

### DIFF
--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -4,7 +4,7 @@ A native chat client for the [dreb](https://github.com/aebrer/dreb) coding agent
 
 This package is modeled on `@dreb/dashboard`: an extension **host** owns the RPC child and the authoritative transcript state, and a **webview** renders it. The only transport difference is that the dashboard's HTTP+SSE layer is replaced by VS Code's `postMessage` bridge.
 
-> Status: **Phase 3** (change review — per-turn git snapshot + per-hunk keep/reject) on top of Phase 2 (built-in slash commands + TUI-parity status header) and the Phase 0 + 1 foundation. See the [tracking issue](https://github.com/Hrovatin/dreb/issues/12) for the roadmap.
+> Status: **Phase 4** (editor context tagging — tag a selection into the current chat) on top of Phase 3 (change review — per-turn git snapshot + per-hunk keep/reject), Phase 2 (built-in slash commands + TUI-parity status header), and the Phase 0 + 1 foundation. See the [tracking issue](https://github.com/Hrovatin/dreb/issues/12) for the roadmap.
 
 ## Architecture
 
@@ -14,12 +14,13 @@ src/
     protocol.ts       host ↔ webview message envelopes (no @dreb import)
     projection.ts     RPC events → transcript render model (pure, tested)
   host/          # extension host (Node, ESM) — compiled with tsgo
-    extension.ts        activate(): registers `dreb.openChat` + review commands
+    extension.ts        activate(): registers `dreb.openChat`, `dreb.tagSelectionToChat` + review commands
     session-controller.ts  one RpcClient + authoritative transcript per session
     webview-bridge.ts   postMessage wiring + webview HTML/CSP
     cli-path.ts         resolve the dreb CLI (setting → dependency)
     slash-router.ts     route composer text → prompt vs builtin RPC (pure, tested)
     session-registry.ts single-live-panel lifecycle (reentrancy-safe, pure, tested)
+    tag-selection.ts    tag-selection-into-chat orchestration (pure, vscode-free, tested)
     host-ui.ts          native-prompt port (quick pick / input / dialogs); vscode-free
     vscode-host-ui.ts   the real `HostUi` backed by `vscode.window`
     git-snapshot.ts     per-turn baseline capture + diff + `git apply -R` (pure node, tested)
@@ -29,6 +30,7 @@ src/
     vscode-review-ui.ts the real `ReviewUi` backed by `vscode.scm`
   shared/
     format.ts           status-header + `/session` display formatters (pure, tested)
+    tagged-context.ts   editor-selection context DTO + chip label + prompt fold (pure, tested)
   webview/       # SolidJS UI — bundled with Vite → dist/webview
     app.tsx             transcript, collapsible activity box, composer, needs-input,
                         the status header (model · thinking · cost · ctx), and the
@@ -71,6 +73,12 @@ Because the agent runs out-of-process and writes edits straight to disk, the ext
 - **Keep / reject** — the `dreb.review.*` commands accept a file (clear its marker — **no commit**), accept/revert all, revert a whole file to baseline, or **reject the hunk at the cursor** (`dreb.review.rejectHunkAtCursor`, which drives `git apply --reverse` on exactly that hunk). Rejecting a hunk restores only that region and never clobbers your own pre-existing edits.
 
 Review is host-authoritative, so it survives webview reload. Outside a git repository it degrades gracefully (disabled, no snapshots). The pure logic (`review-model.ts`, `diff-hunks.ts`) and the git plumbing (`git-snapshot.ts`, against real temp repos) are unit-tested; all `vscode` SCM/diff calls are isolated behind the `ReviewUi` port.
+
+## Editor integration
+
+Tag a code selection into the chat as removable context. Select any range (a whole line or part of one) and run **dreb: Add Selection to Chat** — from the command palette or the editor right-click menu (shown only when there is a selection, `when: editorHasSelection`). The selection is added to the composer as a **removable chip** labelled `basename:line` (or `basename:start-end`); multiple selections accumulate. On send, each chip is folded into the prompt as a located, fenced code block (workspace-relative path + line range) so the agent knows exactly where the code came from — dreb's agent accepts text + images only, so there is no separate structured-context channel. Sending with only chips and no typed text is allowed. Tagging with no chat open opens one first, then attaches.
+
+The selection is captured **at tag time** (a pre-resolved snapshot, not a lazy reference). The orchestration lives in the vscode-free, unit-tested `host/tag-selection.ts`; the DTO builder, chip label, and prompt formatter are pure functions in `shared/tagged-context.ts`; delivery to the composer is queued until the webview is `ready` so tagging into a freshly opened chat still lands.
 
 
 ## Requirements

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -22,6 +22,11 @@
 				"category": "dreb"
 			},
 			{
+				"command": "dreb.tagSelectionToChat",
+				"title": "Add Selection to Chat",
+				"category": "dreb"
+			},
+			{
 				"command": "dreb.review.openDiff",
 				"title": "Open Diff",
 				"category": "dreb",
@@ -89,9 +94,14 @@
 			],
 			"editor/context": [
 				{
+					"command": "dreb.tagSelectionToChat",
+					"when": "editorHasSelection",
+					"group": "dreb@1"
+				},
+				{
 					"command": "dreb.review.rejectHunkAtCursor",
 					"when": "editorTextFocus",
-					"group": "dreb@1"
+					"group": "dreb@2"
 				}
 			]
 		},

--- a/packages/vscode/src/host/extension.ts
+++ b/packages/vscode/src/host/extension.ts
@@ -12,11 +12,11 @@
 import { homedir } from "node:os";
 import { relative, sep } from "node:path";
 import * as vscode from "vscode";
-import { buildTaggedContext } from "../shared/tagged-context.js";
 import { resolveCliPath } from "./cli-path.js";
 import type { ReviewUi } from "./review-ui.js";
 import { SessionController } from "./session-controller.js";
 import { SessionRegistry } from "./session-registry.js";
+import { tagSelectionToChat } from "./tag-selection.js";
 import { createVscodeHostUi } from "./vscode-host-ui.js";
 import { createVscodeReviewUi } from "./vscode-review-ui.js";
 import { connectWebview, getWebviewHtml } from "./webview-bridge.js";
@@ -45,40 +45,34 @@ const registry = new SessionRegistry<ChatSession>({
 export function activate(context: vscode.ExtensionContext): void {
 	context.subscriptions.push(
 		vscode.commands.registerCommand("dreb.openChat", () => {
-			registry
-				.open(() => createSession(context))
-				.catch((err) => {
-					vscode.window.showErrorMessage(`dreb: failed to open chat — ${errorText(err)}`);
-				});
+			void openChatOrNotify(context);
 		}),
-		vscode.commands.registerCommand("dreb.tagSelectionToChat", async () => {
-			const editor = vscode.window.activeTextEditor;
-			if (!editor || editor.selection.isEmpty) {
-				vscode.window.showInformationMessage("dreb: select some code to add to the chat.");
-				return;
-			}
-			// Capture the selection synchronously — opening/revealing the panel may
-			// shift editor focus, so read everything before the first await.
-			const selection = editor.selection;
-			const document = editor.document;
-			const captured = {
-				fsPath: document.uri.fsPath,
-				startLine: selection.start.line + 1,
-				endLine: selection.end.line + 1,
-				language: document.languageId,
-				text: document.getText(selection),
-			};
-			try {
-				await registry.open(() => createSession(context));
-			} catch (err) {
-				vscode.window.showErrorMessage(`dreb: failed to open chat — ${errorText(err)}`);
-				return;
-			}
-			const session = registry.active;
-			if (!session) return;
-			session.controller.tagContext(buildTaggedContext({ ...captured, cwd: session.controller.cwd }));
-			session.panel.reveal(vscode.ViewColumn.Active);
-		}),
+		vscode.commands.registerCommand("dreb.tagSelectionToChat", () =>
+			tagSelectionToChat({
+				captureSelection: () => {
+					const editor = vscode.window.activeTextEditor;
+					if (!editor || editor.selection.isEmpty) return undefined;
+					const { selection, document } = editor;
+					return {
+						fsPath: document.uri.fsPath,
+						startLine: selection.start.line + 1,
+						endLine: selection.end.line + 1,
+						language: document.languageId,
+						text: document.getText(selection),
+					};
+				},
+				openTarget: async () => {
+					const session = await openChatOrNotify(context);
+					if (!session) return undefined;
+					return {
+						cwd: session.controller.cwd,
+						tagContext: (ctx) => session.controller.tagContext(ctx),
+						reveal: () => session.panel.reveal(vscode.ViewColumn.Active),
+					};
+				},
+				onNoSelection: () => vscode.window.showInformationMessage("dreb: select some code to add to the chat."),
+			}),
+		),
 		vscode.commands.registerCommand("dreb.review.openDiff", (arg?: unknown) => {
 			const resolved = resolveReviewTarget(arg);
 			if (resolved) void resolved.controller.reviewOpenDiff(resolved.path);
@@ -137,6 +131,19 @@ function toRepoRelative(cwd: string, uri: vscode.Uri): string | undefined {
 
 export async function deactivate(): Promise<void> {
 	await registry.disposeActive();
+}
+
+/** Open (or reveal) the chat panel, surfacing any failure as an error message.
+ * Returns the live session, or undefined when opening failed. Shared by the
+ * `dreb.openChat` and `dreb.tagSelectionToChat` commands. */
+async function openChatOrNotify(context: vscode.ExtensionContext): Promise<ChatSession | undefined> {
+	try {
+		await registry.open(() => createSession(context));
+		return registry.active;
+	} catch (err) {
+		vscode.window.showErrorMessage(`dreb: failed to open chat — ${errorText(err)}`);
+		return undefined;
+	}
 }
 
 /** Build a fresh chat session: controller, webview panel, and transport wiring.

--- a/packages/vscode/src/host/extension.ts
+++ b/packages/vscode/src/host/extension.ts
@@ -12,6 +12,7 @@
 import { homedir } from "node:os";
 import { relative, sep } from "node:path";
 import * as vscode from "vscode";
+import { buildTaggedContext } from "../shared/tagged-context.js";
 import { resolveCliPath } from "./cli-path.js";
 import type { ReviewUi } from "./review-ui.js";
 import { SessionController } from "./session-controller.js";
@@ -49,6 +50,34 @@ export function activate(context: vscode.ExtensionContext): void {
 				.catch((err) => {
 					vscode.window.showErrorMessage(`dreb: failed to open chat — ${errorText(err)}`);
 				});
+		}),
+		vscode.commands.registerCommand("dreb.tagSelectionToChat", async () => {
+			const editor = vscode.window.activeTextEditor;
+			if (!editor || editor.selection.isEmpty) {
+				vscode.window.showInformationMessage("dreb: select some code to add to the chat.");
+				return;
+			}
+			// Capture the selection synchronously — opening/revealing the panel may
+			// shift editor focus, so read everything before the first await.
+			const selection = editor.selection;
+			const document = editor.document;
+			const captured = {
+				fsPath: document.uri.fsPath,
+				startLine: selection.start.line + 1,
+				endLine: selection.end.line + 1,
+				language: document.languageId,
+				text: document.getText(selection),
+			};
+			try {
+				await registry.open(() => createSession(context));
+			} catch (err) {
+				vscode.window.showErrorMessage(`dreb: failed to open chat — ${errorText(err)}`);
+				return;
+			}
+			const session = registry.active;
+			if (!session) return;
+			session.controller.tagContext(buildTaggedContext({ ...captured, cwd: session.controller.cwd }));
+			session.panel.reveal(vscode.ViewColumn.Active);
 		}),
 		vscode.commands.registerCommand("dreb.review.openDiff", (arg?: unknown) => {
 			const resolved = resolveReviewTarget(arg);

--- a/packages/vscode/src/host/session-controller.ts
+++ b/packages/vscode/src/host/session-controller.ts
@@ -14,7 +14,15 @@
 
 import { formatSessionStats } from "../shared/format.js";
 import { applyEvent, createTranscriptState, type TranscriptState } from "../shared/projection.js";
-import type { HostStatus, ReviewFileDto, ReviewStateDto, SlashCommandDto, UiResponse } from "../shared/protocol.js";
+import type {
+	HostStatus,
+	ReviewFileDto,
+	ReviewStateDto,
+	SlashCommandDto,
+	TaggedContextDto,
+	UiResponse,
+} from "../shared/protocol.js";
+import { buildPromptWithContext } from "../shared/tagged-context.js";
 import { hunkIndexForLine, parseFileDiff } from "./diff-hunks.js";
 import {
 	baselineContent,
@@ -133,6 +141,8 @@ export type ControllerUpdate =
 	| { kind: "commands"; commands: SlashCommandDto[] }
 	/** The change-review set changed (per-turn detection, accept/revert). */
 	| { kind: "review"; review: ReviewStateDto }
+	/** An editor selection was tagged into the chat (Phase 4). */
+	| { kind: "tag-context"; context: TaggedContextDto }
 	/** Transcript was replaced host-side (e.g. `/new`, `/import`); the bridge
 	 * re-sends a fresh snapshot. */
 	| { kind: "resync" };
@@ -300,7 +310,7 @@ export class SessionController {
 	 * child crash) surfaces a notice instead of dispatching into a client that
 	 * isn't ready, and every awaited RPC call is wrapped so a rejection becomes
 	 * a visible notice rather than an unhandled promise rejection. */
-	async submit(text: string): Promise<void> {
+	async submit(text: string, attachments?: TaggedContextDto[]): Promise<void> {
 		if (!this.client || !this.status.connected) {
 			this.emitNotice(
 				this.status.error
@@ -314,7 +324,9 @@ export class SessionController {
 		try {
 			switch (decision.kind) {
 				case "prompt":
-					await this.client.prompt(decision.message);
+					// Fold any tagged editor selections into the prompt as located
+					// context (attachments only apply to prompts, not slash builtins).
+					await this.client.prompt(buildPromptWithContext(decision.message, attachments));
 					return;
 				case "builtin":
 					await this.runBuiltin(decision.command, decision.arg);
@@ -576,6 +588,13 @@ export class SessionController {
 	/** Answer a blocking extension-UI request. */
 	respondUi(response: UiResponse): void {
 		this.client?.sendExtensionUIResponse({ type: "extension_ui_response", ...response });
+	}
+
+	/** Tag an editor selection into the chat (Phase 4). Emits an update the
+	 * bridge forwards to the webview as a removable composer chip (queued until
+	 * the webview is live, so tagging into a freshly opened chat still lands). */
+	tagContext(context: TaggedContextDto): void {
+		this.emit({ kind: "tag-context", context });
 	}
 
 	// ── Change review ──────────────────────────────────────────────────────

--- a/packages/vscode/src/host/session-controller.ts
+++ b/packages/vscode/src/host/session-controller.ts
@@ -320,9 +320,17 @@ export class SessionController {
 			return;
 		}
 		const decision = routeInput(text, this.commands);
-		if (decision.kind === "empty") return;
+		// An attachment-only submit (chips attached, no typed text) is deliberately
+		// allowed by the composer; with no attachments there is genuinely nothing
+		// to send, so short-circuit only then.
+		if (decision.kind === "empty" && (!attachments || attachments.length === 0)) return;
 		try {
 			switch (decision.kind) {
+				case "empty":
+					// Reached only with attachments present (see guard above): send the
+					// folded context so a chips-only submit isn't silently dropped.
+					await this.client.prompt(buildPromptWithContext(text, attachments));
+					return;
 				case "prompt":
 					// Fold any tagged editor selections into the prompt as located
 					// context (attachments only apply to prompts, not slash builtins).

--- a/packages/vscode/src/host/tag-selection.ts
+++ b/packages/vscode/src/host/tag-selection.ts
@@ -1,0 +1,59 @@
+/**
+ * Orchestration for the `dreb.tagSelectionToChat` command (Phase 4), factored
+ * out of `extension.ts` so it can be unit tested without the `vscode` module.
+ *
+ * The vscode-specific bits (reading the active editor, opening the panel,
+ * showing notices) are injected via {@link TagSelectionDeps}; the branching this
+ * function owns — empty-selection guard, capture-before-`await` ordering,
+ * open-if-none, cwd threading, tag, reveal — is the tested logic.
+ */
+
+import type { TaggedContextDto } from "../shared/protocol.js";
+import { buildTaggedContext } from "../shared/tagged-context.js";
+
+/** A selection captured synchronously from the active editor (1-based lines). */
+export interface SelectionSnapshot {
+	fsPath: string;
+	startLine: number;
+	endLine: number;
+	language: string;
+	text: string;
+}
+
+/** The chat session a tagged selection is delivered into. */
+export interface TagTarget {
+	/** Working directory used to relativize the selection's path. */
+	cwd: string;
+	/** Deliver the context to the composer (as a removable chip). */
+	tagContext: (context: TaggedContextDto) => void;
+	/** Bring the chat panel to the foreground. */
+	reveal: () => void;
+}
+
+export interface TagSelectionDeps {
+	/** Snapshot the active selection synchronously, or return undefined when
+	 * there is no editor or the selection is empty. Called before any `await` so
+	 * opening/revealing the panel can't shift focus out from under the capture. */
+	captureSelection: () => SelectionSnapshot | undefined;
+	/** Open (or reveal) the chat and return the live target, or undefined when
+	 * opening failed (the dep is responsible for surfacing that error). */
+	openTarget: () => Promise<TagTarget | undefined>;
+	/** Surface "nothing selected" to the user. */
+	onNoSelection: () => void;
+}
+
+/** Capture the active selection, ensure a chat exists, and deliver the selection
+ * as a located context chip. No-ops (with a notice) when nothing is selected,
+ * and aborts quietly if the chat could not be opened. */
+export async function tagSelectionToChat(deps: TagSelectionDeps): Promise<void> {
+	// Capture BEFORE awaiting openTarget — revealing the panel may move focus.
+	const snapshot = deps.captureSelection();
+	if (!snapshot) {
+		deps.onNoSelection();
+		return;
+	}
+	const target = await deps.openTarget();
+	if (!target) return;
+	target.tagContext(buildTaggedContext({ ...snapshot, cwd: target.cwd }));
+	target.reveal();
+}

--- a/packages/vscode/src/host/webview-bridge.ts
+++ b/packages/vscode/src/host/webview-bridge.ts
@@ -13,7 +13,7 @@
  */
 
 import * as vscode from "vscode";
-import type { HostToWebview, WebviewToHost } from "../shared/protocol.js";
+import type { HostToWebview, TaggedContextDto, WebviewToHost } from "../shared/protocol.js";
 import type { SessionController } from "./session-controller.js";
 
 /** Build the webview HTML shell referencing the vite-built assets. */
@@ -48,6 +48,10 @@ export function getWebviewHtml(webview: vscode.Webview, extensionUri: vscode.Uri
 /** Wire a controller to a webview. Returns a disposable that tears down both. */
 export function connectWebview(webview: vscode.Webview, controller: SessionController): vscode.Disposable {
 	let live = false;
+	// Selections tagged before the webview announced `ready` (e.g. tagging into a
+	// freshly opened chat) — buffered here and flushed once live so they aren't
+	// dropped by the pre-ready gate.
+	const pendingTags: TaggedContextDto[] = [];
 	const post = (message: HostToWebview): void => {
 		void webview.postMessage(message);
 	};
@@ -56,6 +60,14 @@ export function connectWebview(webview: vscode.Webview, controller: SessionContr
 	};
 
 	const unsubscribe = controller.onUpdate((update) => {
+		// Tagged selections are buffered before `ready` (unlike streamed events,
+		// which the snapshot already captures), so handle them ahead of the
+		// pre-ready gate below.
+		if (update.kind === "tag-context") {
+			if (live) post({ type: "tag-context", context: update.context });
+			else pendingTags.push(update.context);
+			return;
+		}
 		if (!live) return;
 		switch (update.kind) {
 			case "event":
@@ -97,11 +109,13 @@ export function connectWebview(webview: vscode.Webview, controller: SessionContr
 				});
 				live = true;
 				post({ type: "review", review: controller.getReviewState() });
+				// Deliver any selections tagged before the webview was live.
+				for (const context of pendingTags.splice(0)) post({ type: "tag-context", context });
 				pushCommands();
 				return;
 			}
 			case "submit":
-				void controller.submit(raw.text);
+				void controller.submit(raw.text, raw.attachments);
 				return;
 			case "abort":
 				void controller.abort();

--- a/packages/vscode/src/shared/protocol.ts
+++ b/packages/vscode/src/shared/protocol.ts
@@ -82,6 +82,22 @@ export interface ReviewStateDto {
 	files: ReviewFileDto[];
 }
 
+/** An editor selection tagged into the chat (Phase 4). Shown as a removable
+ * composer chip and folded into the next prompt as located context. */
+export interface TaggedContextDto {
+	/** Workspace-relative source path (forward slashes), or basename when the
+	 * file is outside the workspace. */
+	path: string;
+	/** 1-based inclusive start line of the selection. */
+	startLine: number;
+	/** 1-based inclusive end line of the selection. */
+	endLine: number;
+	/** Document language id, for the fenced block (may be empty). */
+	language: string;
+	/** The selected text, captured at tag time. */
+	text: string;
+}
+
 /** Messages sent from the host to the webview. */
 export type HostToWebview =
 	| { type: "snapshot"; state: TranscriptState; commands: SlashCommandDto[]; status: HostStatus }
@@ -89,12 +105,14 @@ export type HostToWebview =
 	| { type: "commands"; commands: SlashCommandDto[] }
 	| { type: "status"; status: HostStatus }
 	/** Change-review set changed (per-turn detection, accept/revert). */
-	| { type: "review"; review: ReviewStateDto };
+	| { type: "review"; review: ReviewStateDto }
+	/** An editor selection was tagged into the chat — add it as a composer chip. */
+	| { type: "tag-context"; context: TaggedContextDto };
 
 /** Messages sent from the webview to the host. */
 export type WebviewToHost =
 	| { type: "ready" }
-	| { type: "submit"; text: string }
+	| { type: "submit"; text: string; attachments?: TaggedContextDto[] }
 	| { type: "abort" }
 	| { type: "refresh-commands" }
 	| { type: "ui-response"; response: UiResponse }

--- a/packages/vscode/src/shared/tagged-context.ts
+++ b/packages/vscode/src/shared/tagged-context.ts
@@ -1,0 +1,88 @@
+/**
+ * Pure helpers for editor-selection context tags (Phase 4).
+ *
+ * A "tagged context" is a snippet the user pulled from an editor selection into
+ * the chat. This module builds the {@link TaggedContextDto}, formats the chip
+ * label the composer shows, and folds attachments into the prompt text the host
+ * sends to the agent.
+ *
+ * It is intentionally free of `vscode` AND of any `node:` builtins so the same
+ * code can be bundled into the webview (for `taggedContextLabel`) and imported
+ * by the host (for `buildTaggedContext` / `buildPromptWithContext`), and unit
+ * tested in plain node — mirroring `shared/format.ts`.
+ */
+
+import type { TaggedContextDto } from "./protocol.js";
+
+/** Inputs the host captures from the active editor to build a context tag. */
+export interface TaggedContextInput {
+	/** Absolute filesystem path of the selection's document. */
+	fsPath: string;
+	/** The session's working directory, used to relativize `fsPath`. */
+	cwd: string;
+	/** 1-based inclusive start line of the selection. */
+	startLine: number;
+	/** 1-based inclusive end line of the selection. */
+	endLine: number;
+	/** The document's language id (e.g. "typescript"), for the fenced block. */
+	language: string;
+	/** The selected text. */
+	text: string;
+}
+
+/** Last path segment of a slash/back-slash separated path. */
+function basename(path: string): string {
+	const parts = path.replace(/\\/g, "/").split("/").filter(Boolean);
+	return parts.at(-1) ?? path;
+}
+
+/** `fsPath` relative to `cwd` with forward slashes; falls back to the basename
+ * when the file is outside the workspace (so the chip still has a sane label). */
+function toWorkspaceRelative(fsPath: string, cwd: string): string {
+	const file = fsPath.replace(/\\/g, "/");
+	const root = cwd.replace(/\\/g, "/").replace(/\/+$/, "");
+	if (root.length > 0 && file === root) return basename(file);
+	if (root.length > 0 && file.startsWith(`${root}/`)) return file.slice(root.length + 1);
+	return basename(file);
+}
+
+/** Build the DTO carried across the host↔webview boundary and folded into the
+ * prompt. The `path` is workspace-relative so the agent knows the source. */
+export function buildTaggedContext(input: TaggedContextInput): TaggedContextDto {
+	return {
+		path: toWorkspaceRelative(input.fsPath, input.cwd),
+		startLine: input.startLine,
+		endLine: input.endLine,
+		language: input.language,
+		text: input.text,
+	};
+}
+
+/** Short chip label shown in the composer: `basename:line` or
+ * `basename:start-end` (Copilot-style). */
+export function taggedContextLabel(context: TaggedContextDto): string {
+	const name = basename(context.path);
+	return context.endLine > context.startLine
+		? `${name}:${context.startLine}-${context.endLine}`
+		: `${name}:${context.startLine}`;
+}
+
+/** One attachment as a located, fenced code block for the prompt. */
+export function formatTaggedContext(context: TaggedContextDto): string {
+	const location =
+		context.endLine > context.startLine
+			? `lines ${context.startLine}-${context.endLine}`
+			: `line ${context.startLine}`;
+	const fence = context.language && context.language.length > 0 ? context.language : "";
+	return `\`${context.path}\` (${location}):\n\`\`\`${fence}\n${context.text}\n\`\`\``;
+}
+
+/** Fold tagged attachments into the message sent to the agent: the located
+ * code blocks first, then the user's text. Returns `text` unchanged when there
+ * are no attachments; returns just the blocks when the text is empty. */
+export function buildPromptWithContext(text: string, attachments?: readonly TaggedContextDto[]): string {
+	if (!attachments || attachments.length === 0) return text;
+	const blocks = attachments.map(formatTaggedContext).join("\n\n");
+	const trimmed = text.trim();
+	return trimmed.length > 0 ? `${blocks}\n\n${trimmed}` : blocks;
+}

--- a/packages/vscode/src/webview/app.tsx
+++ b/packages/vscode/src/webview/app.tsx
@@ -10,7 +10,8 @@ import {
 	type TranscriptState,
 	type UiRequest,
 } from "../shared/projection.js";
-import type { HostStatus, ReviewStateDto, SlashCommandDto, UiResponse } from "../shared/protocol.js";
+import type { HostStatus, ReviewStateDto, SlashCommandDto, TaggedContextDto, UiResponse } from "../shared/protocol.js";
+import { taggedContextLabel } from "../shared/tagged-context.js";
 import { renderMarkdown } from "./markdown.js";
 import { onHostMessage, postToHost } from "./vscode-api.js";
 
@@ -22,6 +23,9 @@ export function App() {
 	// "unavailable" notice before the first review message arrives; the host
 	// publishes the authoritative enabled/files state on connect and on reload.
 	const [review, setReview] = createSignal<ReviewStateDto>({ enabled: true, files: [] });
+	// Editor selections tagged into the chat (Phase 4), shown as removable chips
+	// above the composer and folded into the next submitted message.
+	const [attachments, setAttachments] = createSignal<TaggedContextDto[]>([]);
 	const [tick, setTick] = createSignal(0);
 
 	let scrollEl: HTMLDivElement | undefined;
@@ -48,6 +52,9 @@ export function App() {
 					break;
 				case "review":
 					setReview(msg.review);
+					break;
+				case "tag-context":
+					setAttachments((current) => [...current, msg.context]);
 					break;
 			}
 			setTick((t) => t + 1);
@@ -165,7 +172,12 @@ export function App() {
 			<Composer
 				streaming={state.streaming}
 				commands={commands()}
-				onSubmit={(text) => postToHost({ type: "submit", text })}
+				attachments={attachments()}
+				onRemoveAttachment={(index) => setAttachments((current) => current.filter((_, i) => i !== index))}
+				onSubmit={(text) => {
+					postToHost({ type: "submit", text, attachments: attachments() });
+					setAttachments([]);
+				}}
 				onAbort={() => postToHost({ type: "abort" })}
 			/>
 		</div>
@@ -412,6 +424,8 @@ function AskResponse(props: { request: UiRequest; onRespond: (response: UiRespon
 function Composer(props: {
 	streaming: boolean;
 	commands: SlashCommandDto[];
+	attachments: TaggedContextDto[];
+	onRemoveAttachment: (index: number) => void;
 	onSubmit: (text: string) => void;
 	onAbort: () => void;
 }) {
@@ -426,7 +440,9 @@ function Composer(props: {
 
 	const submit = () => {
 		const value = text();
-		if (value.trim().length === 0) return;
+		// Allow sending with only attachments (no typed text), but never a
+		// completely empty message.
+		if (value.trim().length === 0 && props.attachments.length === 0) return;
 		props.onSubmit(value);
 		setText("");
 	};
@@ -452,6 +468,30 @@ function Composer(props: {
 									<span class="dreb-menu-desc">{command.description}</span>
 								</Show>
 							</button>
+						)}
+					</For>
+				</div>
+			</Show>
+			<Show when={props.attachments.length > 0}>
+				<div class="dreb-attachments">
+					<For each={props.attachments}>
+						{(attachment, index) => (
+							<span
+								class="dreb-attachment"
+								title={`${attachment.path} (lines ${attachment.startLine}-${attachment.endLine})`}
+							>
+								<span class="dreb-attachment-icon">{"{}"}</span>
+								<span class="dreb-attachment-label">{taggedContextLabel(attachment)}</span>
+								<button
+									type="button"
+									class="dreb-attachment-remove"
+									title="Remove from chat"
+									aria-label="Remove from chat"
+									onClick={() => props.onRemoveAttachment(index())}
+								>
+									×
+								</button>
+							</span>
 						)}
 					</For>
 				</div>

--- a/packages/vscode/src/webview/styles.css
+++ b/packages/vscode/src/webview/styles.css
@@ -319,6 +319,47 @@ body {
 	align-items: flex-end;
 }
 
+.dreb-attachments {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 6px;
+	margin-bottom: 8px;
+}
+.dreb-attachment {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	max-width: 100%;
+	padding: 1px 4px 1px 8px;
+	font-size: 0.8em;
+	border-radius: 4px;
+	border: 1px solid var(--vscode-panel-border, rgba(128, 128, 128, 0.3));
+	background: var(--vscode-badge-background, rgba(128, 128, 128, 0.18));
+	color: var(--vscode-foreground);
+}
+.dreb-attachment-icon {
+	font-family: var(--vscode-editor-font-family, monospace);
+	opacity: 0.7;
+}
+.dreb-attachment-label {
+	font-family: var(--vscode-editor-font-family, monospace);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.dreb-attachment-remove {
+	border: none;
+	background: transparent;
+	color: var(--vscode-descriptionForeground);
+	cursor: pointer;
+	padding: 0 2px;
+	font-size: 1.1em;
+	line-height: 1;
+}
+.dreb-attachment-remove:hover {
+	color: var(--vscode-foreground);
+}
+
 .dreb-input {
 	flex: 1;
 	resize: vertical;

--- a/packages/vscode/test/session-controller.test.ts
+++ b/packages/vscode/test/session-controller.test.ts
@@ -346,6 +346,37 @@ describe("SessionController", () => {
 		expect(fake.prompts).toEqual(["`src/a.ts` (lines 5-7):\n```typescript\nconst y = 2;\n```\n\nexplain this"]);
 	});
 
+	it("sends the folded context for an attachment-only submit (empty text)", async () => {
+		const fake = new FakeClient();
+		const controller = makeController(fake);
+		await controller.start();
+
+		// The composer allows sending with only chips and no typed text; the
+		// context must still reach the agent rather than being silently dropped.
+		await controller.submit("", [
+			{ path: "src/a.ts", startLine: 5, endLine: 5, language: "typescript", text: "const y = 2;" },
+		]);
+		await controller.submit("   ", [
+			{ path: "src/b.ts", startLine: 1, endLine: 2, language: "typescript", text: "B" },
+		]);
+
+		expect(fake.prompts).toEqual([
+			"`src/a.ts` (line 5):\n```typescript\nconst y = 2;\n```",
+			"`src/b.ts` (lines 1-2):\n```typescript\nB\n```",
+		]);
+	});
+
+	it("does not prompt on a truly empty submit (no text, no attachments)", async () => {
+		const fake = new FakeClient();
+		const controller = makeController(fake);
+		await controller.start();
+
+		await controller.submit("");
+		await controller.submit("   ", []);
+
+		expect(fake.prompts).toHaveLength(0);
+	});
+
 	it("ignores attachments for a slash builtin (only prompts get context)", async () => {
 		const fake = new FakeClient();
 		const controller = makeController(fake);

--- a/packages/vscode/test/session-controller.test.ts
+++ b/packages/vscode/test/session-controller.test.ts
@@ -334,6 +334,45 @@ describe("SessionController", () => {
 		expect(fake.compactions).toEqual(["now"]);
 	});
 
+	it("folds tagged attachments into the prompt as located context", async () => {
+		const fake = new FakeClient();
+		const controller = makeController(fake);
+		await controller.start();
+
+		await controller.submit("explain this", [
+			{ path: "src/a.ts", startLine: 5, endLine: 7, language: "typescript", text: "const y = 2;" },
+		]);
+
+		expect(fake.prompts).toEqual(["`src/a.ts` (lines 5-7):\n```typescript\nconst y = 2;\n```\n\nexplain this"]);
+	});
+
+	it("ignores attachments for a slash builtin (only prompts get context)", async () => {
+		const fake = new FakeClient();
+		const controller = makeController(fake);
+		await controller.start();
+
+		await controller.submit("/compact tidy", [{ path: "a.ts", startLine: 1, endLine: 1, language: "ts", text: "x" }]);
+
+		expect(fake.prompts).toHaveLength(0);
+		expect(fake.compactions).toEqual(["tidy"]);
+	});
+
+	it("tagContext emits a tag-context update to listeners", async () => {
+		const fake = new FakeClient();
+		const controller = makeController(fake);
+		await controller.start();
+
+		const updates: Array<{ kind: string }> = [];
+		controller.onUpdate((u) => updates.push(u));
+		const context = { path: "src/a.ts", startLine: 3, endLine: 5, language: "ts", text: "x" };
+		controller.tagContext(context);
+
+		const tag = updates.find((u) => u.kind === "tag-context") as
+			| { kind: "tag-context"; context: unknown }
+			| undefined;
+		expect(tag?.context).toEqual(context);
+	});
+
 	it("forwards registered agent commands through prompt", async () => {
 		const fake = new FakeClient();
 		fake.commandsResult = [{ name: "review", source: "prompt" }];

--- a/packages/vscode/test/tag-selection.test.ts
+++ b/packages/vscode/test/tag-selection.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from "vitest";
+import { type SelectionSnapshot, type TagTarget, tagSelectionToChat } from "../src/host/tag-selection.js";
+import type { TaggedContextDto } from "../src/shared/protocol.js";
+
+/** A recording TagTarget with the fields the orchestrator threads through. */
+function makeTarget(cwd: string) {
+	const tagged: TaggedContextDto[] = [];
+	let revealed = 0;
+	const target: TagTarget = {
+		cwd,
+		tagContext: (ctx) => tagged.push(ctx),
+		reveal: () => {
+			revealed += 1;
+		},
+	};
+	return { target, tagged, revealed: () => revealed };
+}
+
+const snapshot: SelectionSnapshot = {
+	fsPath: "/home/me/proj/src/app.ts",
+	startLine: 10,
+	endLine: 12,
+	language: "typescript",
+	text: "const x = 1;",
+};
+
+describe("tagSelectionToChat", () => {
+	it("notifies and does nothing when there is no selection", async () => {
+		const onNoSelection = vi.fn();
+		const openTarget = vi.fn(async () => undefined);
+
+		await tagSelectionToChat({
+			captureSelection: () => undefined,
+			openTarget,
+			onNoSelection,
+		});
+
+		expect(onNoSelection).toHaveBeenCalledTimes(1);
+		expect(openTarget).not.toHaveBeenCalled();
+	});
+
+	it("tags the selection into the target and reveals it, relativizing the path", async () => {
+		const { target, tagged, revealed } = makeTarget("/home/me/proj");
+
+		await tagSelectionToChat({
+			captureSelection: () => snapshot,
+			openTarget: async () => target,
+			onNoSelection: vi.fn(),
+		});
+
+		expect(tagged).toEqual([
+			{ path: "src/app.ts", startLine: 10, endLine: 12, language: "typescript", text: "const x = 1;" },
+		]);
+		expect(revealed()).toBe(1);
+	});
+
+	it("aborts quietly (no tag, no reveal) when the chat could not be opened", async () => {
+		const { target, tagged, revealed } = makeTarget("/home/me/proj");
+		const spy = vi.spyOn(target, "tagContext");
+
+		await tagSelectionToChat({
+			captureSelection: () => snapshot,
+			openTarget: async () => undefined,
+			onNoSelection: vi.fn(),
+		});
+
+		expect(spy).not.toHaveBeenCalled();
+		expect(tagged).toHaveLength(0);
+		expect(revealed()).toBe(0);
+	});
+
+	it("captures the selection BEFORE awaiting openTarget (focus-shift guard)", async () => {
+		const order: string[] = [];
+		const { target } = makeTarget("/home/me/proj");
+
+		await tagSelectionToChat({
+			captureSelection: () => {
+				order.push("capture");
+				return snapshot;
+			},
+			openTarget: async () => {
+				order.push("open");
+				return target;
+			},
+			onNoSelection: vi.fn(),
+		});
+
+		expect(order).toEqual(["capture", "open"]);
+	});
+});

--- a/packages/vscode/test/tagged-context.test.ts
+++ b/packages/vscode/test/tagged-context.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import type { TaggedContextDto } from "../src/shared/protocol.js";
+import {
+	buildPromptWithContext,
+	buildTaggedContext,
+	formatTaggedContext,
+	taggedContextLabel,
+} from "../src/shared/tagged-context.js";
+
+describe("buildTaggedContext", () => {
+	it("relativizes an in-workspace path with forward slashes", () => {
+		const dto = buildTaggedContext({
+			fsPath: "/home/me/proj/src/app.ts",
+			cwd: "/home/me/proj",
+			startLine: 10,
+			endLine: 12,
+			language: "typescript",
+			text: "const x = 1;",
+		});
+		expect(dto).toEqual({
+			path: "src/app.ts",
+			startLine: 10,
+			endLine: 12,
+			language: "typescript",
+			text: "const x = 1;",
+		});
+	});
+
+	it("tolerates a trailing slash on cwd and backslash paths", () => {
+		const dto = buildTaggedContext({
+			fsPath: "C:\\work\\proj\\src\\a.ts",
+			cwd: "C:\\work\\proj\\",
+			startLine: 1,
+			endLine: 1,
+			language: "typescript",
+			text: "x",
+		});
+		expect(dto.path).toBe("src/a.ts");
+	});
+
+	it("falls back to the basename for a file outside the workspace", () => {
+		const dto = buildTaggedContext({
+			fsPath: "/etc/hosts",
+			cwd: "/home/me/proj",
+			startLine: 3,
+			endLine: 3,
+			language: "plaintext",
+			text: "127.0.0.1",
+		});
+		expect(dto.path).toBe("hosts");
+	});
+
+	it("labels the workspace root file itself by basename", () => {
+		const dto = buildTaggedContext({
+			fsPath: "/home/me/proj",
+			cwd: "/home/me/proj",
+			startLine: 1,
+			endLine: 1,
+			language: "",
+			text: "",
+		});
+		expect(dto.path).toBe("proj");
+	});
+});
+
+describe("taggedContextLabel", () => {
+	const base: TaggedContextDto = { path: "src/a.ts", startLine: 5, endLine: 5, language: "typescript", text: "x" };
+
+	it("shows basename:line for a single-line selection", () => {
+		expect(taggedContextLabel(base)).toBe("a.ts:5");
+	});
+
+	it("shows basename:start-end for a multi-line selection", () => {
+		expect(taggedContextLabel({ ...base, startLine: 5, endLine: 9 })).toBe("a.ts:5-9");
+	});
+});
+
+describe("formatTaggedContext", () => {
+	it("emits a located fenced block with the language", () => {
+		const out = formatTaggedContext({
+			path: "src/a.ts",
+			startLine: 5,
+			endLine: 7,
+			language: "typescript",
+			text: "const y = 2;",
+		});
+		expect(out).toBe("`src/a.ts` (lines 5-7):\n```typescript\nconst y = 2;\n```");
+	});
+
+	it("uses singular 'line' and an empty fence when language is blank", () => {
+		const out = formatTaggedContext({ path: "a.txt", startLine: 3, endLine: 3, language: "", text: "hi" });
+		expect(out).toBe("`a.txt` (line 3):\n```\nhi\n```");
+	});
+});
+
+describe("buildPromptWithContext", () => {
+	const a: TaggedContextDto = { path: "a.ts", startLine: 1, endLine: 1, language: "ts", text: "A" };
+	const b: TaggedContextDto = { path: "b.ts", startLine: 2, endLine: 3, language: "ts", text: "B" };
+
+	it("returns the text unchanged when there are no attachments", () => {
+		expect(buildPromptWithContext("hello", [])).toBe("hello");
+		expect(buildPromptWithContext("hello", undefined)).toBe("hello");
+	});
+
+	it("prepends a single attachment before the user text", () => {
+		expect(buildPromptWithContext("explain this", [a])).toBe("`a.ts` (line 1):\n```ts\nA\n```\n\nexplain this");
+	});
+
+	it("joins multiple attachments then the text", () => {
+		const out = buildPromptWithContext("compare", [a, b]);
+		expect(out).toBe("`a.ts` (line 1):\n```ts\nA\n```\n\n`b.ts` (lines 2-3):\n```ts\nB\n```\n\ncompare");
+	});
+
+	it("returns just the blocks when the text is empty", () => {
+		expect(buildPromptWithContext("   ", [a])).toBe("`a.ts` (line 1):\n```ts\nA\n```");
+	});
+});

--- a/packages/vscode/test/webview-bridge.test.ts
+++ b/packages/vscode/test/webview-bridge.test.ts
@@ -170,10 +170,58 @@ describe("connectWebview", () => {
 		send({ type: "ui-response", response: { id: "u1", confirmed: true } });
 		send({ type: "refresh-commands" });
 
-		expect(submit).toHaveBeenCalledWith("hi there");
+		expect(submit).toHaveBeenCalledWith("hi there", undefined);
 		expect(abort).toHaveBeenCalledTimes(1);
 		expect(respondUi).toHaveBeenCalledWith({ id: "u1", confirmed: true });
 		expect(refresh).toHaveBeenCalled();
+	});
+
+	it("forwards submit attachments to the controller", async () => {
+		const fake = new BridgeFakeClient();
+		const controller = await makeController(fake);
+		const submit = vi.spyOn(controller, "submit").mockResolvedValue();
+		const { webview, send } = makeWebview();
+		connectWebview(webview as any, controller);
+
+		const attachments = [{ path: "a.ts", startLine: 1, endLine: 2, language: "ts", text: "A" }];
+		send({ type: "submit", text: "explain", attachments });
+		expect(submit).toHaveBeenCalledWith("explain", attachments);
+	});
+
+	it("forwards a live tag-context update as a tag-context message", async () => {
+		const fake = new BridgeFakeClient();
+		const controller = await makeController(fake);
+		const { webview, posted, send } = makeWebview();
+		connectWebview(webview as any, controller);
+		send({ type: "ready" });
+
+		const context = { path: "src/a.ts", startLine: 3, endLine: 5, language: "ts", text: "x" };
+		controller.tagContext(context);
+
+		const tags = posted.filter((m) => m.type === "tag-context") as Array<
+			Extract<HostToWebview, { type: "tag-context" }>
+		>;
+		expect(tags).toHaveLength(1);
+		expect(tags[0].context).toEqual(context);
+	});
+
+	it("buffers a tag-context tagged before ready and flushes it once live", async () => {
+		const fake = new BridgeFakeClient();
+		const controller = await makeController(fake);
+		const { webview, posted, send } = makeWebview();
+		connectWebview(webview as any, controller);
+
+		// Tag BEFORE the webview announces ready (e.g. tagging into a fresh chat).
+		const context = { path: "src/a.ts", startLine: 1, endLine: 1, language: "ts", text: "x" };
+		controller.tagContext(context);
+		expect(posted.filter((m) => m.type === "tag-context")).toHaveLength(0);
+
+		send({ type: "ready" });
+		const tags = posted.filter((m) => m.type === "tag-context") as Array<
+			Extract<HostToWebview, { type: "tag-context" }>
+		>;
+		expect(tags).toHaveLength(1);
+		expect(tags[0].context).toEqual(context);
 	});
 
 	it("routes pick-model / pick-thinking messages to the controller", async () => {


### PR DESCRIPTION
Closes #20

VSCode extension Phase 4 — tag an editor selection into the current chat: select any range (line or partial line), add it via right-click or the command palette, and it rides along as a removable context chip folded into the next message. Part of the epic #12.

Implementation plan posted as a comment below.
