### PR TITLE
VSCode extension Phase 5b: clickable code links in chat (file + symbol refs)

### DIFF
--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -4,7 +4,7 @@ A native chat client for the [dreb](https://github.com/aebrer/dreb) coding agent
 
 This package is modeled on `@dreb/dashboard`: an extension **host** owns the RPC child and the authoritative transcript state, and a **webview** renders it. The only transport difference is that the dashboard's HTTP+SSE layer is replaced by VS Code's `postMessage` bridge.
 
-> Status: **Phase 5** (sessions side panel — a Copilot-style sidebar listing sessions with live status, resume, rename, pin, archive, delete; multiple sessions run concurrently) on top of Phase 4b (context tagging — tag an editor selection or a file/folder into the current chat), Phase 3 (change review — per-turn git snapshot + per-hunk keep/reject), Phase 2 (built-in slash commands + TUI-parity status header), and the Phase 0 + 1 foundation. See the [tracking issue](https://github.com/Hrovatin/dreb/issues/12) for the roadmap.
+> Status: **Phase 5b** (clickable code links — file/symbol references in answers open the code in the editor, grounded in the session's own tool results) on top of Phase 5 (sessions side panel — a Copilot-style sidebar listing sessions with live status, resume, rename, pin, archive, delete; multiple sessions run concurrently), Phase 4b (context tagging — tag an editor selection or a file/folder into the current chat), Phase 3 (change review — per-turn git snapshot + per-hunk keep/reject), Phase 2 (built-in slash commands + TUI-parity status header), and the Phase 0 + 1 foundation. See the [tracking issue](https://github.com/Hrovatin/dreb/issues/12) for the roadmap.
 
 ## Architecture
 
@@ -32,6 +32,8 @@ src/
     review-model.ts     change-review cycle + accept state (pure, tested)
     review-ui.ts        SCM / quick-diff / diff-viewer port; vscode-free
     vscode-review-ui.ts the real `ReviewUi` backed by `vscode.scm`
+    source-link-ui.ts   clicked-code-link open/resolve port; vscode-free
+    vscode-source-link-ui.ts the real `SourceLinkUi` (open file / resolve symbol → definition)
   shared/
     format.ts           status-header + `/session` display formatters (pure, tested)
     tagged-context.ts   selection + file/folder context DTOs, chip label, prompt fold + threshold (pure, tested)
@@ -41,6 +43,7 @@ src/
     app.tsx             transcript, collapsible activity box, composer, needs-input,
                         the status header (model · thinking · cost · ctx), and the
                         change-review bar
+    code-links.ts       grounded file/symbol linkification of answers (pure, tested)
     sidebar/app.tsx     the sessions side panel — grouped list, live status, resume,
                         inline rename, pin / archive / delete
 ```
@@ -105,6 +108,18 @@ Tag context into the chat as removable chips. Two kinds of context can be tagged
 dreb's agent accepts text + images only, so there is no separate structured-context channel: all tags are folded into the prompt text. Sending with only chips and no typed text is allowed. Tagging with no chat open opens one first, then attaches.
 
 The pure DTO builders, chip label/title, threshold logic, and prompt formatter are unit-tested in `shared/tagged-context.ts`; the selection command orchestration lives in the vscode-free `host/tag-selection.ts`; the file picker is driven through the `HostUi` port (`pickWorkspaceFiles`), so the controller stays vscode-free. Delivery to the composer is queued until the webview is `ready` so tagging into a freshly opened chat still lands.
+
+
+## Clickable code links
+
+File paths and code symbols that appear in an answer render as **clickable links** that open the referenced code at the right spot in the editor.
+
+- **File references** — a `path:line[:col]` (e.g. `src/app.ts:38`) or a workspace-relative path with a directory + extension render as links. Clicking opens the file and selects/reveals the line (1-based line/column from the answer are converted to VS Code's 0-based `Position`).
+- **Symbol references** — a class/function name renders as a link **only when it is grounded** — i.e. it actually appeared in this response's own tool results (`search`/`grep`). Clicking prefers the symbol's real **definition** via the workspace symbol provider; if the language server finds nothing, it falls back to the **grounded location** captured from the tool hit. This grounding gate is what keeps ordinary prose from being over-linkified.
+- **Reliability lives in the client, not the model.** The agent is never trusted to emit valid links: the webview linkifies syntactically/greedily but only *grounds* ambiguous symbols against real tool hits, and the host **validates** on click (a path that does not exist, or a symbol that resolves nowhere, shows an unobtrusive notice — never a broken jump). References that match nothing real simply stay plain text.
+- Links are wired via **event delegation → `postToHost`** (not `href` navigation), so they work under the webview's strict `default-src 'none'` CSP.
+
+Grounding + linkification are pure and unit-tested in `webview/code-links.ts` (`buildGroundedRefs` parses the tool-output formats; `linkifyAnswer` walks the sanitized answer DOM without corrupting existing markdown links/code spans). The open/resolve logic is driven through the vscode-free `host/source-link-ui.ts` port (real impl `host/vscode-source-link-ui.ts`), so the controller stays testable. A grounded symbol carries its usage location so the host can jump even before the language server resolves; semantic-search-based resolution is a possible future deepening.
 
 
 ## Requirements

--- a/packages/vscode/src/host/extension.ts
+++ b/packages/vscode/src/host/extension.ts
@@ -27,6 +27,7 @@ import { SessionsViewProvider } from "./sessions-view.js";
 import { tagSelectionToChat } from "./tag-selection.js";
 import { createVscodeHostUi } from "./vscode-host-ui.js";
 import { createVscodeReviewUi } from "./vscode-review-ui.js";
+import { createVscodeSourceLinkUi } from "./vscode-source-link-ui.js";
 import { connectWebview, getWebviewHtml } from "./webview-bridge.js";
 
 interface ChatSession {
@@ -227,6 +228,7 @@ function createSession(context: vscode.ExtensionContext, key: string, sessionPat
 		sessionPath,
 		ui: createVscodeHostUi(),
 		review: reviewUi,
+		sourceLink: createVscodeSourceLinkUi(cwd),
 		logger: (line) => console.warn(`[dreb] ${line}`),
 	});
 

--- a/packages/vscode/src/host/session-controller.ts
+++ b/packages/vscode/src/host/session-controller.ts
@@ -16,6 +16,7 @@ import { formatSessionStats } from "../shared/format.js";
 import { applyEvent, createTranscriptState, type TranscriptState } from "../shared/projection.js";
 import type {
 	HostStatus,
+	OpenSourceRef,
 	ReviewFileDto,
 	ReviewStateDto,
 	SlashCommandDto,
@@ -38,6 +39,7 @@ import { type HostUi, noopHostUi } from "./host-ui.js";
 import { ReviewModel } from "./review-model.js";
 import { noopReviewUi, type ReviewUi } from "./review-ui.js";
 import { BUILTIN_COMMANDS, DEFERRED_BUILTINS, routeInput, stripSlash, TERMINAL_ONLY_BUILTINS } from "./slash-router.js";
+import { noopSourceLinkUi, type SourceLinkUi } from "./source-link-ui.js";
 
 /** Thinking levels offered in the picker. The active model may support a subset;
  * `set_thinking_level` clamps server-side and we reflect the applied value via a
@@ -136,6 +138,9 @@ export interface SessionControllerOptions {
 	/** Native change-review surface (SCM group + quick-diff + diff viewer);
 	 * defaults to a no-op so the controller stays vscode-free and testable. */
 	review?: ReviewUi;
+	/** Native code-link opener (Phase 5b); defaults to a no-op so the controller
+	 * stays vscode-free and testable. */
+	sourceLink?: SourceLinkUi;
 	logger?: (line: string) => void;
 }
 
@@ -170,6 +175,7 @@ export class SessionController {
 	private readonly factory: RpcClientFactory;
 	private readonly ui: HostUi;
 	private readonly reviewUi: ReviewUi;
+	private readonly sourceLinkUi: SourceLinkUi;
 	private readonly reviewModel = new ReviewModel();
 	/** Whether change review is active for this cwd (false outside a git repo). */
 	private reviewEnabled = false;
@@ -204,6 +210,7 @@ export class SessionController {
 		this.factory = options.clientFactory ?? defaultClientFactory;
 		this.ui = options.ui ?? noopHostUi;
 		this.reviewUi = options.review ?? noopReviewUi;
+		this.sourceLinkUi = options.sourceLink ?? noopSourceLinkUi;
 		this.logger = options.logger ?? (() => {});
 		this.status = { connected: false, cwd: options.cwd };
 		// Resolve the git-repo state synchronously up front (findGitRoot is a cheap
@@ -688,6 +695,11 @@ export class SessionController {
 	/** Open the baseline↔current diff for a reviewed file. */
 	async reviewOpenDiff(path: string): Promise<void> {
 		await this.reviewUi.openDiff(path);
+	}
+
+	/** Open a code reference the user clicked in an answer (Phase 5b). */
+	async openSource(ref: OpenSourceRef): Promise<void> {
+		await this.sourceLinkUi.openSource(ref);
 	}
 
 	/** Accept a single file (clear its review marker; no commit). */

--- a/packages/vscode/src/host/session-controller.ts
+++ b/packages/vscode/src/host/session-controller.ts
@@ -697,9 +697,16 @@ export class SessionController {
 		await this.reviewUi.openDiff(path);
 	}
 
-	/** Open a code reference the user clicked in an answer (Phase 5b). */
+	/** Open a code reference the user clicked in an answer (Phase 5b). The
+	 * adapter is best-effort and non-throwing, but guard here too so an
+	 * unexpected failure surfaces a notice instead of an unhandled rejection
+	 * (the bridge calls this fire-and-forget). */
 	async openSource(ref: OpenSourceRef): Promise<void> {
-		await this.sourceLinkUi.openSource(ref);
+		try {
+			await this.sourceLinkUi.openSource(ref);
+		} catch (err) {
+			this.emitNotice(`Couldn't open the reference: ${err instanceof Error ? err.message : String(err)}`);
+		}
 	}
 
 	/** Accept a single file (clear its review marker; no commit). */

--- a/packages/vscode/src/host/source-link-ui.ts
+++ b/packages/vscode/src/host/source-link-ui.ts
@@ -1,0 +1,19 @@
+/**
+ * SourceLinkUi — the vscode-free port through which the (node-only, testable)
+ * SessionController opens a clicked code reference in the editor. The real
+ * implementation lives in `vscode-source-link-ui.ts`; tests and headless use
+ * inject the no-op below.
+ */
+
+import type { OpenSourceRef } from "../shared/protocol.js";
+
+export interface SourceLinkUi {
+	/** Open a code reference clicked in an answer: reveal a file location and/or
+	 * navigate to a symbol's definition (best-effort). */
+	openSource(ref: OpenSourceRef): Promise<void>;
+}
+
+/** No-op SourceLinkUi: every call is inert. Default when no UI is injected. */
+export const noopSourceLinkUi: SourceLinkUi = {
+	async openSource() {},
+};

--- a/packages/vscode/src/host/vscode-source-link-ui.ts
+++ b/packages/vscode/src/host/vscode-source-link-ui.ts
@@ -1,0 +1,90 @@
+/// <reference types="vscode" />
+
+/**
+ * vscode-backed SourceLinkUi — opens a clicked code reference (Phase 5b).
+ *
+ * Resolution order, best-effort and non-throwing:
+ *  1. If a `symbol` is present, prefer its real *definition* via the workspace
+ *     symbol provider (language-server accurate). Multiple candidates surface a
+ *     quick pick; an exact-name match is preferred over fuzzy hits.
+ *  2. Otherwise (or if the provider found nothing) fall back to the concrete
+ *     `path`/`line` — for a symbol link that path/line is the grounded *usage*
+ *     location captured from the tool hit that produced the link.
+ *  3. If nothing resolves, show an unobtrusive notice (never a broken jump).
+ *
+ * Line/column from the webview are 1-based (tool-output convention); vscode
+ * `Position` is 0-based, converted here.
+ */
+
+import { existsSync } from "node:fs";
+import { isAbsolute, resolve } from "node:path";
+import * as vscode from "vscode";
+import type { OpenSourceRef } from "../shared/protocol.js";
+import type { SourceLinkUi } from "./source-link-ui.js";
+
+export function createVscodeSourceLinkUi(cwd: string): SourceLinkUi {
+	return {
+		async openSource(ref: OpenSourceRef): Promise<void> {
+			if (ref.symbol) {
+				const loc = await resolveSymbol(ref.symbol);
+				if (loc) {
+					await reveal(loc.uri, loc.range.start.line + 1, loc.range.start.character + 1);
+					return;
+				}
+			}
+			if (ref.path) {
+				await openPath(cwd, ref.path, ref.line, ref.column);
+				return;
+			}
+			if (ref.symbol) {
+				void vscode.window.showInformationMessage(`dreb: couldn't locate “${ref.symbol}”.`);
+			}
+		},
+	};
+}
+
+/** Resolve a symbol to a definition location via the workspace symbol provider,
+ * disambiguating multiple candidates with a quick pick. */
+async function resolveSymbol(symbol: string): Promise<vscode.Location | undefined> {
+	const hits =
+		(await vscode.commands.executeCommand<vscode.SymbolInformation[]>(
+			"vscode.executeWorkspaceSymbolProvider",
+			symbol,
+		)) ?? [];
+	if (hits.length === 0) return undefined;
+	const exact = hits.filter((h) => h.name === symbol);
+	const pool = exact.length > 0 ? exact : hits;
+	if (pool.length === 1) return pool[0].location;
+
+	const pick = await vscode.window.showQuickPick(
+		pool.map((h) => ({
+			label: h.name,
+			description: `${vscode.SymbolKind[h.kind]} · ${vscode.workspace.asRelativePath(h.location.uri)}`,
+			location: h.location,
+		})),
+		{ title: `Go to ${symbol}`, matchOnDescription: true },
+	);
+	return pick?.location;
+}
+
+/** Open a concrete file path (relative to the session cwd) at an optional
+ * 1-based line/column. Missing files degrade to a notice. */
+async function openPath(cwd: string, path: string, line?: number, column?: number): Promise<void> {
+	const abs = isAbsolute(path) ? path : resolve(cwd, path);
+	if (!existsSync(abs)) {
+		void vscode.window.showInformationMessage(`dreb: ${path} not found in the workspace.`);
+		return;
+	}
+	await reveal(vscode.Uri.file(abs), line, column);
+}
+
+/** Open the document and, when a 1-based line is given, select+reveal it. */
+async function reveal(uri: vscode.Uri, line?: number, column?: number): Promise<void> {
+	const doc = await vscode.workspace.openTextDocument(uri);
+	const editor = await vscode.window.showTextDocument(doc, { preview: true });
+	if (line && line > 0) {
+		const pos = new vscode.Position(line - 1, Math.max(0, (column ?? 1) - 1));
+		editor.selection = new vscode.Selection(pos, pos);
+		editor.revealRange(new vscode.Range(pos, pos), vscode.TextEditorRevealType.InCenter);
+	}
+}

--- a/packages/vscode/src/host/vscode-source-link-ui.ts
+++ b/packages/vscode/src/host/vscode-source-link-ui.ts
@@ -44,13 +44,19 @@ export function createVscodeSourceLinkUi(cwd: string): SourceLinkUi {
 }
 
 /** Resolve a symbol to a definition location via the workspace symbol provider,
- * disambiguating multiple candidates with a quick pick. */
+ * disambiguating multiple candidates with a quick pick. Best-effort: a symbol
+ * provider that throws degrades to `undefined` (caller falls back to the path). */
 async function resolveSymbol(symbol: string): Promise<vscode.Location | undefined> {
-	const hits =
-		(await vscode.commands.executeCommand<vscode.SymbolInformation[]>(
-			"vscode.executeWorkspaceSymbolProvider",
-			symbol,
-		)) ?? [];
+	let hits: vscode.SymbolInformation[];
+	try {
+		hits =
+			(await vscode.commands.executeCommand<vscode.SymbolInformation[]>(
+				"vscode.executeWorkspaceSymbolProvider",
+				symbol,
+			)) ?? [];
+	} catch {
+		return undefined;
+	}
 	if (hits.length === 0) return undefined;
 	const exact = hits.filter((h) => h.name === symbol);
 	const pool = exact.length > 0 ? exact : hits;
@@ -78,13 +84,21 @@ async function openPath(cwd: string, path: string, line?: number, column?: numbe
 	await reveal(vscode.Uri.file(abs), line, column);
 }
 
-/** Open the document and, when a 1-based line is given, select+reveal it. */
+/** Open the document and, when a 1-based line is given, select+reveal it. An
+ * open failure (file deleted after the existsSync check, a binary/undecodable
+ * file, permission error) degrades to an unobtrusive notice rather than a silent
+ * no-op — honoring the "never a broken jump" contract. */
 async function reveal(uri: vscode.Uri, line?: number, column?: number): Promise<void> {
-	const doc = await vscode.workspace.openTextDocument(uri);
-	const editor = await vscode.window.showTextDocument(doc, { preview: true });
-	if (line && line > 0) {
-		const pos = new vscode.Position(line - 1, Math.max(0, (column ?? 1) - 1));
-		editor.selection = new vscode.Selection(pos, pos);
-		editor.revealRange(new vscode.Range(pos, pos), vscode.TextEditorRevealType.InCenter);
+	try {
+		const doc = await vscode.workspace.openTextDocument(uri);
+		const editor = await vscode.window.showTextDocument(doc, { preview: true });
+		if (line && line > 0) {
+			const pos = new vscode.Position(line - 1, Math.max(0, (column ?? 1) - 1));
+			editor.selection = new vscode.Selection(pos, pos);
+			editor.revealRange(new vscode.Range(pos, pos), vscode.TextEditorRevealType.InCenter);
+		}
+	} catch (err) {
+		const detail = err instanceof Error ? `: ${err.message}` : "";
+		void vscode.window.showInformationMessage(`dreb: couldn't open ${uri.fsPath}${detail}.`);
 	}
 }

--- a/packages/vscode/src/host/webview-bridge.ts
+++ b/packages/vscode/src/host/webview-bridge.ts
@@ -135,6 +135,9 @@ export function connectWebview(webview: vscode.Webview, controller: SessionContr
 			case "review-open-diff":
 				void controller.reviewOpenDiff(raw.path);
 				return;
+			case "open-source":
+				void controller.openSource(raw.ref);
+				return;
 			case "ui-response":
 				controller.respondUi(raw.response);
 				return;

--- a/packages/vscode/src/shared/protocol.ts
+++ b/packages/vscode/src/shared/protocol.ts
@@ -117,6 +117,22 @@ export interface FileContextDto {
  * into the next prompt. */
 export type TaggedContextDto = SelectionContextDto | FileContextDto;
 
+/** A clickable code reference the user activated in an answer (Phase 5b). Either
+ * a concrete file `path` (optionally with a 1-based `line`/`column`), a `symbol`
+ * name to resolve at click time, or both. When a `symbol` is present the host
+ * prefers jumping to its definition (workspace symbol provider); the `path`/`line`
+ * — captured from the grounding tool hit — is the best-effort fallback location. */
+export interface OpenSourceRef {
+	/** Workspace-relative (or absolute) file path, forward slashes. */
+	path?: string;
+	/** 1-based line to reveal/select. */
+	line?: number;
+	/** 1-based column to place the caret. */
+	column?: number;
+	/** Symbol name (function/class/heading) to resolve to a definition. */
+	symbol?: string;
+}
+
 /** Messages sent from the host to the webview. */
 export type HostToWebview =
 	| { type: "snapshot"; state: TranscriptState; commands: SlashCommandDto[]; status: HostStatus }
@@ -142,4 +158,7 @@ export type WebviewToHost =
 	/** Open the native file/folder picker to tag context (composer `@`). */
 	| { type: "pick-file" }
 	/** Open the baseline→current diff for a reviewed file (indicator click). */
-	| { type: "review-open-diff"; path: string };
+	| { type: "review-open-diff"; path: string }
+	/** Open a code reference clicked in an answer (Phase 5b) — a file location
+	 * and/or a symbol to resolve to its definition. */
+	| { type: "open-source"; ref: OpenSourceRef };

--- a/packages/vscode/src/webview/app.tsx
+++ b/packages/vscode/src/webview/app.tsx
@@ -10,8 +10,16 @@ import {
 	type TranscriptState,
 	type UiRequest,
 } from "../shared/projection.js";
-import type { HostStatus, ReviewStateDto, SlashCommandDto, TaggedContextDto, UiResponse } from "../shared/protocol.js";
+import type {
+	HostStatus,
+	OpenSourceRef,
+	ReviewStateDto,
+	SlashCommandDto,
+	TaggedContextDto,
+	UiResponse,
+} from "../shared/protocol.js";
 import { taggedContextLabel, taggedContextTitle } from "../shared/tagged-context.js";
+import { buildGroundedRefs, linkifyAnswer } from "./code-links.js";
 import { renderMarkdown } from "./markdown.js";
 import { onHostMessage, postToHost } from "./vscode-api.js";
 
@@ -192,8 +200,16 @@ function ResponseView(props: { group: ResponseGroup }) {
 				<ActivityBox group={props.group} />
 			</Show>
 			<Show when={props.group.answer.length > 0}>
-				{/* Sanitized markdown — see renderMarkdown. */}
-				<div class="dreb-answer" innerHTML={renderMarkdown(props.group.answer)} />
+				{/* Sanitized markdown with grounded, clickable code links. Links are
+				    wired via event delegation (postToHost) rather than href navigation,
+				    so they work under the webview's strict CSP. */}
+				{/* biome-ignore lint/a11y/noStaticElementInteractions: delegates activation of the rendered-markdown <a> links (the anchors are the interactive elements) */}
+				{/* biome-ignore lint/a11y/useKeyWithClickEvents: the links are keyboard-focusable anchors inside innerHTML; delegation only forwards their activation */}
+				<div
+					class="dreb-answer"
+					onClick={onCodeLinkClick}
+					innerHTML={linkifyAnswer(renderMarkdown(props.group.answer), buildGroundedRefs(props.group.activity))}
+				/>
 			</Show>
 			<Show when={props.group.error}>
 				<div class="dreb-banner error">{props.group.error}</div>
@@ -530,6 +546,22 @@ function Composer(props: {
 			</div>
 		</div>
 	);
+}
+
+/** Delegated click handler on a rendered answer: intercept a clicked code link
+ * and ask the host to open it. Uses event delegation (not `href`) so it works
+ * under the webview's `default-src 'none'` CSP. */
+function onCodeLinkClick(event: MouseEvent): void {
+	const target = event.target as HTMLElement | null;
+	const link = target?.closest?.("a.dreb-code-link") as HTMLElement | null;
+	if (!link) return;
+	event.preventDefault();
+	const ref: OpenSourceRef = {};
+	if (link.dataset.path) ref.path = link.dataset.path;
+	if (link.dataset.line) ref.line = Number(link.dataset.line);
+	if (link.dataset.column) ref.column = Number(link.dataset.column);
+	if (link.dataset.symbol) ref.symbol = link.dataset.symbol;
+	if (ref.path || ref.symbol) postToHost({ type: "open-source", ref });
 }
 
 function argPreview(args: unknown): string | undefined {

--- a/packages/vscode/src/webview/app.tsx
+++ b/packages/vscode/src/webview/app.tsx
@@ -193,7 +193,7 @@ export function App() {
 	);
 }
 
-function ResponseView(props: { group: ResponseGroup }) {
+export function ResponseView(props: { group: ResponseGroup }) {
 	return (
 		<div class="dreb-response">
 			<Show when={props.group.activity.length > 0}>

--- a/packages/vscode/src/webview/code-links.ts
+++ b/packages/vscode/src/webview/code-links.ts
@@ -47,20 +47,12 @@ function normalizePath(path: string): string {
 	return path.trim().replace(/\\/g, "/");
 }
 
-/** Pull a string `path` field out of a tool's `args` (read/find/grep all carry
- * one), tolerating the `unknown` type. */
-function argsPath(args: unknown): string | undefined {
-	if (args && typeof args === "object" && "path" in args) {
-		const p = (args as { path?: unknown }).path;
-		if (typeof p === "string" && p.length > 0) return p;
-	}
-	return undefined;
-}
-
-function argsPattern(args: unknown): string | undefined {
-	if (args && typeof args === "object" && "pattern" in args) {
-		const p = (args as { pattern?: unknown }).pattern;
-		if (typeof p === "string" && p.length > 0) return p;
+/** Pull a non-empty string field (e.g. `path`/`pattern`) out of a tool's `args`,
+ * tolerating the `unknown` type. */
+function argsField(args: unknown, field: string): string | undefined {
+	if (args && typeof args === "object" && field in args) {
+		const v = (args as Record<string, unknown>)[field];
+		if (typeof v === "string" && v.length > 0) return v;
 	}
 	return undefined;
 }
@@ -76,7 +68,7 @@ export function buildGroundedRefs(activity: readonly ActivityItem[]): GroundedRe
 
 	for (const item of activity) {
 		if (item.kind !== "tool") continue;
-		const callPath = argsPath(item.args);
+		const callPath = argsField(item.args, "path");
 		if (callPath) paths.add(normalizePath(callPath));
 
 		const lines = item.resultText ? item.resultText.split("\n") : [];
@@ -113,7 +105,7 @@ export function buildGroundedRefs(activity: readonly ActivityItem[]): GroundedRe
 
 		// A grep whose pattern is a bare identifier grounds that symbol at its
 		// first hit (a usage site — the host still prefers the LSP definition).
-		const pattern = argsPattern(item.args);
+		const pattern = argsField(item.args, "pattern");
 		if (item.toolName === "grep" && pattern && IDENTIFIER.test(pattern) && firstGrepHit && !symbols.has(pattern)) {
 			symbols.set(pattern, firstGrepHit);
 		}

--- a/packages/vscode/src/webview/code-links.ts
+++ b/packages/vscode/src/webview/code-links.ts
@@ -1,0 +1,236 @@
+/**
+ * Clickable code links (Phase 5b) — turn file/symbol references in an assistant
+ * answer into links that open the code in the editor.
+ *
+ * Reliability lives in the *client*, not the model: we never trust the LLM to
+ * emit valid links. Instead we (1) linkify only references that are either
+ * syntactically unambiguous (a `path:line`, or a path with a directory + file
+ * extension) or (2) *grounded* — i.e. the exact path/symbol appeared in this
+ * response's own tool results (read/grep/search/find). A grounded symbol also
+ * carries the location from its tool hit, so clicking can jump straight there
+ * even before any language-server resolution. References that match nothing real
+ * simply stay plain text — the failure mode is "no link", never a broken link.
+ *
+ * `buildGroundedRefs` is pure string parsing (node-testable); `linkifyAnswer`
+ * needs a DOM (`document`) to walk text nodes safely without corrupting the
+ * markdown-rendered `<a>`/`<code>` structure — covered by a jsdom test.
+ */
+
+import type { ActivityItem } from "../shared/projection.js";
+
+/** A best-known source location for a grounded reference. */
+export interface GroundedLocation {
+	/** Path exactly as it appeared in the tool result (tool-cwd-relative). */
+	path: string;
+	/** 1-based line, when the tool hit carried one. */
+	line?: number;
+}
+
+/** The set of real paths and symbol→location pairs observed in a response's own
+ * tool activity, used to gate + locate linkification of that response's answer. */
+export interface GroundedRefs {
+	/** Normalized (forward-slash) paths seen in tool results. */
+	paths: Set<string>;
+	/** Symbol name → best-known location, from search/grep hits. */
+	symbols: Map<string, GroundedLocation>;
+}
+
+/** A `path:line:` match line from the grep tool (`formatBlock`). */
+const GREP_HIT = /^(.+?):(\d+):/;
+/** A `N. filePath:Lstart[-Lend] (kind name)` line from semantic search
+ * (`formatResults`). */
+const SEARCH_HIT = /^\s*\d+\.\s+(.+?):L(\d+)(?:-\d+)?\s+\((?:\w+)(?:\s+([^)]+))?\)\s*$/;
+/** A bare identifier (safe to treat as a symbol / grep pattern). */
+const IDENTIFIER = /^[A-Za-z_$][\w$]*$/;
+
+function normalizePath(path: string): string {
+	return path.trim().replace(/\\/g, "/");
+}
+
+/** Pull a string `path` field out of a tool's `args` (read/find/grep all carry
+ * one), tolerating the `unknown` type. */
+function argsPath(args: unknown): string | undefined {
+	if (args && typeof args === "object" && "path" in args) {
+		const p = (args as { path?: unknown }).path;
+		if (typeof p === "string" && p.length > 0) return p;
+	}
+	return undefined;
+}
+
+function argsPattern(args: unknown): string | undefined {
+	if (args && typeof args === "object" && "pattern" in args) {
+		const p = (args as { pattern?: unknown }).pattern;
+		if (typeof p === "string" && p.length > 0) return p;
+	}
+	return undefined;
+}
+
+/**
+ * Derive the grounded reference set for one response from its tool activity.
+ * Parses the known tool output formats (grep `path:line:`, search
+ * `filePath:Lstart (kind name)`, find bare paths) plus tool-call `args.path`.
+ */
+export function buildGroundedRefs(activity: readonly ActivityItem[]): GroundedRefs {
+	const paths = new Set<string>();
+	const symbols = new Map<string, GroundedLocation>();
+
+	for (const item of activity) {
+		if (item.kind !== "tool") continue;
+		const callPath = argsPath(item.args);
+		if (callPath) paths.add(normalizePath(callPath));
+
+		const lines = item.resultText ? item.resultText.split("\n") : [];
+		let firstGrepHit: GroundedLocation | undefined;
+		for (const raw of lines) {
+			const line = raw.trimEnd();
+			if (line.length === 0) continue;
+
+			const search = SEARCH_HIT.exec(line);
+			if (search) {
+				const path = normalizePath(search[1]);
+				const startLine = Number(search[2]) || undefined;
+				paths.add(path);
+				const name = search[3]?.trim().split(/\s+/).pop();
+				if (name && IDENTIFIER.test(name) && !symbols.has(name)) {
+					symbols.set(name, { path, line: startLine });
+				}
+				continue;
+			}
+
+			const grep = GREP_HIT.exec(line);
+			if (grep) {
+				const path = normalizePath(grep[1]);
+				paths.add(path);
+				if (!firstGrepHit) firstGrepHit = { path, line: Number(grep[2]) };
+				continue;
+			}
+
+			// find output: a bare path (has a slash or a file extension, no spaces).
+			if (item.toolName === "find" && /^[^\s:]+$/.test(line) && (line.includes("/") || /\.[A-Za-z]/.test(line))) {
+				paths.add(normalizePath(line));
+			}
+		}
+
+		// A grep whose pattern is a bare identifier grounds that symbol at its
+		// first hit (a usage site — the host still prefers the LSP definition).
+		const pattern = argsPattern(item.args);
+		if (item.toolName === "grep" && pattern && IDENTIFIER.test(pattern) && firstGrepHit && !symbols.has(pattern)) {
+			symbols.set(pattern, firstGrepHit);
+		}
+	}
+
+	return { paths, symbols };
+}
+
+/** A file reference: a path with a file extension, optional `:line[:col]`. */
+const FILE_REF = /(?<![\w./-])((?:\.{0,2}\/)?(?:[\w.-]+\/)*[\w.-]+\.[A-Za-z][\w-]*)(?::(\d+))?(?::(\d+))?/g;
+
+interface Hit {
+	start: number;
+	end: number;
+	el: HTMLAnchorElement;
+}
+
+function makeLink(): HTMLAnchorElement {
+	const a = document.createElement("a");
+	a.className = "dreb-code-link";
+	a.href = "#";
+	return a;
+}
+
+/** Collect file-reference hits in `text`. A match is linkified when it carries a
+ * line, contains a directory separator, or its path is grounded — a bare
+ * `foo.ts` with none of these is left alone (too ambiguous). */
+function fileHits(text: string, refs: GroundedRefs): Hit[] {
+	const hits: Hit[] = [];
+	FILE_REF.lastIndex = 0;
+	let m: RegExpExecArray | null = FILE_REF.exec(text);
+	while (m !== null) {
+		const [raw, path, lineStr, colStr] = m;
+		const normalized = normalizePath(path);
+		const grounded = refs.paths.has(normalized);
+		if (lineStr !== undefined || path.includes("/") || grounded) {
+			const a = makeLink();
+			a.textContent = raw;
+			a.dataset.path = path;
+			if (lineStr) a.dataset.line = lineStr;
+			if (colStr) a.dataset.column = colStr;
+			hits.push({ start: m.index, end: m.index + raw.length, el: a });
+		}
+		m = FILE_REF.exec(text);
+	}
+	return hits;
+}
+
+/** Collect grounded-symbol hits in `text` (whole-word, from the bounded grounded
+ * set only — so ordinary prose is never over-linkified). */
+function symbolHits(text: string, refs: GroundedRefs): Hit[] {
+	if (refs.symbols.size === 0) return [];
+	const names = [...refs.symbols.keys()].sort((a, b) => b.length - a.length).map(escapeRe);
+	const re = new RegExp(`\\b(${names.join("|")})\\b`, "g");
+	const hits: Hit[] = [];
+	let m: RegExpExecArray | null = re.exec(text);
+	while (m !== null) {
+		const name = m[1];
+		const loc = refs.symbols.get(name);
+		const a = makeLink();
+		a.textContent = name;
+		a.dataset.symbol = name;
+		if (loc?.path) a.dataset.path = loc.path;
+		if (loc?.line) a.dataset.line = String(loc.line);
+		hits.push({ start: m.index, end: m.index + name.length, el: a });
+		m = re.exec(text);
+	}
+	return hits;
+}
+
+function escapeRe(s: string): string {
+	return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** Replace one text node with linkified content, preferring file matches over
+ * symbol matches when they overlap. Returns the new nodes, or null if none. */
+function linkifyTextNode(node: Text, refs: GroundedRefs): Node[] | null {
+	const text = node.data;
+	const all = [...fileHits(text, refs), ...symbolHits(text, refs)].sort((a, b) => a.start - b.start);
+	if (all.length === 0) return null;
+
+	const out: Node[] = [];
+	let cursor = 0;
+	for (const hit of all) {
+		if (hit.start < cursor) continue; // overlaps a prior (earlier/file) hit — skip
+		if (hit.start > cursor) out.push(document.createTextNode(text.slice(cursor, hit.start)));
+		out.push(hit.el);
+		cursor = hit.end;
+	}
+	if (cursor < text.length) out.push(document.createTextNode(text.slice(cursor)));
+	return out;
+}
+
+function walk(parent: Node, refs: GroundedRefs): void {
+	const children = Array.from(parent.childNodes);
+	for (const child of children) {
+		if (child.nodeType === 3 /* text */) {
+			const replaced = linkifyTextNode(child as Text, refs);
+			if (replaced) (child as ChildNode).replaceWith(...replaced);
+		} else if (child.nodeType === 1 /* element */) {
+			const el = child as Element;
+			// Never nest links inside an existing anchor.
+			if (el.tagName === "A") continue;
+			walk(el, refs);
+		}
+	}
+}
+
+/**
+ * Linkify file/symbol references in already-sanitized answer HTML. Operates on
+ * text nodes via a DOM walk so existing markdown links/code spans are preserved
+ * and all inserted text is auto-escaped by the DOM. Idempotent-safe: skips
+ * inside existing anchors.
+ */
+export function linkifyAnswer(html: string, refs: GroundedRefs): string {
+	const root = document.createElement("div");
+	root.innerHTML = html;
+	walk(root, refs);
+	return root.innerHTML;
+}

--- a/packages/vscode/src/webview/styles.css
+++ b/packages/vscode/src/webview/styles.css
@@ -137,6 +137,23 @@ body {
 .dreb-answer code {
 	font-family: var(--vscode-editor-font-family, monospace);
 }
+/* Clickable code links (Phase 5b) — subtle, editor-native affordance. */
+.dreb-code-link {
+	color: var(--vscode-textLink-foreground, #3794ff);
+	text-decoration: none;
+	cursor: pointer;
+	border-radius: 3px;
+}
+.dreb-code-link:hover {
+	text-decoration: underline;
+	color: var(--vscode-textLink-activeForeground, var(--vscode-textLink-foreground, #3794ff));
+}
+.dreb-answer code .dreb-code-link {
+	color: inherit;
+	text-decoration: underline;
+	text-decoration-style: dotted;
+	text-underline-offset: 2px;
+}
 
 /* Activity box ------------------------------------------------------------ */
 .dreb-activity {

--- a/packages/vscode/test/code-links.test.tsx
+++ b/packages/vscode/test/code-links.test.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+/**
+ * Clickable code links (Phase 5b) — grounding + linkification.
+ *
+ * `buildGroundedRefs` is pure parsing of the known tool-output formats;
+ * `linkifyAnswer` walks the sanitized answer DOM and wraps only references that
+ * are syntactically unambiguous or grounded, without corrupting existing
+ * markdown. jsdom provides the `document` the DOM walk needs.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { ActivityItem, ToolActivity } from "../src/shared/projection.js";
+import { buildGroundedRefs, linkifyAnswer } from "../src/webview/code-links.js";
+
+function tool(partial: Partial<ToolActivity> & Pick<ToolActivity, "toolName">): ToolActivity {
+	return {
+		kind: "tool",
+		toolCallId: "t1",
+		args: {},
+		status: "done",
+		resultText: "",
+		...partial,
+	};
+}
+
+describe("buildGroundedRefs", () => {
+	it("grounds paths from read args, grep hits, search hits, and find output", () => {
+		const activity: ActivityItem[] = [
+			tool({ toolName: "read", args: { path: "src/read-me.ts" } }),
+			tool({ toolName: "grep", args: { pattern: "foo" }, resultText: "src/grep-hit.ts:42: const foo = 1" }),
+			tool({ toolName: "search", resultText: "1. src/search-hit.ts:L10-20 (function widget)" }),
+			tool({ toolName: "find", resultText: "src/found-a.ts\nsrc/found-b.ts" }),
+		];
+		const refs = buildGroundedRefs(activity);
+		expect(refs.paths.has("src/read-me.ts")).toBe(true);
+		expect(refs.paths.has("src/grep-hit.ts")).toBe(true);
+		expect(refs.paths.has("src/search-hit.ts")).toBe(true);
+		expect(refs.paths.has("src/found-a.ts")).toBe(true);
+		expect(refs.paths.has("src/found-b.ts")).toBe(true);
+	});
+
+	it("grounds a symbol with its location from a search hit", () => {
+		const refs = buildGroundedRefs([
+			tool({ toolName: "search", resultText: "1. src/widget.ts:L10-20 (function widget)" }),
+		]);
+		expect(refs.symbols.get("widget")).toEqual({ path: "src/widget.ts", line: 10 });
+	});
+
+	it("grounds a grep symbol from a bare-identifier pattern at its first hit", () => {
+		const refs = buildGroundedRefs([
+			tool({ toolName: "grep", args: { pattern: "Widget" }, resultText: "src/widget.ts:7: class Widget {}" }),
+		]);
+		expect(refs.symbols.get("Widget")).toEqual({ path: "src/widget.ts", line: 7 });
+	});
+
+	it("ignores thinking activity and non-hit noise", () => {
+		const refs = buildGroundedRefs([
+			{ kind: "thinking", text: "considering src/secret.ts:1" },
+			tool({ toolName: "bash", resultText: "no colon-line hits here" }),
+		]);
+		expect(refs.paths.size).toBe(0);
+		expect(refs.symbols.size).toBe(0);
+	});
+});
+
+describe("linkifyAnswer", () => {
+	const empty = { paths: new Set<string>(), symbols: new Map() };
+
+	function links(html: string): HTMLAnchorElement[] {
+		const div = document.createElement("div");
+		div.innerHTML = html;
+		return [...div.querySelectorAll("a.dreb-code-link")] as HTMLAnchorElement[];
+	}
+
+	it("linkifies a path:line reference with path + line data", () => {
+		const out = linkifyAnswer("<p>See src/a.ts:42 now</p>", empty);
+		const [a] = links(out);
+		expect(a).toBeTruthy();
+		expect(a.dataset.path).toBe("src/a.ts");
+		expect(a.dataset.line).toBe("42");
+		expect(a.textContent).toBe("src/a.ts:42");
+	});
+
+	it("linkifies a bare path that contains a directory separator", () => {
+		const out = linkifyAnswer("<p>edit src/a.ts here</p>", empty);
+		const [a] = links(out);
+		expect(a?.dataset.path).toBe("src/a.ts");
+		expect(a?.dataset.line).toBeUndefined();
+	});
+
+	it("does NOT linkify a bare filename with no slash and no grounding", () => {
+		expect(links(linkifyAnswer("<p>the file a.ts is here</p>", empty))).toHaveLength(0);
+	});
+
+	it("linkifies a bare grounded filename (no slash) because it is real", () => {
+		const refs = { paths: new Set(["a.ts"]), symbols: new Map() };
+		const [a] = links(linkifyAnswer("<p>the file a.ts is here</p>", refs));
+		expect(a?.dataset.path).toBe("a.ts");
+	});
+
+	it("linkifies a grounded symbol with its symbol + grounded location", () => {
+		const refs = { paths: new Set<string>(), symbols: new Map([["Widget", { path: "src/widget.ts", line: 7 }]]) };
+		const [a] = links(linkifyAnswer("<p>the <code>Widget</code> class</p>", refs));
+		expect(a?.dataset.symbol).toBe("Widget");
+		expect(a?.dataset.path).toBe("src/widget.ts");
+		expect(a?.dataset.line).toBe("7");
+	});
+
+	it("does NOT linkify an ungrounded word", () => {
+		const refs = { paths: new Set<string>(), symbols: new Map([["Widget", { path: "src/widget.ts" }]]) };
+		expect(links(linkifyAnswer("<p>a Gadget and a thing</p>", refs))).toHaveLength(0);
+	});
+
+	it("never nests a link inside an existing markdown anchor", () => {
+		const out = linkifyAnswer('<p>see <a href="http://x">src/a.ts:9</a></p>', empty);
+		// The only anchor is the original external link; no code-link was added inside it.
+		expect(links(out)).toHaveLength(0);
+		expect(out).toContain('href="http://x"');
+	});
+
+	it("preserves surrounding markup and escapes text", () => {
+		const out = linkifyAnswer("<p><strong>bold</strong> src/a.ts:1 &amp; more</p>", empty);
+		expect(out).toContain("<strong>bold</strong>");
+		expect(out).toContain("&amp;");
+		expect(links(out)).toHaveLength(1);
+	});
+});

--- a/packages/vscode/test/code-links.test.tsx
+++ b/packages/vscode/test/code-links.test.tsx
@@ -124,4 +124,25 @@ describe("linkifyAnswer", () => {
 		expect(out).toContain("&amp;");
 		expect(links(out)).toHaveLength(1);
 	});
+
+	it("prefers the file link over an overlapping grounded symbol in the same text", () => {
+		// `widget` is a grounded symbol AND a substring of the grounded file token
+		// `src/widget.ts:42`. The file hit must win the overlap: one link, carrying
+		// the line number, with no stray/duplicate text or nested anchor.
+		const refs = {
+			paths: new Set(["src/widget.ts"]),
+			symbols: new Map([["widget", { path: "src/widget.ts", line: 7 }]]),
+		};
+		const out = linkifyAnswer("<p>See src/widget.ts:42 here</p>", refs);
+		const all = links(out);
+		expect(all).toHaveLength(1);
+		expect(all[0].dataset.path).toBe("src/widget.ts");
+		expect(all[0].dataset.line).toBe("42");
+		expect(all[0].dataset.symbol).toBeUndefined();
+		expect(all[0].textContent).toBe("src/widget.ts:42");
+		// No text was dropped or duplicated around the single link.
+		const div = document.createElement("div");
+		div.innerHTML = out;
+		expect(div.textContent).toBe("See src/widget.ts:42 here");
+	});
 });

--- a/packages/vscode/test/response-click.test.tsx
+++ b/packages/vscode/test/response-click.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+/**
+ * End-to-end click wiring for clickable code links (Phase 5b, finding 2).
+ *
+ * `code-links.ts` writes the `data-path/line/column/symbol` attributes; the
+ * chat's `ResponseView` wires `onClick={onCodeLinkClick}` on the rendered
+ * answer, and `onCodeLinkClick` reads exactly those keys and posts `open-source`
+ * to the host. Unit tests cover each side in isolation; this test renders the
+ * real `ResponseView` in jsdom, dispatches a real click on a *produced* link,
+ * and asserts the whole producer→delegation→postToHost contract holds together
+ * (a dataset-key rename, a dropped `preventDefault`, or broken `closest()`
+ * delegation would fail here while the isolated tests stayed green).
+ */
+
+import { render } from "solid-js/web/dist/web.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ResponseGroup, ToolActivity } from "../src/shared/projection.js";
+
+const hoisted = vi.hoisted(() => ({ posted: [] as unknown[] }));
+
+vi.mock("../src/webview/vscode-api.js", () => ({
+	onHostMessage: () => () => {},
+	postToHost: (msg: unknown) => {
+		hoisted.posted.push(msg);
+	},
+}));
+
+import { ResponseView } from "../src/webview/app.js";
+
+function group(partial: Partial<ResponseGroup>): ResponseGroup {
+	return {
+		kind: "response",
+		id: 1,
+		activity: [],
+		answer: "",
+		streaming: false,
+		collapsed: true,
+		...partial,
+	};
+}
+
+function searchTool(resultText: string): ToolActivity {
+	return { kind: "tool", toolCallId: "t1", toolName: "search", args: {}, status: "done", resultText };
+}
+
+let dispose: (() => void) | undefined;
+afterEach(() => {
+	dispose?.();
+	dispose = undefined;
+	hoisted.posted.length = 0;
+	document.body.innerHTML = "";
+});
+
+function mount(g: ResponseGroup): HTMLElement {
+	const host = document.createElement("div");
+	document.body.appendChild(host);
+	dispose = render(() => <ResponseView group={g} />, host);
+	return host;
+}
+
+describe("ResponseView code-link click wiring", () => {
+	it("posts open-source with path+line when a path:line link is clicked", () => {
+		const host = mount(group({ answer: "See src/a.ts:42 for details." }));
+		const link = host.querySelector("a.dreb-code-link") as HTMLAnchorElement;
+		expect(link).toBeTruthy();
+
+		link.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+
+		expect(hoisted.posted).toEqual([{ type: "open-source", ref: { path: "src/a.ts", line: 42 } }]);
+	});
+
+	it("posts symbol + grounded location when a grounded symbol link is clicked", () => {
+		const g = group({
+			answer: "The Widget class handles it.",
+			activity: [searchTool("1. src/widget.ts:L7-20 (class Widget)")],
+		});
+		const host = mount(g);
+		// The answer's grounded-symbol link (not any link the activity box may render).
+		const answer = host.querySelector(".dreb-answer") as HTMLElement;
+		const link = answer.querySelector("a.dreb-code-link") as HTMLAnchorElement;
+		expect(link?.dataset.symbol).toBe("Widget");
+
+		link.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+
+		expect(hoisted.posted).toEqual([
+			{ type: "open-source", ref: { symbol: "Widget", path: "src/widget.ts", line: 7 } },
+		]);
+	});
+
+	it("calls preventDefault so the href='#' anchor does not scroll-jump", () => {
+		const host = mount(group({ answer: "open src/a.ts:1 now" }));
+		const link = host.querySelector("a.dreb-code-link") as HTMLAnchorElement;
+		const evt = new MouseEvent("click", { bubbles: true, cancelable: true });
+		link.dispatchEvent(evt);
+		expect(evt.defaultPrevented).toBe(true);
+	});
+
+	it("posts nothing when plain (non-link) answer text is clicked", () => {
+		const host = mount(group({ answer: "just some prose with no references" }));
+		const answer = host.querySelector(".dreb-answer") as HTMLElement;
+		expect(answer.querySelector("a.dreb-code-link")).toBeNull();
+
+		answer.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+
+		expect(hoisted.posted).toEqual([]);
+	});
+});

--- a/packages/vscode/test/session-controller.test.ts
+++ b/packages/vscode/test/session-controller.test.ts
@@ -1011,4 +1011,20 @@ describe("SessionController.openSource", () => {
 		});
 		await expect(controller.openSource({ path: "src/a.ts", line: 1 })).resolves.toBeUndefined();
 	});
+
+	it("swallows a throwing SourceLinkUi into a notice (bridge calls it fire-and-forget)", async () => {
+		const sourceLink: SourceLinkUi = {
+			async openSource() {
+				throw new Error("boom");
+			},
+		};
+		const controller = new SessionController({
+			cwd: "/tmp/project",
+			cliPath: "/cli.js",
+			clientFactory: () => new FakeClient(),
+			sourceLink,
+		});
+		// Must not reject — an unhandled rejection is exactly what we're guarding.
+		await expect(controller.openSource({ symbol: "Widget" })).resolves.toBeUndefined();
+	});
 });

--- a/packages/vscode/test/session-controller.test.ts
+++ b/packages/vscode/test/session-controller.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import type { HostUi, HostUiPickItem } from "../src/host/host-ui.js";
 import { type RpcClientLike, SessionController } from "../src/host/session-controller.js";
+import type { SourceLinkUi } from "../src/host/source-link-ui.js";
+import type { OpenSourceRef } from "../src/shared/protocol.js";
 
 /** Fake RpcClient that captures calls and lets a test drive events/exit. */
 class FakeClient implements RpcClientLike {
@@ -974,5 +976,39 @@ describe("SessionController", () => {
 		await Promise.resolve();
 
 		expect(controller.sessionPath).toBe("/abs/live.jsonl");
+	});
+});
+
+describe("SessionController.openSource", () => {
+	it("delegates a clicked code reference to the injected SourceLinkUi", async () => {
+		const calls: OpenSourceRef[] = [];
+		const sourceLink: SourceLinkUi = {
+			async openSource(ref) {
+				calls.push(ref);
+			},
+		};
+		const controller = new SessionController({
+			cwd: "/tmp/project",
+			cliPath: "/cli.js",
+			clientFactory: () => new FakeClient(),
+			sourceLink,
+		});
+
+		await controller.openSource({ path: "src/a.ts", line: 12 });
+		await controller.openSource({ symbol: "Widget", path: "src/a.ts", line: 3 });
+
+		expect(calls).toEqual([
+			{ path: "src/a.ts", line: 12 },
+			{ symbol: "Widget", path: "src/a.ts", line: 3 },
+		]);
+	});
+
+	it("is inert (no throw) when no SourceLinkUi is injected", async () => {
+		const controller = new SessionController({
+			cwd: "/tmp/project",
+			cliPath: "/cli.js",
+			clientFactory: () => new FakeClient(),
+		});
+		await expect(controller.openSource({ path: "src/a.ts", line: 1 })).resolves.toBeUndefined();
 	});
 });

--- a/packages/vscode/test/vscode-source-link-ui.test.ts
+++ b/packages/vscode/test/vscode-source-link-ui.test.ts
@@ -12,6 +12,8 @@ const hoisted = vi.hoisted(() => ({
 	exists: new Set<string>(),
 	symbolHits: [] as any[],
 	pickResult: undefined as any,
+	pickCount: 0,
+	openThrows: false,
 	shown: [] as { uri: any; selection?: any; revealed: boolean }[],
 	info: [] as string[],
 }));
@@ -50,7 +52,10 @@ vi.mock("vscode", () => {
 			executeCommand: vi.fn(async () => hoisted.symbolHits),
 		},
 		window: {
-			showQuickPick: vi.fn(async () => hoisted.pickResult),
+			showQuickPick: vi.fn(async () => {
+				hoisted.pickCount++;
+				return hoisted.pickResult;
+			}),
 			showInformationMessage: vi.fn(async (m: string) => {
 				hoisted.info.push(m);
 			}),
@@ -72,7 +77,10 @@ vi.mock("vscode", () => {
 			}),
 		},
 		workspace: {
-			openTextDocument: vi.fn(async (uri: any) => ({ uri })),
+			openTextDocument: vi.fn(async (uri: any) => {
+				if (hoisted.openThrows) throw new Error("cannot open binary file");
+				return { uri };
+			}),
 			asRelativePath: (uri: any) => uri.fsPath,
 		},
 	};
@@ -84,6 +92,8 @@ function reset() {
 	hoisted.exists = new Set();
 	hoisted.symbolHits = [];
 	hoisted.pickResult = undefined;
+	hoisted.pickCount = 0;
+	hoisted.openThrows = false;
 	hoisted.shown = [];
 	hoisted.info = [];
 }
@@ -111,6 +121,21 @@ describe("createVscodeSourceLinkUi", () => {
 
 		expect(hoisted.shown).toHaveLength(0);
 		expect(hoisted.info[0]).toContain("not found");
+	});
+
+	it("surfaces a notice (not a silent no-op) when opening the document fails", async () => {
+		reset();
+		// File exists at check time but openTextDocument rejects (binary file, or
+		// deleted between existsSync and open). Must degrade to a notice, and must
+		// not reject — the bridge calls openSource fire-and-forget.
+		hoisted.exists.add("/proj/assets/logo.png");
+		hoisted.openThrows = true;
+		const ui = createVscodeSourceLinkUi("/proj");
+
+		await expect(ui.openSource({ path: "assets/logo.png", line: 1 })).resolves.toBeUndefined();
+
+		expect(hoisted.shown).toHaveLength(0);
+		expect(hoisted.info[0]).toContain("couldn't open");
 	});
 
 	it("prefers a symbol's definition (workspace symbol provider) over the grounded path", async () => {
@@ -155,6 +180,39 @@ describe("createVscodeSourceLinkUi", () => {
 
 		expect(hoisted.shown).toHaveLength(1);
 		expect(hoisted.shown[0].uri.fsPath).toBe("/proj/b.ts");
+		expect(hoisted.pickCount).toBe(1);
+	});
+
+	it("uses the exact-name match directly, without a quick pick, amid fuzzy hits", async () => {
+		reset();
+		// Fuzzy workspace-symbol search commonly returns substring matches
+		// (WidgetFactory, MyWidget) alongside the exact one. The exact name must
+		// win directly — no disambiguation prompt, no fuzzy definition.
+		hoisted.symbolHits = [
+			{
+				name: "WidgetFactory",
+				kind: 4,
+				location: { uri: { fsPath: "/proj/factory.ts" }, range: { start: { line: 0, character: 0 } } },
+			},
+			{
+				name: "Widget",
+				kind: 4,
+				location: { uri: { fsPath: "/proj/widget.ts" }, range: { start: { line: 9, character: 4 } } },
+			},
+			{
+				name: "MyWidget",
+				kind: 4,
+				location: { uri: { fsPath: "/proj/my.ts" }, range: { start: { line: 2, character: 0 } } },
+			},
+		];
+		const ui = createVscodeSourceLinkUi("/proj");
+
+		await ui.openSource({ symbol: "Widget" });
+
+		expect(hoisted.pickCount).toBe(0);
+		expect(hoisted.shown).toHaveLength(1);
+		expect(hoisted.shown[0].uri.fsPath).toBe("/proj/widget.ts");
+		expect(hoisted.shown[0].selection.active.line).toBe(9);
 	});
 
 	it("falls back to the grounded path/line when the provider finds nothing", async () => {

--- a/packages/vscode/test/vscode-source-link-ui.test.ts
+++ b/packages/vscode/test/vscode-source-link-ui.test.ts
@@ -1,0 +1,183 @@
+/**
+ * vscode-backed SourceLinkUi (Phase 5b) — open/resolve behavior.
+ *
+ * `vscode` and `node:fs` are mocked so the resolution logic (path reveal, symbol
+ * → definition via the workspace symbol provider, grounded fallback, and the
+ * not-found notice) is exercised without a real editor or filesystem.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+	exists: new Set<string>(),
+	symbolHits: [] as any[],
+	pickResult: undefined as any,
+	shown: [] as { uri: any; selection?: any; revealed: boolean }[],
+	info: [] as string[],
+}));
+
+vi.mock("node:fs", () => ({
+	existsSync: (p: string) => hoisted.exists.has(p),
+}));
+
+vi.mock("vscode", () => {
+	class Position {
+		constructor(
+			public line: number,
+			public character: number,
+		) {}
+	}
+	class Selection {
+		constructor(
+			public anchor: Position,
+			public active: Position,
+		) {}
+	}
+	class Range {
+		constructor(
+			public start: Position,
+			public end: Position,
+		) {}
+	}
+	return {
+		Position,
+		Selection,
+		Range,
+		TextEditorRevealType: { InCenter: 2 },
+		SymbolKind: { Class: 4, Function: 11 },
+		Uri: { file: (p: string) => ({ scheme: "file", fsPath: p, path: p }) },
+		commands: {
+			executeCommand: vi.fn(async () => hoisted.symbolHits),
+		},
+		window: {
+			showQuickPick: vi.fn(async () => hoisted.pickResult),
+			showInformationMessage: vi.fn(async (m: string) => {
+				hoisted.info.push(m);
+			}),
+			showTextDocument: vi.fn(async (doc: any) => {
+				const record = { uri: doc.uri, selection: undefined as any, revealed: false };
+				const editor = {
+					get selection() {
+						return record.selection;
+					},
+					set selection(v: any) {
+						record.selection = v;
+					},
+					revealRange: () => {
+						record.revealed = true;
+					},
+				};
+				hoisted.shown.push(record);
+				return editor;
+			}),
+		},
+		workspace: {
+			openTextDocument: vi.fn(async (uri: any) => ({ uri })),
+			asRelativePath: (uri: any) => uri.fsPath,
+		},
+	};
+});
+
+import { createVscodeSourceLinkUi } from "../src/host/vscode-source-link-ui.js";
+
+function reset() {
+	hoisted.exists = new Set();
+	hoisted.symbolHits = [];
+	hoisted.pickResult = undefined;
+	hoisted.shown = [];
+	hoisted.info = [];
+}
+
+describe("createVscodeSourceLinkUi", () => {
+	it("opens a concrete path at a 0-based converted line/column", async () => {
+		reset();
+		hoisted.exists.add("/proj/src/a.ts");
+		const ui = createVscodeSourceLinkUi("/proj");
+
+		await ui.openSource({ path: "src/a.ts", line: 42, column: 3 });
+
+		expect(hoisted.shown).toHaveLength(1);
+		expect(hoisted.shown[0].uri.fsPath).toBe("/proj/src/a.ts");
+		expect(hoisted.shown[0].selection.active.line).toBe(41);
+		expect(hoisted.shown[0].selection.active.character).toBe(2);
+		expect(hoisted.shown[0].revealed).toBe(true);
+	});
+
+	it("shows a notice and opens nothing when the path does not exist", async () => {
+		reset();
+		const ui = createVscodeSourceLinkUi("/proj");
+
+		await ui.openSource({ path: "src/missing.ts", line: 1 });
+
+		expect(hoisted.shown).toHaveLength(0);
+		expect(hoisted.info[0]).toContain("not found");
+	});
+
+	it("prefers a symbol's definition (workspace symbol provider) over the grounded path", async () => {
+		reset();
+		hoisted.exists.add("/proj/src/usage.ts");
+		hoisted.symbolHits = [
+			{
+				name: "Widget",
+				kind: 4,
+				location: { uri: { fsPath: "/proj/src/widget.ts" }, range: { start: { line: 9, character: 4 } } },
+			},
+		];
+		const ui = createVscodeSourceLinkUi("/proj");
+
+		// A grounded usage path/line is provided, but the definition should win.
+		await ui.openSource({ symbol: "Widget", path: "src/usage.ts", line: 3 });
+
+		expect(hoisted.shown).toHaveLength(1);
+		expect(hoisted.shown[0].uri.fsPath).toBe("/proj/src/widget.ts");
+		expect(hoisted.shown[0].selection.active.line).toBe(9);
+	});
+
+	it("disambiguates multiple symbol hits with a quick pick", async () => {
+		reset();
+		const hitB = {
+			name: "Widget",
+			kind: 4,
+			location: { uri: { fsPath: "/proj/b.ts" }, range: { start: { line: 1, character: 0 } } },
+		};
+		hoisted.symbolHits = [
+			{
+				name: "Widget",
+				kind: 4,
+				location: { uri: { fsPath: "/proj/a.ts" }, range: { start: { line: 0, character: 0 } } },
+			},
+			hitB,
+		];
+		hoisted.pickResult = { location: hitB.location };
+		const ui = createVscodeSourceLinkUi("/proj");
+
+		await ui.openSource({ symbol: "Widget" });
+
+		expect(hoisted.shown).toHaveLength(1);
+		expect(hoisted.shown[0].uri.fsPath).toBe("/proj/b.ts");
+	});
+
+	it("falls back to the grounded path/line when the provider finds nothing", async () => {
+		reset();
+		hoisted.exists.add("/proj/src/usage.ts");
+		hoisted.symbolHits = [];
+		const ui = createVscodeSourceLinkUi("/proj");
+
+		await ui.openSource({ symbol: "Widget", path: "src/usage.ts", line: 3 });
+
+		expect(hoisted.shown).toHaveLength(1);
+		expect(hoisted.shown[0].uri.fsPath).toBe("/proj/src/usage.ts");
+		expect(hoisted.shown[0].selection.active.line).toBe(2);
+	});
+
+	it("shows a notice when a symbol resolves nowhere and no path is given", async () => {
+		reset();
+		hoisted.symbolHits = [];
+		const ui = createVscodeSourceLinkUi("/proj");
+
+		await ui.openSource({ symbol: "Nope" });
+
+		expect(hoisted.shown).toHaveLength(0);
+		expect(hoisted.info[0]).toContain("couldn't locate");
+	});
+});

--- a/packages/vscode/test/webview-bridge.test.ts
+++ b/packages/vscode/test/webview-bridge.test.ts
@@ -269,6 +269,22 @@ describe("connectWebview", () => {
 		expect(tagFileFromPicker).toHaveBeenCalledTimes(1);
 	});
 
+	it("routes an open-source message to the controller with the parsed ref", async () => {
+		const fake = new BridgeFakeClient();
+		const controller = await makeController(fake);
+		const openSource = vi.spyOn(controller, "openSource").mockResolvedValue();
+
+		const { webview, send } = makeWebview();
+		connectWebview(webview as any, controller);
+
+		send({ type: "open-source", ref: { path: "src/a.ts", line: 12, column: 3 } });
+		send({ type: "open-source", ref: { symbol: "Widget", path: "src/a.ts", line: 5 } });
+
+		expect(openSource).toHaveBeenCalledTimes(2);
+		expect(openSource).toHaveBeenNthCalledWith(1, { path: "src/a.ts", line: 12, column: 3 });
+		expect(openSource).toHaveBeenNthCalledWith(2, { symbol: "Widget", path: "src/a.ts", line: 5 });
+	});
+
 	it("forwards a commands update as a commands message", async () => {
 		const fake = new BridgeFakeClient();
 		const controller = await makeController(fake);


### PR DESCRIPTION
Closes #26

**VSCode extension Phase 5b — clickable code links in chat.** File and symbol references in assistant answers become clickable links that open the referenced code at the right location in the editor. Linkification is grounded in the session's own tool-result hits and validated/resolved host-side, so hallucinated references degrade gracefully to plain text rather than producing broken links.

Base branch: `vscode` (continues the merged Phase 0–5 stack). Implementation plan posted as a comment below.
