### PR TITLE
VSCode extension: inline filtering @-mention picker (typeahead) with @@ for full file picker

### DIFF
--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -26,6 +26,7 @@ src/
     sessions-view-model.ts sidebar list-building + action routing (pure, vscode-free, tested)
     sessions-view.ts    the `dreb.sessions` WebviewView glue (postMessage transport + HTML shell)
     tag-selection.ts    tag-selection-into-chat orchestration (pure, vscode-free, tested)
+    workspace-search.ts @-typeahead pure helpers — folder ancestor-walk (workspace-boundary guarded) + structural-symbol filtering (vscode-free, tested)
     host-ui.ts          native-prompt port (quick pick / input / dialogs); vscode-free
     vscode-host-ui.ts   the real `HostUi` backed by `vscode.window`
     git-snapshot.ts     per-turn baseline capture + diff + `git apply -R` (pure node, tested)
@@ -37,7 +38,8 @@ src/
     vscode-source-link-ui.ts the real `SourceLinkUi` (open file / resolve symbol → definition)
   shared/
     format.ts           status-header + `/session` display formatters (pure, tested)
-    tagged-context.ts   selection + file/folder context DTOs, chip label, prompt fold + threshold (pure, tested)
+    tagged-context.ts   selection + file/folder/symbol context DTOs, chip label, prompt fold + threshold (pure, tested)
+    mention.ts          `@`/`@@` composer trigger parsing, glob escaping, and typeahead result ranking (pure, tested)
     session-list.ts     disk+live session reconciliation, grouping, deterministic ordering, status (pure, tested)
     sidebar-protocol.ts host ↔ sessions-sidebar message envelopes (no @dreb import)
   webview/       # SolidJS UI — bundled with Vite → dist/webview (chat) + dist/webview-sidebar (sessions)
@@ -113,11 +115,13 @@ Tag context into the chat as removable chips. Two kinds of context can be tagged
 
 **Editor selection.** Select any range (a whole line or part of one) and run **dreb: Add Selection to Chat** — from the command palette or the editor right-click menu (shown only when there is a selection, `when: editorHasSelection`). The selection is added as a **removable chip** labelled `basename:line` (or `basename:start-end`). On send, a small selection is folded into the prompt as a located, fenced code block (workspace-relative path + line range) so the agent knows exactly where the code came from. A **large** selection (over `MAX_INLINE_SELECTION_LINES` = 40 lines, or `MAX_INLINE_SELECTION_CHARS` = 2000 characters) instead folds as a `` `path` (lines a-b) `` reference only, to keep the prompt short. The selection is captured **at tag time** (a pre-resolved snapshot, not a lazy reference).
 
-**File / folder.** Type `@` in the composer to open the native VS Code file/folder picker (`showOpenDialog` with files and folders selectable, multi-select). Each chosen path is added as a **removable chip** (`basename`, or `basename/` for a folder). On send, a file/folder tag folds into the prompt as a **path reference only — never the contents** (e.g. `` `src/app.ts` `` or `` `src/host/` (directory) ``), so the agent can open and explore it as needed without bloating the prompt. Paths are workspace-relative when the pick is inside the workspace; the workspace root itself folds as `` `./` (directory) ``, and a pick outside the workspace uses its **absolute** path so the reference stays unambiguous (rather than a bare basename that could collide with a same-named file under the workspace).
+**File / folder / symbol.** Type `@` in the composer to open an **inline typeahead** that filters the workspace as you keep typing — matching **folders**, **files**, and code **symbols** (classes/functions/methods/…), ordered folders → files → symbols. Pick an entry to add it as a chip. Type `@@` instead to open the full **native** VS Code file/folder picker (`showOpenDialog` with files and folders selectable, multi-select) for cases the typeahead doesn't surface. Each chosen entry is added as a **removable chip** (`basename`, `basename/` for a folder, or the symbol name). On send, a file/folder tag folds into the prompt as a **path reference only — never the contents** (e.g. `` `src/app.ts` `` or `` `src/host/` (directory) ``), so the agent can open and explore it as needed without bloating the prompt. Paths are workspace-relative when the pick is inside the workspace; the workspace root itself folds as `` `./` (directory) ``, and a pick outside the workspace uses its **absolute** path so the reference stays unambiguous (rather than a bare basename that could collide with a same-named file under the workspace).
+
+The typeahead search runs host-side (debounced, capped, and ranked by filename-prefix match): folders come from `findFiles` ancestors constrained to the open workspace roots, files from `findFiles`, and symbols from the workspace symbol provider — each source degrades independently, so a failing source just drops its own rows rather than emptying the dropdown.
 
 dreb's agent accepts text + images only, so there is no separate structured-context channel: all tags are folded into the prompt text. Sending with only chips and no typed text is allowed. Tagging with no chat open opens one first, then attaches.
 
-The pure DTO builders, chip label/title, threshold logic, and prompt formatter are unit-tested in `shared/tagged-context.ts`; the selection command orchestration lives in the vscode-free `host/tag-selection.ts`; the file picker is driven through the `HostUi` port (`pickWorkspaceFiles`), so the controller stays vscode-free. Delivery to the composer is queued until the webview is `ready` so tagging into a freshly opened chat still lands.
+The pure DTO builders, chip label/title, threshold logic, and prompt formatter are unit-tested in `shared/tagged-context.ts`; the selection command orchestration lives in the vscode-free `host/tag-selection.ts`; the native picker and the typeahead search are driven through the `HostUi` port (`pickWorkspaceFiles`, `searchWorkspace`), so the controller stays vscode-free. The typeahead's pure derivation logic (folder ancestor-walk with workspace-boundary guard, structural-symbol filtering) lives in `host/workspace-search.ts` and the `@`/`@@` trigger parsing in `shared/mention.ts` — both vscode-free and unit-tested. Delivery to the composer is queued until the webview is `ready` so tagging into a freshly opened chat still lands.
 
 
 ## Clickable code links

--- a/packages/vscode/src/host/host-ui.ts
+++ b/packages/vscode/src/host/host-ui.ts
@@ -36,6 +36,10 @@ export interface HostUi {
 	/** Show the native file/folder picker (multi-select) for tagging context;
 	 * resolves to the chosen files/folders, or undefined if dismissed. */
 	pickWorkspaceFiles(): Promise<PickedFile[] | undefined>;
+	/** Search workspace files for the inline `@`-mention typeahead. Returns
+	 * absolute file paths (files only) matching `query`, capped by the host. An
+	 * empty query returns a bounded set of workspace files. */
+	searchWorkspaceFiles(query: string): Promise<PickedFile[]>;
 }
 
 /** No-op HostUi: every prompt resolves to undefined (as if dismissed). Used as
@@ -56,5 +60,8 @@ export const noopHostUi: HostUi = {
 	},
 	async pickWorkspaceFiles() {
 		return undefined;
+	},
+	async searchWorkspaceFiles() {
+		return [];
 	},
 };

--- a/packages/vscode/src/host/host-ui.ts
+++ b/packages/vscode/src/host/host-ui.ts
@@ -24,6 +24,14 @@ export interface PickedFile {
 	isDirectory: boolean;
 }
 
+/** One hit from the inline `@`-mention workspace search: a folder, a file, or a
+ * code symbol (class/function/method). Absolute `fsPath`s so the controller can
+ * relativize them against the session cwd. */
+export type WorkspaceSearchResult =
+	| { kind: "folder"; fsPath: string }
+	| { kind: "file"; fsPath: string }
+	| { kind: "symbol"; name: string; symbolKind: string; fsPath: string; line: number };
+
 export interface HostUi {
 	/** Show a quick pick; resolves to the chosen item's `value`, or undefined if dismissed. */
 	quickPick(items: HostUiPickItem[], options?: { placeholder?: string }): Promise<string | undefined>;
@@ -36,10 +44,10 @@ export interface HostUi {
 	/** Show the native file/folder picker (multi-select) for tagging context;
 	 * resolves to the chosen files/folders, or undefined if dismissed. */
 	pickWorkspaceFiles(): Promise<PickedFile[] | undefined>;
-	/** Search workspace files for the inline `@`-mention typeahead. Returns
-	 * absolute file paths (files only) matching `query`, capped by the host. An
-	 * empty query returns a bounded set of workspace files. */
-	searchWorkspaceFiles(query: string): Promise<PickedFile[]>;
+	/** Search the workspace for the inline `@`-mention typeahead. Returns folders,
+	 * files, and code symbols matching `query`, capped by the host. An empty query
+	 * returns a bounded set of workspace files (folders/symbols need a query). */
+	searchWorkspace(query: string): Promise<WorkspaceSearchResult[]>;
 }
 
 /** No-op HostUi: every prompt resolves to undefined (as if dismissed). Used as
@@ -61,7 +69,7 @@ export const noopHostUi: HostUi = {
 	async pickWorkspaceFiles() {
 		return undefined;
 	},
-	async searchWorkspaceFiles() {
+	async searchWorkspace() {
 		return [];
 	},
 };

--- a/packages/vscode/src/host/session-controller.ts
+++ b/packages/vscode/src/host/session-controller.ts
@@ -13,7 +13,7 @@
  */
 
 import { formatSessionStats } from "../shared/format.js";
-import { MENTION_RESULT_CAP, rankFileResults } from "../shared/mention.js";
+import { MENTION_RESULT_CAP, rankMentionResults } from "../shared/mention.js";
 import {
 	alignCheckpoints,
 	applyEvent,
@@ -24,7 +24,6 @@ import {
 	type TranscriptState,
 } from "../shared/projection.js";
 import type {
-	FileContextDto,
 	HostStatus,
 	OpenSourceRef,
 	ReviewFileDto,
@@ -36,7 +35,7 @@ import type {
 	UiResponse,
 } from "../shared/protocol.js";
 import { deriveSessionStatus, type SessionRunState } from "../shared/session-list.js";
-import { buildFileContext, buildPromptWithContext } from "../shared/tagged-context.js";
+import { buildFileContext, buildPromptWithContext, buildSymbolContext } from "../shared/tagged-context.js";
 import { hunkIndexForLine, parseFileDiff } from "./diff-hunks.js";
 import {
 	baselineContent,
@@ -765,15 +764,26 @@ export class SessionController {
 		}
 	}
 
-	/** Search workspace files for the inline `@`-mention typeahead dropdown.
-	 * Returns ready-to-tag `FileContextDto`s (workspace-relative paths built with
-	 * the session `cwd`, so a webview selection needs no further host round-trip),
-	 * ranked by relevance to `query` and capped. Stays vscode-free: the search is
-	 * injected via the `HostUi` port. */
-	async searchWorkspaceFiles(query: string): Promise<FileContextDto[]> {
-		const picks = await this.ui.searchWorkspaceFiles(query);
-		const results = picks.map((pick) => buildFileContext({ fsPath: pick.fsPath, cwd: this.cwd }));
-		return rankFileResults(results, query, MENTION_RESULT_CAP);
+	/** Search the workspace for the inline `@`-mention typeahead dropdown. Returns
+	 * ready-to-tag `TaggedContextDto`s (folders, files, and code symbols, with
+	 * workspace-relative paths built from the session `cwd` so a webview selection
+	 * needs no further host round-trip), ranked by kind then relevance to `query`
+	 * and capped. Stays vscode-free: the search is injected via the `HostUi` port. */
+	async searchWorkspace(query: string): Promise<TaggedContextDto[]> {
+		const hits = await this.ui.searchWorkspace(query);
+		const results: TaggedContextDto[] = hits.map((hit) => {
+			if (hit.kind === "symbol") {
+				return buildSymbolContext({
+					fsPath: hit.fsPath,
+					cwd: this.cwd,
+					name: hit.name,
+					symbolKind: hit.symbolKind,
+					line: hit.line,
+				});
+			}
+			return buildFileContext({ fsPath: hit.fsPath, cwd: this.cwd, isDirectory: hit.kind === "folder" });
+		});
+		return rankMentionResults(results, query, MENTION_RESULT_CAP);
 	}
 
 	// ── Change review ──────────────────────────────────────────────────────

--- a/packages/vscode/src/host/session-controller.ts
+++ b/packages/vscode/src/host/session-controller.ts
@@ -13,6 +13,7 @@
  */
 
 import { formatSessionStats } from "../shared/format.js";
+import { MENTION_RESULT_CAP, rankFileResults } from "../shared/mention.js";
 import {
 	alignCheckpoints,
 	applyEvent,
@@ -23,6 +24,7 @@ import {
 	type TranscriptState,
 } from "../shared/projection.js";
 import type {
+	FileContextDto,
 	HostStatus,
 	OpenSourceRef,
 	ReviewFileDto,
@@ -761,6 +763,17 @@ export class SessionController {
 		for (const pick of picks) {
 			this.tagContext(buildFileContext({ fsPath: pick.fsPath, cwd: this.cwd, isDirectory: pick.isDirectory }));
 		}
+	}
+
+	/** Search workspace files for the inline `@`-mention typeahead dropdown.
+	 * Returns ready-to-tag `FileContextDto`s (workspace-relative paths built with
+	 * the session `cwd`, so a webview selection needs no further host round-trip),
+	 * ranked by relevance to `query` and capped. Stays vscode-free: the search is
+	 * injected via the `HostUi` port. */
+	async searchWorkspaceFiles(query: string): Promise<FileContextDto[]> {
+		const picks = await this.ui.searchWorkspaceFiles(query);
+		const results = picks.map((pick) => buildFileContext({ fsPath: pick.fsPath, cwd: this.cwd }));
+		return rankFileResults(results, query, MENTION_RESULT_CAP);
 	}
 
 	// ── Change review ──────────────────────────────────────────────────────

--- a/packages/vscode/src/host/vscode-host-ui.ts
+++ b/packages/vscode/src/host/vscode-host-ui.ts
@@ -9,6 +9,7 @@
 import * as vscode from "vscode";
 import { escapeGlob } from "../shared/mention.js";
 import type { HostUi, HostUiPickItem, PickedFile, WorkspaceSearchResult } from "./host-ui.js";
+import { deriveFolderPaths, selectSymbols } from "./workspace-search.js";
 
 /** A quick-pick item carrying our opaque `value` alongside vscode's fields. */
 interface ValuedQuickPickItem extends vscode.QuickPickItem {
@@ -71,13 +72,17 @@ export function createVscodeHostUi(): HostUi {
 		},
 		async searchWorkspace(query: string): Promise<WorkspaceSearchResult[]> {
 			const q = query.trim();
-			// Run the three sources concurrently; the webview ranks + trims. Folders
-			// and symbols need a query (an empty `@` lists a bounded file set only).
-			const [folders, files, symbols] = await Promise.all([
+			// Run the three sources concurrently and keep whatever succeeds: a
+			// failing source (e.g. a misbehaving symbol provider) degrades to "no
+			// results from that source" rather than emptying the whole dropdown, so
+			// files still show even if symbols throw. Folders and symbols need a
+			// query (an empty `@` lists a bounded file set only).
+			const settled = await Promise.allSettled([
 				q.length > 0 ? searchFolders(q) : Promise.resolve<WorkspaceSearchResult[]>([]),
 				searchFiles(q),
 				q.length > 0 ? searchSymbols(q) : Promise.resolve<WorkspaceSearchResult[]>([]),
 			]);
+			const [folders, files, symbols] = settled.map((r) => (r.status === "fulfilled" ? r.value : []));
 			return [...folders, ...files, ...symbols];
 		},
 	};
@@ -101,50 +106,40 @@ async function searchFiles(query: string): Promise<WorkspaceSearchResult[]> {
 
 /** Folders whose name matches the query, derived from the files nested under a
  * matching directory segment (a recursive `**` + `*query*` directory + `**`
- * include). `findFiles` returns files only, so we walk each hit's ancestors and
- * keep the unique directories whose basename matches the query. */
+ * include). `findFiles` returns files only, so `deriveFolderPaths` walks each
+ * hit's ancestors and keeps the unique in-project directories whose basename
+ * matches the query (ancestors above the workspace root are excluded). */
 async function searchFolders(query: string): Promise<WorkspaceSearchResult[]> {
 	const uris = await vscode.workspace.findFiles(`**/*${escapeGlob(query)}*/**`, undefined, SEARCH_FETCH_CAP);
-	const q = query.toLowerCase();
-	const folders = new Map<string, WorkspaceSearchResult>();
-	for (const uri of uris) {
-		const parts = uri.path.split("/");
-		// Skip the final segment (the file itself); test each ancestor directory.
-		for (let i = 1; i < parts.length - 1; i++) {
-			const seg = parts[i];
-			if (!seg || !seg.toLowerCase().includes(q)) continue;
-			const folderUri = uri.with({ path: parts.slice(0, i + 1).join("/") });
-			if (!folders.has(folderUri.fsPath))
-				folders.set(folderUri.fsPath, { kind: "folder", fsPath: folderUri.fsPath });
-			if (folders.size >= FOLDER_RESULT_CAP) return [...folders.values()];
-		}
-	}
-	return [...folders.values()];
+	if (uris.length === 0) return [];
+	const roots = (vscode.workspace.workspaceFolders ?? []).map((f) => f.uri.path);
+	const folderPaths = deriveFolderPaths(
+		uris.map((u) => u.path),
+		query,
+		roots,
+		FOLDER_RESULT_CAP,
+	);
+	// Every derived path is an ancestor of a hit, so any hit is a valid template
+	// for the shared scheme/authority when reconstructing the OS `fsPath`.
+	const template = uris[0];
+	return folderPaths.map((path) => ({ kind: "folder", fsPath: template.with({ path }).fsPath }));
 }
 
 /** Code symbols (classes/functions/methods/…) matching the query, via the
- * workspace symbol provider. Filtered to structural kinds so the dropdown stays
- * classes-and-functions, not every variable. */
+ * workspace symbol provider. `selectSymbols` filters to structural kinds so the
+ * dropdown stays classes-and-functions, not every variable. */
 async function searchSymbols(query: string): Promise<WorkspaceSearchResult[]> {
-	const symbols =
-		(await vscode.commands.executeCommand<vscode.SymbolInformation[]>(
-			"vscode.executeWorkspaceSymbolProvider",
-			query,
-		)) ?? [];
-	const results: WorkspaceSearchResult[] = [];
-	for (const sym of symbols) {
-		const label = SYMBOL_KIND_LABELS.get(sym.kind);
-		if (!label) continue;
-		results.push({
-			kind: "symbol",
-			name: sym.name,
-			symbolKind: label,
-			fsPath: sym.location.uri.fsPath,
-			line: sym.location.range.start.line + 1,
-		});
-		if (results.length >= SYMBOL_RESULT_CAP) break;
-	}
-	return results;
+	const raw = await vscode.commands.executeCommand<vscode.SymbolInformation[]>(
+		"vscode.executeWorkspaceSymbolProvider",
+		query,
+	);
+	const hits = (raw ?? []).map((sym) => ({
+		kind: sym.kind,
+		name: sym.name,
+		fsPath: sym.location.uri.fsPath,
+		line0: sym.location.range.start.line,
+	}));
+	return selectSymbols(hits, SYMBOL_KIND_LABELS, SYMBOL_RESULT_CAP);
 }
 
 /** Structural symbol kinds surfaced in the inline dropdown, mapped to a

--- a/packages/vscode/src/host/vscode-host-ui.ts
+++ b/packages/vscode/src/host/vscode-host-ui.ts
@@ -7,7 +7,8 @@
  */
 
 import * as vscode from "vscode";
-import type { HostUi, HostUiPickItem, PickedFile } from "./host-ui.js";
+import { escapeGlob } from "../shared/mention.js";
+import type { HostUi, HostUiPickItem, PickedFile, WorkspaceSearchResult } from "./host-ui.js";
 
 /** A quick-pick item carrying our opaque `value` alongside vscode's fields. */
 interface ValuedQuickPickItem extends vscode.QuickPickItem {
@@ -68,36 +69,98 @@ export function createVscodeHostUi(): HostUi {
 				})),
 			);
 		},
-		async searchWorkspaceFiles(query: string): Promise<PickedFile[]> {
-			// Match anywhere in the path segment (`**/*query*`) so partial names
-			// filter as the user types; an empty query lists a bounded workspace set.
-			// `findFiles` respects `files.exclude`/`search.exclude` when the exclude
-			// arg is undefined. Fetch a generous cap; the webview ranks + trims.
-			const include = query.trim().length > 0 ? `**/*${escapeGlob(query.trim())}*` : "**/*";
-			const uris = await vscode.workspace.findFiles(include, undefined, SEARCH_FETCH_CAP);
-			// `findFiles` returns files only — never directories — so isDirectory is
-			// always false here (folders are added via the `@@` native picker).
-			return uris.map((uri) => ({ fsPath: uri.fsPath, isDirectory: false }));
+		async searchWorkspace(query: string): Promise<WorkspaceSearchResult[]> {
+			const q = query.trim();
+			// Run the three sources concurrently; the webview ranks + trims. Folders
+			// and symbols need a query (an empty `@` lists a bounded file set only).
+			const [folders, files, symbols] = await Promise.all([
+				q.length > 0 ? searchFolders(q) : Promise.resolve<WorkspaceSearchResult[]>([]),
+				searchFiles(q),
+				q.length > 0 ? searchSymbols(q) : Promise.resolve<WorkspaceSearchResult[]>([]),
+			]);
+			return [...folders, ...files, ...symbols];
 		},
 	};
 }
 
 /** Upper bound on files fetched per inline search before webview-side ranking. */
 const SEARCH_FETCH_CAP = 200;
+/** Upper bound on unique folders derived per inline search. */
+const FOLDER_RESULT_CAP = 50;
+/** Upper bound on workspace symbols fetched per inline search. */
+const SYMBOL_RESULT_CAP = 50;
 
-/** Escape glob metacharacters so a typed query is matched literally within the
- * include pattern (a stray `{`, `[`, `*`, `?` would otherwise corrupt the glob).
- * Path separators in the query are dropped to a single `*` wildcard. */
-function escapeGlob(query: string): string {
-	const special = new Set(["*", "?", "{", "}", "[", "]", "(", ")", "!", "+", "@"]);
-	let out = "";
-	for (const ch of query) {
-		if (ch === "/" || ch === "\\") out += "*";
-		else if (special.has(ch)) out += `\\${ch}`;
-		else out += ch;
-	}
-	return out;
+/** Files whose name matches the query, respecting the workspace's
+ * `files.exclude`/`search.exclude`. An empty query lists a bounded workspace
+ * set. Uses a recursive `**` + `*query*` filename include. */
+async function searchFiles(query: string): Promise<WorkspaceSearchResult[]> {
+	const include = query.length > 0 ? `**/*${escapeGlob(query)}*` : "**/*";
+	const uris = await vscode.workspace.findFiles(include, undefined, SEARCH_FETCH_CAP);
+	return uris.map((uri) => ({ kind: "file", fsPath: uri.fsPath }));
 }
+
+/** Folders whose name matches the query, derived from the files nested under a
+ * matching directory segment (a recursive `**` + `*query*` directory + `**`
+ * include). `findFiles` returns files only, so we walk each hit's ancestors and
+ * keep the unique directories whose basename matches the query. */
+async function searchFolders(query: string): Promise<WorkspaceSearchResult[]> {
+	const uris = await vscode.workspace.findFiles(`**/*${escapeGlob(query)}*/**`, undefined, SEARCH_FETCH_CAP);
+	const q = query.toLowerCase();
+	const folders = new Map<string, WorkspaceSearchResult>();
+	for (const uri of uris) {
+		const parts = uri.path.split("/");
+		// Skip the final segment (the file itself); test each ancestor directory.
+		for (let i = 1; i < parts.length - 1; i++) {
+			const seg = parts[i];
+			if (!seg || !seg.toLowerCase().includes(q)) continue;
+			const folderUri = uri.with({ path: parts.slice(0, i + 1).join("/") });
+			if (!folders.has(folderUri.fsPath))
+				folders.set(folderUri.fsPath, { kind: "folder", fsPath: folderUri.fsPath });
+			if (folders.size >= FOLDER_RESULT_CAP) return [...folders.values()];
+		}
+	}
+	return [...folders.values()];
+}
+
+/** Code symbols (classes/functions/methods/…) matching the query, via the
+ * workspace symbol provider. Filtered to structural kinds so the dropdown stays
+ * classes-and-functions, not every variable. */
+async function searchSymbols(query: string): Promise<WorkspaceSearchResult[]> {
+	const symbols =
+		(await vscode.commands.executeCommand<vscode.SymbolInformation[]>(
+			"vscode.executeWorkspaceSymbolProvider",
+			query,
+		)) ?? [];
+	const results: WorkspaceSearchResult[] = [];
+	for (const sym of symbols) {
+		const label = SYMBOL_KIND_LABELS.get(sym.kind);
+		if (!label) continue;
+		results.push({
+			kind: "symbol",
+			name: sym.name,
+			symbolKind: label,
+			fsPath: sym.location.uri.fsPath,
+			line: sym.location.range.start.line + 1,
+		});
+		if (results.length >= SYMBOL_RESULT_CAP) break;
+	}
+	return results;
+}
+
+/** Structural symbol kinds surfaced in the inline dropdown, mapped to a
+ * human-readable label. Non-structural kinds (variables, fields, constants, …)
+ * are intentionally omitted so the list stays classes/functions-focused. */
+const SYMBOL_KIND_LABELS = new Map<vscode.SymbolKind, string>([
+	[vscode.SymbolKind.Class, "class"],
+	[vscode.SymbolKind.Interface, "interface"],
+	[vscode.SymbolKind.Enum, "enum"],
+	[vscode.SymbolKind.Struct, "struct"],
+	[vscode.SymbolKind.Function, "function"],
+	[vscode.SymbolKind.Method, "method"],
+	[vscode.SymbolKind.Constructor, "constructor"],
+	[vscode.SymbolKind.Namespace, "namespace"],
+	[vscode.SymbolKind.Module, "module"],
+]);
 
 /** Whether `uri` points at a directory (defaults to false when it can't be
  * stat'd, so the tag still folds as a plain file reference). */

--- a/packages/vscode/src/host/vscode-host-ui.ts
+++ b/packages/vscode/src/host/vscode-host-ui.ts
@@ -68,7 +68,35 @@ export function createVscodeHostUi(): HostUi {
 				})),
 			);
 		},
+		async searchWorkspaceFiles(query: string): Promise<PickedFile[]> {
+			// Match anywhere in the path segment (`**/*query*`) so partial names
+			// filter as the user types; an empty query lists a bounded workspace set.
+			// `findFiles` respects `files.exclude`/`search.exclude` when the exclude
+			// arg is undefined. Fetch a generous cap; the webview ranks + trims.
+			const include = query.trim().length > 0 ? `**/*${escapeGlob(query.trim())}*` : "**/*";
+			const uris = await vscode.workspace.findFiles(include, undefined, SEARCH_FETCH_CAP);
+			// `findFiles` returns files only — never directories — so isDirectory is
+			// always false here (folders are added via the `@@` native picker).
+			return uris.map((uri) => ({ fsPath: uri.fsPath, isDirectory: false }));
+		},
 	};
+}
+
+/** Upper bound on files fetched per inline search before webview-side ranking. */
+const SEARCH_FETCH_CAP = 200;
+
+/** Escape glob metacharacters so a typed query is matched literally within the
+ * include pattern (a stray `{`, `[`, `*`, `?` would otherwise corrupt the glob).
+ * Path separators in the query are dropped to a single `*` wildcard. */
+function escapeGlob(query: string): string {
+	const special = new Set(["*", "?", "{", "}", "[", "]", "(", ")", "!", "+", "@"]);
+	let out = "";
+	for (const ch of query) {
+		if (ch === "/" || ch === "\\") out += "*";
+		else if (special.has(ch)) out += `\\${ch}`;
+		else out += ch;
+	}
+	return out;
 }
 
 /** Whether `uri` points at a directory (defaults to false when it can't be

--- a/packages/vscode/src/host/webview-bridge.ts
+++ b/packages/vscode/src/host/webview-bridge.ts
@@ -144,10 +144,14 @@ export function connectWebview(webview: vscode.Webview, controller: SessionContr
 			case "pick-file":
 				void controller.tagFileFromPicker();
 				return;
-			case "search-files":
+			case "search-workspace":
+				// Fire-and-forget: post the results on success, or an empty set on
+				// failure so the dropdown degrades gracefully instead of leaking an
+				// unhandled rejection (findFiles/symbol-provider can reject).
 				void controller
-					.searchWorkspaceFiles(raw.query)
-					.then((results) => post({ type: "file-results", requestId: raw.requestId, results }));
+					.searchWorkspace(raw.query)
+					.then((results) => post({ type: "mention-results", requestId: raw.requestId, results }))
+					.catch(() => post({ type: "mention-results", requestId: raw.requestId, results: [] }));
 				return;
 			case "review-open-diff":
 				void controller.reviewOpenDiff(raw.path);

--- a/packages/vscode/src/host/webview-bridge.ts
+++ b/packages/vscode/src/host/webview-bridge.ts
@@ -144,6 +144,11 @@ export function connectWebview(webview: vscode.Webview, controller: SessionContr
 			case "pick-file":
 				void controller.tagFileFromPicker();
 				return;
+			case "search-files":
+				void controller
+					.searchWorkspaceFiles(raw.query)
+					.then((results) => post({ type: "file-results", requestId: raw.requestId, results }));
+				return;
 			case "review-open-diff":
 				void controller.reviewOpenDiff(raw.path);
 				return;

--- a/packages/vscode/src/host/workspace-search.ts
+++ b/packages/vscode/src/host/workspace-search.ts
@@ -1,0 +1,87 @@
+/**
+ * Pure, vscode-free helpers backing the inline `@`-mention workspace search.
+ *
+ * The `vscode.workspace.findFiles` / `executeWorkspaceSymbolProvider` calls live
+ * in `vscode-host-ui.ts`; the derivation logic (which ancestor directories to
+ * surface, which symbols to keep) lives here so it is unit-testable without the
+ * VSCode module — the same split that `escapeGlob` uses.
+ */
+
+import type { WorkspaceSearchResult } from "./host-ui.js";
+
+/** Strip a single trailing slash so root comparisons are consistent. */
+function stripTrailingSlash(path: string): string {
+	return path.length > 1 && path.endsWith("/") ? path.slice(0, -1) : path;
+}
+
+/** Whether `folderPath` is one of the workspace roots or a descendant of one.
+ * Ancestors above every root (e.g. the user's home directory) are excluded so
+ * the dropdown only ever offers folders inside the open project. */
+function isWithinRoots(folderPath: string, roots: readonly string[]): boolean {
+	return roots.some((root) => folderPath === root || folderPath.startsWith(`${root}/`));
+}
+
+/**
+ * Derive the in-project folders whose name matches `query`, from the POSIX
+ * `uri.path`s of the matching files. `findFiles` returns files only, so each
+ * hit's ancestor directories are walked and the unique ones whose segment
+ * matches the (case-insensitive) query are kept — but only those inside a
+ * workspace root, so ancestors above the project (whose absolute path segments
+ * can also match) are never surfaced. Returns POSIX folder paths, capped.
+ */
+export function deriveFolderPaths(
+	filePaths: readonly string[],
+	query: string,
+	workspaceRoots: readonly string[],
+	cap: number,
+): string[] {
+	const q = query.toLowerCase();
+	const roots = workspaceRoots.map(stripTrailingSlash);
+	const seen = new Set<string>();
+	const out: string[] = [];
+	for (const filePath of filePaths) {
+		const parts = filePath.split("/");
+		// Skip the final segment (the file itself); test each ancestor directory.
+		for (let i = 1; i < parts.length - 1; i++) {
+			const seg = parts[i];
+			if (!seg || !seg.toLowerCase().includes(q)) continue;
+			const folderPath = parts.slice(0, i + 1).join("/");
+			if (!isWithinRoots(folderPath, roots)) continue;
+			if (seen.has(folderPath)) continue;
+			seen.add(folderPath);
+			out.push(folderPath);
+			if (out.length >= cap) return out;
+		}
+	}
+	return out;
+}
+
+/** A raw workspace-symbol hit, already flattened out of `vscode.SymbolInformation`
+ * so this module stays vscode-free. `line0` is the provider's 0-based line. */
+export interface RawSymbolHit {
+	kind: number;
+	name: string;
+	fsPath: string;
+	line0: number;
+}
+
+/**
+ * Filter raw workspace symbols to the structural kinds present in `labels`
+ * (classes/functions/…), mapping each to a `symbol` result with a 1-based line
+ * and capping the list. Kinds absent from `labels` (variables, fields, …) are
+ * dropped so the dropdown stays classes-and-functions.
+ */
+export function selectSymbols(
+	symbols: readonly RawSymbolHit[],
+	labels: ReadonlyMap<number, string>,
+	cap: number,
+): WorkspaceSearchResult[] {
+	const out: WorkspaceSearchResult[] = [];
+	for (const sym of symbols) {
+		const label = labels.get(sym.kind);
+		if (!label) continue;
+		out.push({ kind: "symbol", name: sym.name, symbolKind: label, fsPath: sym.fsPath, line: sym.line0 + 1 });
+		if (out.length >= cap) break;
+	}
+	return out;
+}

--- a/packages/vscode/src/shared/mention.ts
+++ b/packages/vscode/src/shared/mention.ts
@@ -1,15 +1,16 @@
 /**
  * Pure helpers for the composer's inline `@`-mention file picker (Phase 4c).
  *
- * Typing `@` opens a small typeahead dropdown that filters workspace files as
- * the user keeps typing; typing `@@` escalates to the full native file picker.
- * These functions parse the "active mention" out of the composer text at the
- * caret and rank host-supplied file results — kept free of `vscode` and any
- * `node:` builtins so the same code runs in the webview bundle and unit tests
- * (mirroring `shared/format.ts` and `shared/tagged-context.ts`).
+ * Typing `@` opens a small typeahead dropdown that filters the workspace as the
+ * user keeps typing (folders, files, then code symbols); typing `@@` escalates
+ * to the full native file picker. These functions parse the "active mention" out
+ * of the composer text at the caret, rank host-supplied results, and escape a
+ * query into a glob — kept free of `vscode` and any `node:` builtins so the same
+ * code runs in the webview bundle, the host search, and unit tests (mirroring
+ * `shared/format.ts` and `shared/tagged-context.ts`).
  */
 
-import type { FileContextDto } from "./protocol.js";
+import type { TaggedContextDto } from "./protocol.js";
 
 /** The active `@`-mention token immediately before the caret. */
 export interface MentionToken {
@@ -70,36 +71,87 @@ function filename(path: string): string {
 	return (parts.at(-1) ?? path).toLowerCase();
 }
 
+/** Ordering tier by result kind: folders first, then files, then symbols —
+ * so the dropdown reads folders → files → classes/functions top to bottom. */
+function kindRank(dto: TaggedContextDto): number {
+	if (dto.kind === "file") return dto.isDirectory ? 0 : 1;
+	if (dto.kind === "symbol") return 2;
+	return 1; // selections never appear in mention results; treat as a file tier.
+}
+
+/** The lowercased (name, path) a query is matched against for one result. For a
+ * symbol the "name" is the symbol identifier; for a file/folder it is the last
+ * path segment. */
+function matchText(dto: TaggedContextDto): { name: string; path: string } {
+	if (dto.kind === "symbol") return { name: dto.name.toLowerCase(), path: dto.path.toLowerCase() };
+	if (dto.kind === "file") return { name: filename(dto.path), path: dto.path.toLowerCase() };
+	return { name: "", path: "" };
+}
+
+/** The path used for tiebreaking (shorter/alpha) — the file/folder path or the
+ * symbol's defining file path. */
+function pathOf(dto: TaggedContextDto): string {
+	return dto.kind === "selection" ? "" : dto.path;
+}
+
 /**
- * Rank file results for an inline `@`-mention query and cap the list.
- *
- * Ordering (best first): filename prefix match, then filename substring, then
- * path substring, then non-matches; ties break by shorter path, then alpha. An
- * empty query keeps input order (already host-ordered) and just applies `cap`.
+ * Rank inline `@`-mention results and cap the list. Results are grouped by kind
+ * (folders, then files, then symbols) and, within each group, ordered by
+ * relevance to `query`: name prefix, then name substring, then path substring;
+ * non-matches are dropped. Ties break by shorter path, then alphabetically. An
+ * empty query keeps the host's per-kind order and just applies the kind grouping
+ * and `cap`.
  */
-export function rankFileResults(results: readonly FileContextDto[], query: string, cap: number): FileContextDto[] {
+export function rankMentionResults(
+	results: readonly TaggedContextDto[],
+	query: string,
+	cap: number,
+): TaggedContextDto[] {
 	const q = query.trim().toLowerCase();
-	if (q.length === 0) return results.slice(0, cap);
-	const score = (dto: FileContextDto): number => {
-		const name = filename(dto.path);
-		const path = dto.path.toLowerCase();
-		if (name.startsWith(q)) return 0;
-		if (name.includes(q)) return 1;
-		if (path.includes(q)) return 2;
-		return 3;
-	};
-	return results
-		.map((dto, index) => ({ dto, index, rank: score(dto) }))
-		.filter((entry) => entry.rank < 3)
+	const scored = results.map((dto, index) => {
+		const { name, path } = matchText(dto);
+		let match: number;
+		if (q.length === 0) match = 0;
+		else if (name.startsWith(q)) match = 0;
+		else if (name.includes(q)) match = 1;
+		else if (path.includes(q)) match = 2;
+		else match = 3;
+		return { dto, index, kind: kindRank(dto), match };
+	});
+	return scored
+		.filter((entry) => entry.match < 3)
 		.sort((a, b) => {
-			if (a.rank !== b.rank) return a.rank - b.rank;
-			if (a.dto.path.length !== b.dto.path.length) return a.dto.path.length - b.dto.path.length;
-			if (a.dto.path !== b.dto.path) return a.dto.path < b.dto.path ? -1 : 1;
+			if (a.kind !== b.kind) return a.kind - b.kind;
+			// Empty query: preserve the host's order within each kind group.
+			if (q.length === 0) return a.index - b.index;
+			if (a.match !== b.match) return a.match - b.match;
+			const ap = pathOf(a.dto);
+			const bp = pathOf(b.dto);
+			if (ap.length !== bp.length) return ap.length - bp.length;
+			if (ap !== bp) return ap < bp ? -1 : 1;
 			return a.index - b.index;
 		})
 		.slice(0, cap)
 		.map((entry) => entry.dto);
 }
 
-/** Maximum number of inline file suggestions shown in the dropdown. */
+/**
+ * Escape glob metacharacters so a typed query is matched literally within a
+ * `findFiles` include pattern (a stray `{`, `[`, `*`, `?`, `@` would otherwise
+ * corrupt the glob). Path separators in the query collapse to a single `*`
+ * wildcard so `src/app` still filters. Pure (no `vscode`), so the host search
+ * and its unit tests share one implementation.
+ */
+export function escapeGlob(query: string): string {
+	const special = new Set(["*", "?", "{", "}", "[", "]", "(", ")", "!", "+", "@"]);
+	let out = "";
+	for (const ch of query) {
+		if (ch === "/" || ch === "\\") out += "*";
+		else if (special.has(ch)) out += `\\${ch}`;
+		else out += ch;
+	}
+	return out;
+}
+
+/** Maximum number of inline mention suggestions shown in the dropdown. */
 export const MENTION_RESULT_CAP = 10;

--- a/packages/vscode/src/shared/mention.ts
+++ b/packages/vscode/src/shared/mention.ts
@@ -1,0 +1,105 @@
+/**
+ * Pure helpers for the composer's inline `@`-mention file picker (Phase 4c).
+ *
+ * Typing `@` opens a small typeahead dropdown that filters workspace files as
+ * the user keeps typing; typing `@@` escalates to the full native file picker.
+ * These functions parse the "active mention" out of the composer text at the
+ * caret and rank host-supplied file results — kept free of `vscode` and any
+ * `node:` builtins so the same code runs in the webview bundle and unit tests
+ * (mirroring `shared/format.ts` and `shared/tagged-context.ts`).
+ */
+
+import type { FileContextDto } from "./protocol.js";
+
+/** The active `@`-mention token immediately before the caret. */
+export interface MentionToken {
+	/** Index of the leading `@` in the text. */
+	start: number;
+	/** Caret index (exclusive end of the token). */
+	end: number;
+	/** The query typed after the `@` (may be empty). */
+	query: string;
+}
+
+/**
+ * Find the `@`-mention token the caret is currently editing, or `null`.
+ *
+ * A token is active when, scanning back from the caret, an `@` is found that is
+ * at the start of the text or preceded by whitespace, with no whitespace (or a
+ * second `@`) between it and the caret. This deliberately does NOT fire for `@`
+ * embedded mid-word (e.g. an email address) or once the query contains a space.
+ *
+ * `@@` is handled by {@link isFullPickerTrigger}, not here — a query starting
+ * with `@` is rejected so the two triggers never both fire.
+ */
+export function activeMention(text: string, caret: number): MentionToken | null {
+	const before = text.slice(0, caret);
+	// (^|whitespace) @ (no-whitespace, no-@ run) — anchored at the caret.
+	const match = /(?:^|\s)@([^\s@]*)$/.exec(before);
+	if (!match) return null;
+	const query = match[1] ?? "";
+	const start = caret - query.length - 1; // position of the `@`
+	return { start, end: caret, query };
+}
+
+/**
+ * Whether the text just before the caret is a `@@` full-picker trigger — two
+ * consecutive `@` at the start of a token (start of text or after whitespace).
+ */
+export function isFullPickerTrigger(text: string, caret: number): boolean {
+	return /(?:^|\s)@@$/.test(text.slice(0, caret));
+}
+
+/**
+ * Replace the active mention token's `@query` span with `replacement`, returning
+ * the new text and the caret position after the replacement. Used to strip the
+ * `@` token when a file is selected (replacement `""`) or when `@@` escalates.
+ */
+export function replaceMention(
+	text: string,
+	token: { start: number; end: number },
+	replacement: string,
+): { text: string; caret: number } {
+	const next = text.slice(0, token.start) + replacement + text.slice(token.end);
+	return { text: next, caret: token.start + replacement.length };
+}
+
+/** Lowercase last path segment of a forward-slashed path. */
+function filename(path: string): string {
+	const parts = path.split("/").filter(Boolean);
+	return (parts.at(-1) ?? path).toLowerCase();
+}
+
+/**
+ * Rank file results for an inline `@`-mention query and cap the list.
+ *
+ * Ordering (best first): filename prefix match, then filename substring, then
+ * path substring, then non-matches; ties break by shorter path, then alpha. An
+ * empty query keeps input order (already host-ordered) and just applies `cap`.
+ */
+export function rankFileResults(results: readonly FileContextDto[], query: string, cap: number): FileContextDto[] {
+	const q = query.trim().toLowerCase();
+	if (q.length === 0) return results.slice(0, cap);
+	const score = (dto: FileContextDto): number => {
+		const name = filename(dto.path);
+		const path = dto.path.toLowerCase();
+		if (name.startsWith(q)) return 0;
+		if (name.includes(q)) return 1;
+		if (path.includes(q)) return 2;
+		return 3;
+	};
+	return results
+		.map((dto, index) => ({ dto, index, rank: score(dto) }))
+		.filter((entry) => entry.rank < 3)
+		.sort((a, b) => {
+			if (a.rank !== b.rank) return a.rank - b.rank;
+			if (a.dto.path.length !== b.dto.path.length) return a.dto.path.length - b.dto.path.length;
+			if (a.dto.path !== b.dto.path) return a.dto.path < b.dto.path ? -1 : 1;
+			return a.index - b.index;
+		})
+		.slice(0, cap)
+		.map((entry) => entry.dto);
+}
+
+/** Maximum number of inline file suggestions shown in the dropdown. */
+export const MENTION_RESULT_CAP = 10;

--- a/packages/vscode/src/shared/mention.ts
+++ b/packages/vscode/src/shared/mention.ts
@@ -81,17 +81,17 @@ function kindRank(dto: TaggedContextDto): number {
 
 /** The lowercased (name, path) a query is matched against for one result. For a
  * symbol the "name" is the symbol identifier; for a file/folder it is the last
- * path segment. */
+ * path segment. (Selections never reach the mention dropdown; they fold through
+ * the file/path arm harmlessly.) */
 function matchText(dto: TaggedContextDto): { name: string; path: string } {
 	if (dto.kind === "symbol") return { name: dto.name.toLowerCase(), path: dto.path.toLowerCase() };
-	if (dto.kind === "file") return { name: filename(dto.path), path: dto.path.toLowerCase() };
-	return { name: "", path: "" };
+	return { name: filename(dto.path), path: dto.path.toLowerCase() };
 }
 
 /** The path used for tiebreaking (shorter/alpha) — the file/folder path or the
  * symbol's defining file path. */
 function pathOf(dto: TaggedContextDto): string {
-	return dto.kind === "selection" ? "" : dto.path;
+	return dto.path;
 }
 
 /**

--- a/packages/vscode/src/shared/protocol.ts
+++ b/packages/vscode/src/shared/protocol.ts
@@ -112,10 +112,27 @@ export interface FileContextDto {
 	isDirectory?: boolean;
 }
 
-/** A context attachment tagged into the chat: an editor selection or a
- * file/folder reference. Carried across the host↔webview boundary and folded
- * into the next prompt. */
-export type TaggedContextDto = SelectionContextDto | FileContextDto;
+/** A code symbol (class / function / method / …) tagged into the chat via the
+ * inline `@` picker (Phase 4c). Shown as a removable composer chip and folded
+ * into the next prompt as a **located reference** (path + line + symbol name)
+ * so the agent can jump straight to the definition — never the body text. */
+export interface SymbolContextDto {
+	kind: "symbol";
+	/** Symbol name, e.g. "SessionController" or "handleClick". */
+	name: string;
+	/** Human-readable kind label, e.g. "class", "function", "method". */
+	symbolKind: string;
+	/** Workspace-relative path (forward slashes) of the file that defines the
+	 * symbol, or the absolute path when it lives outside the workspace. */
+	path: string;
+	/** 1-based line of the symbol's definition. */
+	line: number;
+}
+
+/** A context attachment tagged into the chat: an editor selection, a file/folder
+ * reference, or a code symbol. Carried across the host↔webview boundary and
+ * folded into the next prompt. */
+export type TaggedContextDto = SelectionContextDto | FileContextDto | SymbolContextDto;
 
 /** A clickable code reference the user activated in an answer (Phase 5b). Either
  * a concrete file `path` (optionally with a 1-based `line`/`column`), a `symbol`
@@ -173,9 +190,10 @@ export type HostToWebview =
 	| { type: "checkpoints"; checkpoints: Checkpoint[] }
 	/** The session branch tree, in response to a `show-tree` request (Phase 6). */
 	| { type: "tree"; tree: SessionTreeDto }
-	/** Results for an inline `@`-mention file search, matched to the request's
-	 * `requestId` so the webview can drop stale (out-of-order) responses. */
-	| { type: "file-results"; requestId: number; results: FileContextDto[] }
+	/** Results for an inline `@`-mention workspace search, matched to the
+	 * request's `requestId` so the webview can drop stale (out-of-order)
+	 * responses. Mixes folders, files, and code symbols (in that order). */
+	| { type: "mention-results"; requestId: number; results: TaggedContextDto[] }
 	/** Pre-fill the composer (e.g. a user-message fork's re-ask text) (Phase 6). */
 	| { type: "composer-prefill"; text: string };
 
@@ -192,9 +210,10 @@ export type WebviewToHost =
 	| { type: "pick-thinking" }
 	/** Open the native file/folder picker to tag context (composer `@@`). */
 	| { type: "pick-file" }
-	/** Inline `@`-mention file search: the host replies with a `file-results`
-	 * message carrying the same `requestId` (composer typeahead dropdown). */
-	| { type: "search-files"; query: string; requestId: number }
+	/** Inline `@`-mention workspace search: the host replies with a
+	 * `mention-results` message carrying the same `requestId` (composer typeahead
+	 * dropdown of folders, files, and code symbols). */
+	| { type: "search-workspace"; query: string; requestId: number }
 	/** Open the baseline→current diff for a reviewed file (indicator click). */
 	| { type: "review-open-diff"; path: string }
 	/** Accept all pending edits, clearing them from the change-review

--- a/packages/vscode/src/shared/protocol.ts
+++ b/packages/vscode/src/shared/protocol.ts
@@ -173,6 +173,9 @@ export type HostToWebview =
 	| { type: "checkpoints"; checkpoints: Checkpoint[] }
 	/** The session branch tree, in response to a `show-tree` request (Phase 6). */
 	| { type: "tree"; tree: SessionTreeDto }
+	/** Results for an inline `@`-mention file search, matched to the request's
+	 * `requestId` so the webview can drop stale (out-of-order) responses. */
+	| { type: "file-results"; requestId: number; results: FileContextDto[] }
 	/** Pre-fill the composer (e.g. a user-message fork's re-ask text) (Phase 6). */
 	| { type: "composer-prefill"; text: string };
 
@@ -187,8 +190,11 @@ export type WebviewToHost =
 	| { type: "pick-model" }
 	/** Open the native thinking-level picker (header click). */
 	| { type: "pick-thinking" }
-	/** Open the native file/folder picker to tag context (composer `@`). */
+	/** Open the native file/folder picker to tag context (composer `@@`). */
 	| { type: "pick-file" }
+	/** Inline `@`-mention file search: the host replies with a `file-results`
+	 * message carrying the same `requestId` (composer typeahead dropdown). */
+	| { type: "search-files"; query: string; requestId: number }
 	/** Open the baseline→current diff for a reviewed file (indicator click). */
 	| { type: "review-open-diff"; path: string }
 	/** Accept all pending edits, clearing them from the change-review

--- a/packages/vscode/src/shared/tagged-context.ts
+++ b/packages/vscode/src/shared/tagged-context.ts
@@ -2,15 +2,16 @@
  * Pure helpers for chat context tags.
  *
  * A "tagged context" is something the user pulled into the chat as context:
- * either an editor **selection** (Phase 4) or a **file/folder** reference
- * (Phase 4b, via the `@` picker). This module builds the {@link TaggedContextDto}
- * variants, formats the chip label/title the composer shows, and folds
- * attachments into the prompt text the host sends to the agent.
+ * an editor **selection** (Phase 4), a **file/folder** reference, or a code
+ * **symbol** (Phase 4c, via the `@` picker). This module builds the
+ * {@link TaggedContextDto} variants, formats the chip label/title the composer
+ * shows, and folds attachments into the prompt text the host sends to the agent.
  *
  * Selections are inlined as a located fenced code block when small, but degrade
  * to a path + line-span reference once they exceed {@link MAX_INLINE_SELECTION_LINES}
  * or {@link MAX_INLINE_SELECTION_CHARS} (keeping the prompt short). File/folder
- * tags are **always** a path reference only — never the contents.
+ * tags are **always** a path reference only — never the contents. Symbol tags
+ * fold to a located reference (path + line + symbol name).
  *
  * It is intentionally free of `vscode` AND of any `node:` builtins so the same
  * code can be bundled into the webview (for the chip label/title) and imported
@@ -18,7 +19,7 @@
  * plain node — mirroring `shared/format.ts`.
  */
 
-import type { FileContextDto, SelectionContextDto, TaggedContextDto } from "./protocol.js";
+import type { FileContextDto, SelectionContextDto, SymbolContextDto, TaggedContextDto } from "./protocol.js";
 
 /** A selection larger than this many lines folds as a reference, not a block. */
 export const MAX_INLINE_SELECTION_LINES = 40;
@@ -50,6 +51,21 @@ export interface FileContextInput {
 	cwd: string;
 	/** True when the picked path is a directory. */
 	isDirectory?: boolean;
+}
+
+/** Inputs the host captures from the inline `@` symbol search to build a symbol
+ * tag (workspace symbol provider hit). */
+export interface SymbolContextInput {
+	/** Absolute filesystem path of the file that defines the symbol. */
+	fsPath: string;
+	/** The session's working directory, used to relativize `fsPath`. */
+	cwd: string;
+	/** Symbol name (e.g. "SessionController"). */
+	name: string;
+	/** Human-readable kind label (e.g. "class", "function", "method"). */
+	symbolKind: string;
+	/** 1-based line of the symbol's definition. */
+	line: number;
 }
 
 /** Last path segment of a slash/back-slash separated path. */
@@ -96,6 +112,18 @@ export function buildFileContext(input: FileContextInput): FileContextDto {
 	return dto;
 }
 
+/** Build a code-symbol context DTO. Folded into the prompt as a located
+ * reference (path + line + symbol name) only — never the symbol's body. */
+export function buildSymbolContext(input: SymbolContextInput): SymbolContextDto {
+	return {
+		kind: "symbol",
+		name: input.name,
+		symbolKind: input.symbolKind,
+		path: toWorkspaceRelative(input.fsPath, input.cwd),
+		line: input.line,
+	};
+}
+
 /** 1-based inclusive line span of a selection (`line N` or `lines A-B`). */
 function selectionSpan(context: SelectionContextDto): string {
 	return context.endLine > context.startLine
@@ -110,10 +138,15 @@ function fitsInline(context: SelectionContextDto): boolean {
 }
 
 /** Short chip label shown in the composer. Selection: `basename:line` or
- * `basename:start-end` (Copilot-style). File: `basename`. Folder: `basename/`. */
+ * `basename:start-end` (Copilot-style). File: `basename`. Folder: `basename/`.
+ * Symbol: the symbol name. */
 export function taggedContextLabel(context: TaggedContextDto): string {
+	if (context.kind === "symbol") return context.name;
+	if (context.kind === "file") {
+		const name = basename(context.path);
+		return context.isDirectory ? `${name}/` : name;
+	}
 	const name = basename(context.path);
-	if (context.kind === "file") return context.isDirectory ? `${name}/` : name;
 	return context.endLine > context.startLine
 		? `${name}:${context.startLine}-${context.endLine}`
 		: `${name}:${context.startLine}`;
@@ -121,14 +154,18 @@ export function taggedContextLabel(context: TaggedContextDto): string {
 
 /** Hover title for the composer chip: the full path + a kind-specific note. */
 export function taggedContextTitle(context: TaggedContextDto): string {
+	if (context.kind === "symbol") return `${context.name} — ${context.symbolKind} in ${context.path}:${context.line}`;
 	if (context.kind === "file") return context.isDirectory ? `${context.path}/ (directory)` : context.path;
 	return `${context.path} (${selectionSpan(context)})`;
 }
 
 /** One attachment folded into the prompt. Small selections inline a located
  * fenced code block; large selections and all file/folder tags fold to a path
- * reference only. */
+ * reference only; symbols fold to a located reference (path + line + name). */
 export function formatTaggedContext(context: TaggedContextDto): string {
+	if (context.kind === "symbol") {
+		return `\`${context.path}:${context.line}\` (${context.symbolKind} \`${context.name}\`)`;
+	}
 	if (context.kind === "file") {
 		return context.isDirectory ? `\`${context.path}/\` (directory)` : `\`${context.path}\``;
 	}

--- a/packages/vscode/src/webview/app.tsx
+++ b/packages/vscode/src/webview/app.tsx
@@ -1,6 +1,7 @@
 import { createEffect, createMemo, createSignal, For, onCleanup, onMount, Show } from "solid-js";
 import { createStore, produce, reconcile } from "solid-js/store";
 import { formatContextUsage, formatCost, formatModel, formatThinking } from "../shared/format.js";
+import { activeMention, isFullPickerTrigger, replaceMention } from "../shared/mention.js";
 import {
 	activitySummary,
 	applyEvent,
@@ -12,6 +13,7 @@ import {
 	type UiRequest,
 } from "../shared/projection.js";
 import type {
+	FileContextDto,
 	HostStatus,
 	OpenSourceRef,
 	ReviewStateDto,
@@ -45,6 +47,15 @@ export function App() {
 	// A composer pre-fill request (a user-message fork's re-ask text). Bumped
 	// `nonce` retriggers the effect even when the text repeats.
 	const [prefill, setPrefill] = createSignal<{ text: string; nonce: number }>();
+	// Inline `@`-mention file search (Phase 4c): results for the composer's
+	// typeahead dropdown, plus a monotonic request id so out-of-order host
+	// responses are dropped (only the latest query's results are shown).
+	const [fileResults, setFileResults] = createSignal<FileContextDto[]>([]);
+	let fileSearchId = 0;
+	const searchFiles = (query: string) => {
+		fileSearchId += 1;
+		postToHost({ type: "search-files", query, requestId: fileSearchId });
+	};
 	const [tick, setTick] = createSignal(0);
 
 	let scrollEl: HTMLDivElement | undefined;
@@ -83,6 +94,11 @@ export function App() {
 					break;
 				case "composer-prefill":
 					setPrefill((prev) => ({ text: msg.text, nonce: (prev?.nonce ?? 0) + 1 }));
+					break;
+				case "file-results":
+					// Drop stale (out-of-order) responses: only the latest query's
+					// results are shown in the typeahead dropdown.
+					if (msg.requestId === fileSearchId) setFileResults(msg.results);
 					break;
 			}
 			setTick((t) => t + 1);
@@ -237,6 +253,7 @@ export function App() {
 				commands={commands()}
 				attachments={attachments()}
 				prefill={prefill()}
+				fileResults={fileResults()}
 				onRemoveAttachment={(index) => setAttachments((current) => current.filter((_, i) => i !== index))}
 				onSubmit={(text) => {
 					postToHost({ type: "submit", text, attachments: attachments() });
@@ -244,6 +261,8 @@ export function App() {
 				}}
 				onAbort={() => postToHost({ type: "abort" })}
 				onPickFile={() => postToHost({ type: "pick-file" })}
+				onSearchFiles={searchFiles}
+				onTagFile={(context) => setAttachments((current) => [...current, context])}
 			/>
 		</div>
 	);
@@ -598,12 +617,23 @@ function Composer(props: {
 	commands: SlashCommandDto[];
 	attachments: TaggedContextDto[];
 	prefill?: { text: string; nonce: number };
+	fileResults: FileContextDto[];
 	onRemoveAttachment: (index: number) => void;
 	onSubmit: (text: string) => void;
 	onAbort: () => void;
 	onPickFile: () => void;
+	onSearchFiles: (query: string) => void;
+	onTagFile: (context: FileContextDto) => void;
 }) {
 	const [text, setText] = createSignal("");
+	// Caret position, tracked so the `@`-mention parser knows which token the user
+	// is editing (updated on input and on caret moves via keyboard/mouse).
+	const [caret, setCaret] = createSignal(0);
+	// Set true when the user dismisses the file dropdown (Escape); reset whenever
+	// the mention token changes so a fresh `@` re-opens it.
+	const [mentionClosed, setMentionClosed] = createSignal(false);
+	let inputEl: HTMLTextAreaElement | undefined;
+	let searchTimer: ReturnType<typeof setTimeout> | undefined;
 
 	// Apply a host-driven pre-fill (a user-message fork's re-ask text). The
 	// `nonce` makes the effect retrigger even when the same text is sent twice.
@@ -619,15 +649,65 @@ function Composer(props: {
 		return props.commands.filter((c) => c.name.toLowerCase().startsWith(query)).slice(0, 8);
 	});
 
-	// Typing a lone `@` opens the native file/folder picker (Phase 4b) rather than
-	// entering the character — mirroring the `/` command affordance.
-	const onInput = (value: string) => {
-		if (value === "@") {
-			setText("");
+	// The `@`-mention token the caret is editing, if any (drives the file
+	// typeahead dropdown). Host results are already ranked + capped.
+	const mention = createMemo(() => activeMention(text(), caret()));
+	const fileMenuOpen = createMemo(() => mention() !== null && !mentionClosed() && props.fileResults.length > 0);
+
+	const scheduleSearch = (query: string) => {
+		if (searchTimer) clearTimeout(searchTimer);
+		searchTimer = setTimeout(() => props.onSearchFiles(query), 120);
+	};
+	onCleanup(() => {
+		if (searchTimer) clearTimeout(searchTimer);
+	});
+
+	// Composer input: handle `@@` escalation to the native picker, drive the
+	// inline `@` typeahead, and otherwise just track the text + caret.
+	const onInput = (el: HTMLTextAreaElement) => {
+		const value = el.value;
+		const pos = el.selectionStart ?? value.length;
+		// `@@` (at the start of a token) opens the full native file/folder picker,
+		// stripping the two `@` first (Phase 4b behavior, now the explicit trigger).
+		if (isFullPickerTrigger(value, pos)) {
+			const stripped = replaceMention(value, { start: pos - 2, end: pos }, "");
+			setText(stripped.text);
+			setCaret(stripped.caret);
+			restoreCaret(stripped.caret);
 			props.onPickFile();
 			return;
 		}
 		setText(value);
+		setCaret(pos);
+		const token = activeMention(value, pos);
+		if (token) {
+			setMentionClosed(false);
+			scheduleSearch(token.query);
+		}
+	};
+
+	// Keep the caret signal in sync when the user moves the caret without typing
+	// (arrow keys, clicking) so the mention parser stays accurate.
+	const syncCaret = (el: HTMLTextAreaElement) => setCaret(el.selectionStart ?? el.value.length);
+
+	const restoreCaret = (pos: number) => {
+		queueMicrotask(() => {
+			if (!inputEl) return;
+			inputEl.focus();
+			inputEl.setSelectionRange(pos, pos);
+		});
+	};
+
+	// Select a file from the inline dropdown: strip the `@query` token and tag the
+	// file as a composer chip (the host already built the workspace-relative DTO).
+	const selectFile = (context: FileContextDto) => {
+		const token = mention();
+		if (!token) return;
+		const stripped = replaceMention(text(), token, "");
+		setText(stripped.text);
+		setCaret(stripped.caret);
+		props.onTagFile(context);
+		restoreCaret(stripped.caret);
 	};
 
 	const submit = () => {
@@ -637,11 +717,18 @@ function Composer(props: {
 		if (value.trim().length === 0 && props.attachments.length === 0) return;
 		props.onSubmit(value);
 		setText("");
+		setCaret(0);
 	};
 
 	const pick = (name: string) => setText(`/${name} `);
 
 	const onKeyDown = (event: KeyboardEvent) => {
+		// Escape closes the file typeahead without submitting or losing text.
+		if (event.key === "Escape" && fileMenuOpen()) {
+			event.preventDefault();
+			setMentionClosed(true);
+			return;
+		}
 		if (event.key === "Enter" && !event.shiftKey) {
 			event.preventDefault();
 			submit();
@@ -659,6 +746,23 @@ function Composer(props: {
 								<Show when={command.description}>
 									<span class="dreb-menu-desc">{command.description}</span>
 								</Show>
+							</button>
+						)}
+					</For>
+				</div>
+			</Show>
+			<Show when={fileMenuOpen()}>
+				<div class="dreb-menu">
+					<For each={props.fileResults}>
+						{(file) => (
+							<button
+								type="button"
+								class="dreb-menu-item"
+								title={taggedContextTitle(file)}
+								onClick={() => selectFile(file)}
+							>
+								<span class="dreb-menu-name">@{taggedContextLabel(file)}</span>
+								<span class="dreb-menu-desc">{file.path}</span>
 							</button>
 						)}
 					</For>
@@ -687,12 +791,15 @@ function Composer(props: {
 			</Show>
 			<div class="dreb-composer-row">
 				<textarea
+					ref={inputEl}
 					class="dreb-input"
 					rows={2}
-					placeholder="Message dreb…  (/ for commands, @ for files)"
+					placeholder="Message dreb…  (/ for commands, @ for files, @@ for picker)"
 					value={text()}
-					onInput={(e) => onInput(e.currentTarget.value)}
+					onInput={(e) => onInput(e.currentTarget)}
 					onKeyDown={onKeyDown}
+					onKeyUp={(e) => syncCaret(e.currentTarget)}
+					onClick={(e) => syncCaret(e.currentTarget)}
 				/>
 				<Show
 					when={props.streaming}

--- a/packages/vscode/src/webview/app.tsx
+++ b/packages/vscode/src/webview/app.tsx
@@ -13,7 +13,6 @@ import {
 	type UiRequest,
 } from "../shared/projection.js";
 import type {
-	FileContextDto,
 	HostStatus,
 	OpenSourceRef,
 	ReviewStateDto,
@@ -47,14 +46,15 @@ export function App() {
 	// A composer pre-fill request (a user-message fork's re-ask text). Bumped
 	// `nonce` retriggers the effect even when the text repeats.
 	const [prefill, setPrefill] = createSignal<{ text: string; nonce: number }>();
-	// Inline `@`-mention file search (Phase 4c): results for the composer's
-	// typeahead dropdown, plus a monotonic request id so out-of-order host
-	// responses are dropped (only the latest query's results are shown).
-	const [fileResults, setFileResults] = createSignal<FileContextDto[]>([]);
-	let fileSearchId = 0;
-	const searchFiles = (query: string) => {
-		fileSearchId += 1;
-		postToHost({ type: "search-files", query, requestId: fileSearchId });
+	// Inline `@`-mention workspace search (Phase 4c): results for the composer's
+	// typeahead dropdown (folders, files, then code symbols), plus a monotonic
+	// request id so out-of-order host responses are dropped (only the latest
+	// query's results are shown).
+	const [mentionResults, setMentionResults] = createSignal<TaggedContextDto[]>([]);
+	let mentionSearchId = 0;
+	const searchWorkspace = (query: string) => {
+		mentionSearchId += 1;
+		postToHost({ type: "search-workspace", query, requestId: mentionSearchId });
 	};
 	const [tick, setTick] = createSignal(0);
 
@@ -95,10 +95,10 @@ export function App() {
 				case "composer-prefill":
 					setPrefill((prev) => ({ text: msg.text, nonce: (prev?.nonce ?? 0) + 1 }));
 					break;
-				case "file-results":
+				case "mention-results":
 					// Drop stale (out-of-order) responses: only the latest query's
 					// results are shown in the typeahead dropdown.
-					if (msg.requestId === fileSearchId) setFileResults(msg.results);
+					if (msg.requestId === mentionSearchId) setMentionResults(msg.results);
 					break;
 			}
 			setTick((t) => t + 1);
@@ -253,7 +253,7 @@ export function App() {
 				commands={commands()}
 				attachments={attachments()}
 				prefill={prefill()}
-				fileResults={fileResults()}
+				mentionResults={mentionResults()}
 				onRemoveAttachment={(index) => setAttachments((current) => current.filter((_, i) => i !== index))}
 				onSubmit={(text) => {
 					postToHost({ type: "submit", text, attachments: attachments() });
@@ -261,8 +261,8 @@ export function App() {
 				}}
 				onAbort={() => postToHost({ type: "abort" })}
 				onPickFile={() => postToHost({ type: "pick-file" })}
-				onSearchFiles={searchFiles}
-				onTagFile={(context) => setAttachments((current) => [...current, context])}
+				onSearchWorkspace={searchWorkspace}
+				onTagContext={(context) => setAttachments((current) => [...current, context])}
 			/>
 		</div>
 	);
@@ -612,18 +612,21 @@ function AskResponse(props: { request: UiRequest; onRespond: (response: UiRespon
 	);
 }
 
-function Composer(props: {
+/** The message composer: text input plus the `/`-command and inline `@`-mention
+ * dropdowns. Exported for component tests (`composer.test.tsx`) that drive the
+ * `@`/`@@` typeahead orchestration directly. */
+export function Composer(props: {
 	streaming: boolean;
 	commands: SlashCommandDto[];
 	attachments: TaggedContextDto[];
 	prefill?: { text: string; nonce: number };
-	fileResults: FileContextDto[];
+	mentionResults: TaggedContextDto[];
 	onRemoveAttachment: (index: number) => void;
 	onSubmit: (text: string) => void;
 	onAbort: () => void;
 	onPickFile: () => void;
-	onSearchFiles: (query: string) => void;
-	onTagFile: (context: FileContextDto) => void;
+	onSearchWorkspace: (query: string) => void;
+	onTagContext: (context: TaggedContextDto) => void;
 }) {
 	const [text, setText] = createSignal("");
 	// Caret position, tracked so the `@`-mention parser knows which token the user
@@ -652,11 +655,11 @@ function Composer(props: {
 	// The `@`-mention token the caret is editing, if any (drives the file
 	// typeahead dropdown). Host results are already ranked + capped.
 	const mention = createMemo(() => activeMention(text(), caret()));
-	const fileMenuOpen = createMemo(() => mention() !== null && !mentionClosed() && props.fileResults.length > 0);
+	const mentionMenuOpen = createMemo(() => mention() !== null && !mentionClosed() && props.mentionResults.length > 0);
 
 	const scheduleSearch = (query: string) => {
 		if (searchTimer) clearTimeout(searchTimer);
-		searchTimer = setTimeout(() => props.onSearchFiles(query), 120);
+		searchTimer = setTimeout(() => props.onSearchWorkspace(query), 120);
 	};
 	onCleanup(() => {
 		if (searchTimer) clearTimeout(searchTimer);
@@ -698,15 +701,16 @@ function Composer(props: {
 		});
 	};
 
-	// Select a file from the inline dropdown: strip the `@query` token and tag the
-	// file as a composer chip (the host already built the workspace-relative DTO).
-	const selectFile = (context: FileContextDto) => {
+	// Select a result from the inline dropdown: strip the `@query` token and tag
+	// the folder/file/symbol as a composer chip (the host already built the
+	// workspace-relative DTO).
+	const selectResult = (context: TaggedContextDto) => {
 		const token = mention();
 		if (!token) return;
 		const stripped = replaceMention(text(), token, "");
 		setText(stripped.text);
 		setCaret(stripped.caret);
-		props.onTagFile(context);
+		props.onTagContext(context);
 		restoreCaret(stripped.caret);
 	};
 
@@ -723,8 +727,8 @@ function Composer(props: {
 	const pick = (name: string) => setText(`/${name} `);
 
 	const onKeyDown = (event: KeyboardEvent) => {
-		// Escape closes the file typeahead without submitting or losing text.
-		if (event.key === "Escape" && fileMenuOpen()) {
+		// Escape closes the mention typeahead without submitting or losing text.
+		if (event.key === "Escape" && mentionMenuOpen()) {
 			event.preventDefault();
 			setMentionClosed(true);
 			return;
@@ -751,18 +755,18 @@ function Composer(props: {
 					</For>
 				</div>
 			</Show>
-			<Show when={fileMenuOpen()}>
+			<Show when={mentionMenuOpen()}>
 				<div class="dreb-menu">
-					<For each={props.fileResults}>
-						{(file) => (
+					<For each={props.mentionResults}>
+						{(result) => (
 							<button
 								type="button"
 								class="dreb-menu-item"
-								title={taggedContextTitle(file)}
-								onClick={() => selectFile(file)}
+								title={taggedContextTitle(result)}
+								onClick={() => selectResult(result)}
 							>
-								<span class="dreb-menu-name">@{taggedContextLabel(file)}</span>
-								<span class="dreb-menu-desc">{file.path}</span>
+								<span class="dreb-menu-name">@{taggedContextLabel(result)}</span>
+								<span class="dreb-menu-desc">{mentionResultDesc(result)}</span>
 							</button>
 						)}
 					</For>
@@ -773,7 +777,9 @@ function Composer(props: {
 					<For each={props.attachments}>
 						{(attachment, index) => (
 							<span class="dreb-attachment" title={taggedContextTitle(attachment)}>
-								<span class="dreb-attachment-icon">{attachment.kind === "file" ? "@" : "{}"}</span>
+								<span class="dreb-attachment-icon">
+									{attachment.kind === "file" ? "@" : attachment.kind === "symbol" ? "#" : "{}"}
+								</span>
 								<span class="dreb-attachment-label">{taggedContextLabel(attachment)}</span>
 								<button
 									type="button"
@@ -852,4 +858,12 @@ function shortPath(path: string): string {
 	if (!path) return "";
 	const parts = path.split(/[/\\]/).filter(Boolean);
 	return parts.length <= 2 ? path : `…/${parts.slice(-2).join("/")}`;
+}
+
+/** Secondary line shown under a mention-dropdown result: the path for a
+ * file/folder, or `kind · path:line` for a code symbol. */
+function mentionResultDesc(context: TaggedContextDto): string {
+	if (context.kind === "symbol") return `${context.symbolKind} · ${context.path}:${context.line}`;
+	if (context.kind === "file") return context.isDirectory ? `${context.path}/` : context.path;
+	return context.path;
 }

--- a/packages/vscode/test/composer.test.tsx
+++ b/packages/vscode/test/composer.test.tsx
@@ -1,0 +1,200 @@
+// @vitest-environment jsdom
+/**
+ * Composer inline `@`-mention orchestration (Phase 4c).
+ *
+ * The pure helpers (`activeMention`, `isFullPickerTrigger`, `replaceMention`,
+ * `rankMentionResults`) are unit-tested in `mention.test.ts`; this file renders
+ * the real `Composer` in jsdom and drives the textarea to verify the *glue* the
+ * helpers hang off: `@@` escalates to the native picker (and never searches),
+ * `@`-typing schedules a debounced workspace search, selecting a dropdown result
+ * strips the `@query` token and tags the chosen folder/file/symbol, and Escape
+ * dismisses the dropdown. A dataset-key rename, a dropped debounce, or a wrong
+ * token span would fail here while the isolated helper tests stayed green.
+ */
+
+import { render } from "solid-js/web/dist/web.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { FileContextDto, SymbolContextDto, TaggedContextDto } from "../src/shared/protocol.js";
+
+vi.mock("../src/webview/vscode-api.js", () => ({
+	onHostMessage: () => () => {},
+	postToHost: () => {},
+}));
+
+import { Composer } from "../src/webview/app.js";
+
+const folder = (path: string): FileContextDto => ({ kind: "file", path, isDirectory: true });
+const file = (path: string): FileContextDto => ({ kind: "file", path });
+const symbol = (name: string, path: string, line = 1, symbolKind = "function"): SymbolContextDto => ({
+	kind: "symbol",
+	name,
+	symbolKind,
+	path,
+	line,
+});
+
+interface Spies {
+	onPickFile: ReturnType<typeof vi.fn>;
+	onSearchWorkspace: ReturnType<typeof vi.fn>;
+	onTagContext: ReturnType<typeof vi.fn>;
+	onSubmit: ReturnType<typeof vi.fn>;
+}
+
+let dispose: (() => void) | undefined;
+
+afterEach(() => {
+	dispose?.();
+	dispose = undefined;
+	document.body.innerHTML = "";
+	vi.useRealTimers();
+});
+
+function mount(mentionResults: TaggedContextDto[] = []): {
+	host: HTMLElement;
+	textarea: HTMLTextAreaElement;
+	spies: Spies;
+} {
+	const spies: Spies = {
+		onPickFile: vi.fn(),
+		onSearchWorkspace: vi.fn(),
+		onTagContext: vi.fn(),
+		onSubmit: vi.fn(),
+	};
+	const host = document.createElement("div");
+	document.body.appendChild(host);
+	dispose = render(
+		() => (
+			<Composer
+				streaming={false}
+				commands={[]}
+				attachments={[]}
+				mentionResults={mentionResults}
+				onRemoveAttachment={() => {}}
+				onSubmit={spies.onSubmit}
+				onAbort={() => {}}
+				onPickFile={spies.onPickFile}
+				onSearchWorkspace={spies.onSearchWorkspace}
+				onTagContext={spies.onTagContext}
+			/>
+		),
+		host,
+	);
+	const textarea = host.querySelector("textarea.dreb-input") as HTMLTextAreaElement;
+	return { host, textarea, spies };
+}
+
+/** Simulate typing by setting the textarea value + caret and dispatching a
+ * bubbling `input` event (Solid delegates `input`, so this drives `onInput`). */
+function type(textarea: HTMLTextAreaElement, value: string, caret = value.length): void {
+	textarea.value = value;
+	textarea.selectionStart = caret;
+	textarea.selectionEnd = caret;
+	textarea.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+describe("Composer @@ escalation", () => {
+	it("opens the native picker, strips the `@@`, and does not search", () => {
+		const { textarea, spies } = mount();
+		// Type the two `@` incrementally, as a real user would.
+		type(textarea, "@", 1);
+		type(textarea, "@@", 2);
+
+		expect(spies.onPickFile).toHaveBeenCalledTimes(1);
+		expect(spies.onSearchWorkspace).not.toHaveBeenCalled();
+		// The two `@` are stripped so the picker doesn't leave stray text behind.
+		expect(textarea.value).toBe("");
+	});
+
+	it("escalates `@@` after leading text and preserves that text", () => {
+		const { textarea, spies } = mount();
+		type(textarea, "see @@", 6);
+
+		expect(spies.onPickFile).toHaveBeenCalledTimes(1);
+		expect(textarea.value).toBe("see ");
+	});
+});
+
+describe("Composer @ typeahead", () => {
+	beforeEach(() => vi.useFakeTimers());
+
+	it("schedules a single debounced workspace search for the typed query", () => {
+		const { textarea, spies } = mount();
+		type(textarea, "@app", 4);
+
+		// Nothing fires until the debounce elapses.
+		expect(spies.onSearchWorkspace).not.toHaveBeenCalled();
+		vi.advanceTimersByTime(120);
+		expect(spies.onSearchWorkspace).toHaveBeenCalledTimes(1);
+		expect(spies.onSearchWorkspace).toHaveBeenCalledWith("app");
+	});
+
+	it("debounces rapid keystrokes into one trailing search", () => {
+		const { textarea, spies } = mount();
+		type(textarea, "@a", 2);
+		vi.advanceTimersByTime(50);
+		type(textarea, "@ap", 3);
+		vi.advanceTimersByTime(50);
+		type(textarea, "@app", 4);
+		vi.advanceTimersByTime(120);
+
+		expect(spies.onSearchWorkspace).toHaveBeenCalledTimes(1);
+		expect(spies.onSearchWorkspace).toHaveBeenCalledWith("app");
+	});
+
+	it("does not search plain prose without an active `@` token", () => {
+		const { textarea, spies } = mount();
+		type(textarea, "hello world", 11);
+		vi.advanceTimersByTime(120);
+		expect(spies.onSearchWorkspace).not.toHaveBeenCalled();
+	});
+});
+
+describe("Composer mention dropdown", () => {
+	it("renders folders, files, and symbols with @-prefixed labels and descriptions", () => {
+		const results: TaggedContextDto[] = [folder("src/app"), file("src/app.ts"), symbol("run", "src/app.ts", 8)];
+		const { host, textarea } = mount(results);
+		type(textarea, "@app", 4);
+
+		const items = [...host.querySelectorAll(".dreb-menu-item")];
+		const names = items.map((el) => el.querySelector(".dreb-menu-name")?.textContent);
+		const descs = items.map((el) => el.querySelector(".dreb-menu-desc")?.textContent);
+		expect(names).toEqual(["@app/", "@app.ts", "@run"]);
+		expect(descs).toEqual(["src/app/", "src/app.ts", "function · src/app.ts:8"]);
+	});
+
+	it("stays closed when there are no results even with an active `@` token", () => {
+		const { host, textarea } = mount([]);
+		type(textarea, "@app", 4);
+		expect(host.querySelector(".dreb-menu-item")).toBeNull();
+	});
+
+	it("tags the chosen result, strips the `@query` token, and closes the dropdown", () => {
+		const results: TaggedContextDto[] = [file("src/app.ts")];
+		const { host, textarea, spies } = mount(results);
+		type(textarea, "see @app", 8);
+
+		const item = host.querySelector(".dreb-menu-item") as HTMLButtonElement;
+		expect(item).toBeTruthy();
+		item.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+
+		expect(spies.onTagContext).toHaveBeenCalledTimes(1);
+		expect(spies.onTagContext).toHaveBeenCalledWith({ kind: "file", path: "src/app.ts" });
+		// The `@app` token is stripped, leaving the surrounding prose.
+		expect(textarea.value).toBe("see ");
+		// With no active token the dropdown closes.
+		expect(host.querySelector(".dreb-menu-item")).toBeNull();
+	});
+
+	it("dismisses the dropdown on Escape without submitting or losing text", () => {
+		const results: TaggedContextDto[] = [file("src/app.ts")];
+		const { host, textarea, spies } = mount(results);
+		type(textarea, "@app", 4);
+		expect(host.querySelector(".dreb-menu-item")).toBeTruthy();
+
+		textarea.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }));
+
+		expect(host.querySelector(".dreb-menu-item")).toBeNull();
+		expect(spies.onSubmit).not.toHaveBeenCalled();
+		expect(textarea.value).toBe("@app");
+	});
+});

--- a/packages/vscode/test/mention.test.ts
+++ b/packages/vscode/test/mention.test.ts
@@ -1,14 +1,23 @@
 import { describe, expect, it } from "vitest";
 import {
 	activeMention,
+	escapeGlob,
 	isFullPickerTrigger,
 	MENTION_RESULT_CAP,
-	rankFileResults,
+	rankMentionResults,
 	replaceMention,
 } from "../src/shared/mention.js";
-import type { FileContextDto } from "../src/shared/protocol.js";
+import type { FileContextDto, SymbolContextDto, TaggedContextDto } from "../src/shared/protocol.js";
 
 const file = (path: string): FileContextDto => ({ kind: "file", path });
+const folder = (path: string): FileContextDto => ({ kind: "file", path, isDirectory: true });
+const symbol = (name: string, path: string, line = 1, symbolKind = "class"): SymbolContextDto => ({
+	kind: "symbol",
+	name,
+	symbolKind,
+	path,
+	line,
+});
 
 describe("activeMention", () => {
 	it("matches a lone `@` at the start of the text", () => {
@@ -69,39 +78,106 @@ describe("replaceMention", () => {
 		const result = replaceMention("@app rest", { start: 0, end: 4 }, "");
 		expect(result).toEqual({ text: " rest", caret: 0 });
 	});
+
+	it("splices out a token with text on both sides", () => {
+		const result = replaceMention("see @app here", { start: 4, end: 8 }, "");
+		expect(result).toEqual({ text: "see  here", caret: 4 });
+	});
+
+	it("returns the caret after a non-empty replacement", () => {
+		const result = replaceMention("see @app here", { start: 4, end: 8 }, "@app.ts");
+		expect(result).toEqual({ text: "see @app.ts here", caret: 11 });
+	});
 });
 
-describe("rankFileResults", () => {
+describe("rankMentionResults", () => {
 	it("ranks filename prefix matches ahead of substring/path matches", () => {
 		const results = [file("src/components/wrap.ts"), file("src/app.ts"), file("lib/mapper.ts")];
-		const ranked = rankFileResults(results, "app", 10);
-		expect(ranked.map((r) => r.path)).toEqual(["src/app.ts", "lib/mapper.ts"]);
+		const ranked = rankMentionResults(results, "app", 10);
+		expect(ranked.map((r) => (r as FileContextDto).path)).toEqual(["src/app.ts", "lib/mapper.ts"]);
 	});
 
 	it("includes path substring matches after filename matches", () => {
 		const results = [file("src/utils/x.ts"), file("app/y.ts")];
-		const ranked = rankFileResults(results, "app", 10);
-		expect(ranked.map((r) => r.path)).toEqual(["app/y.ts"]);
+		const ranked = rankMentionResults(results, "app", 10);
+		expect(ranked.map((r) => (r as FileContextDto).path)).toEqual(["app/y.ts"]);
 	});
 
 	it("drops non-matching entries", () => {
 		const results = [file("src/a.ts"), file("src/b.ts")];
-		expect(rankFileResults(results, "zzz", 10)).toEqual([]);
+		expect(rankMentionResults(results, "zzz", 10)).toEqual([]);
 	});
 
-	it("keeps input order and just caps for an empty query", () => {
-		const results = [file("b.ts"), file("a.ts"), file("c.ts")];
-		expect(rankFileResults(results, "", 2)).toEqual([file("b.ts"), file("a.ts")]);
+	it("groups by kind order — folders, then files, then symbols", () => {
+		const results: TaggedContextDto[] = [
+			symbol("AppRunner", "src/app.ts", 3, "class"),
+			file("src/app.ts"),
+			folder("src/app"),
+		];
+		const ranked = rankMentionResults(results, "app", 10);
+		expect(ranked.map((r) => r.kind)).toEqual(["file", "file", "symbol"]);
+		// The folder is a file-kind DTO flagged isDirectory; it must lead.
+		expect(ranked[0]).toMatchObject({ kind: "file", isDirectory: true, path: "src/app" });
+		expect(ranked[1]).toMatchObject({ kind: "file", path: "src/app.ts" });
+		expect(ranked[2]).toMatchObject({ kind: "symbol", name: "AppRunner" });
+	});
+
+	it("matches a symbol on its name, not its path", () => {
+		const results: TaggedContextDto[] = [symbol("handleClick", "src/ui/button.ts", 12, "function")];
+		expect(rankMentionResults(results, "handle", 10)).toHaveLength(1);
+		expect(rankMentionResults(results, "button", 10)).toHaveLength(1); // path substring
+		expect(rankMentionResults(results, "zzz", 10)).toHaveLength(0);
+	});
+
+	it("keeps per-kind host order and just caps for an empty query", () => {
+		const results: TaggedContextDto[] = [file("b.ts"), folder("z"), file("a.ts")];
+		// Folder floats to the top (kind order); files keep host order (b before a).
+		expect(rankMentionResults(results, "", 10)).toEqual([folder("z"), file("b.ts"), file("a.ts")]);
 	});
 
 	it("caps the result list", () => {
 		const results = Array.from({ length: MENTION_RESULT_CAP + 5 }, (_, i) => file(`mod${i}.ts`));
-		expect(rankFileResults(results, "mod", MENTION_RESULT_CAP).length).toBe(MENTION_RESULT_CAP);
+		expect(rankMentionResults(results, "mod", MENTION_RESULT_CAP).length).toBe(MENTION_RESULT_CAP);
 	});
 
 	it("breaks ties by shorter path then alphabetically", () => {
 		const results = [file("src/deep/app.ts"), file("app.ts"), file("lib/app.ts")];
-		const ranked = rankFileResults(results, "app", 10);
-		expect(ranked.map((r) => r.path)).toEqual(["app.ts", "lib/app.ts", "src/deep/app.ts"]);
+		const ranked = rankMentionResults(results, "app", 10);
+		expect(ranked.map((r) => (r as FileContextDto).path)).toEqual(["app.ts", "lib/app.ts", "src/deep/app.ts"]);
+	});
+});
+
+describe("escapeGlob", () => {
+	it("leaves plain alphanumerics untouched", () => {
+		expect(escapeGlob("app")).toBe("app");
+		expect(escapeGlob("App123")).toBe("App123");
+	});
+
+	it("escapes each glob metacharacter", () => {
+		expect(escapeGlob("*")).toBe("\\*");
+		expect(escapeGlob("?")).toBe("\\?");
+		expect(escapeGlob("{")).toBe("\\{");
+		expect(escapeGlob("}")).toBe("\\}");
+		expect(escapeGlob("[")).toBe("\\[");
+		expect(escapeGlob("]")).toBe("\\]");
+		expect(escapeGlob("(")).toBe("\\(");
+		expect(escapeGlob(")")).toBe("\\)");
+		expect(escapeGlob("!")).toBe("\\!");
+		expect(escapeGlob("+")).toBe("\\+");
+		expect(escapeGlob("@")).toBe("\\@");
+	});
+
+	it("collapses forward and back slashes to a single wildcard", () => {
+		expect(escapeGlob("src/app")).toBe("src*app");
+		expect(escapeGlob("src\\app")).toBe("src*app");
+		expect(escapeGlob("a/b/c")).toBe("a*b*c");
+	});
+
+	it("escapes a mixed query so the resulting include stays a literal match", () => {
+		expect(escapeGlob("src/@types{x}")).toBe("src*\\@types\\{x\\}");
+	});
+
+	it("returns an empty string for an empty query", () => {
+		expect(escapeGlob("")).toBe("");
 	});
 });

--- a/packages/vscode/test/mention.test.ts
+++ b/packages/vscode/test/mention.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import {
+	activeMention,
+	isFullPickerTrigger,
+	MENTION_RESULT_CAP,
+	rankFileResults,
+	replaceMention,
+} from "../src/shared/mention.js";
+import type { FileContextDto } from "../src/shared/protocol.js";
+
+const file = (path: string): FileContextDto => ({ kind: "file", path });
+
+describe("activeMention", () => {
+	it("matches a lone `@` at the start of the text", () => {
+		expect(activeMention("@", 1)).toEqual({ start: 0, end: 1, query: "" });
+	});
+
+	it("captures the query typed after `@`", () => {
+		expect(activeMention("see @app", 8)).toEqual({ start: 4, end: 8, query: "app" });
+	});
+
+	it("matches `@` after a newline", () => {
+		const text = "line one\n@src";
+		expect(activeMention(text, text.length)).toEqual({ start: 9, end: 13, query: "src" });
+	});
+
+	it("does not fire for `@` embedded mid-word (e.g. an email)", () => {
+		expect(activeMention("mail me@host now", 7)).toBeNull();
+	});
+
+	it("closes the token once the query contains a space", () => {
+		expect(activeMention("@app ts", 7)).toBeNull();
+	});
+
+	it("rejects a query starting with a second `@` (that is the full-picker trigger)", () => {
+		expect(activeMention("@@", 2)).toBeNull();
+	});
+
+	it("parses only up to the caret, ignoring text after it", () => {
+		expect(activeMention("@app more", 4)).toEqual({ start: 0, end: 4, query: "app" });
+	});
+});
+
+describe("isFullPickerTrigger", () => {
+	it("is true for `@@` at the start of the text", () => {
+		expect(isFullPickerTrigger("@@", 2)).toBe(true);
+	});
+
+	it("is true for `@@` after whitespace", () => {
+		expect(isFullPickerTrigger("hi @@", 5)).toBe(true);
+	});
+
+	it("is false for a single `@`", () => {
+		expect(isFullPickerTrigger("@", 1)).toBe(false);
+	});
+
+	it("is false for `@@` embedded mid-word", () => {
+		expect(isFullPickerTrigger("a@@", 3)).toBe(false);
+	});
+});
+
+describe("replaceMention", () => {
+	it("strips the `@query` token when replacement is empty", () => {
+		const result = replaceMention("see @app", { start: 4, end: 8 }, "");
+		expect(result).toEqual({ text: "see ", caret: 4 });
+	});
+
+	it("preserves text after the caret", () => {
+		const result = replaceMention("@app rest", { start: 0, end: 4 }, "");
+		expect(result).toEqual({ text: " rest", caret: 0 });
+	});
+});
+
+describe("rankFileResults", () => {
+	it("ranks filename prefix matches ahead of substring/path matches", () => {
+		const results = [file("src/components/wrap.ts"), file("src/app.ts"), file("lib/mapper.ts")];
+		const ranked = rankFileResults(results, "app", 10);
+		expect(ranked.map((r) => r.path)).toEqual(["src/app.ts", "lib/mapper.ts"]);
+	});
+
+	it("includes path substring matches after filename matches", () => {
+		const results = [file("src/utils/x.ts"), file("app/y.ts")];
+		const ranked = rankFileResults(results, "app", 10);
+		expect(ranked.map((r) => r.path)).toEqual(["app/y.ts"]);
+	});
+
+	it("drops non-matching entries", () => {
+		const results = [file("src/a.ts"), file("src/b.ts")];
+		expect(rankFileResults(results, "zzz", 10)).toEqual([]);
+	});
+
+	it("keeps input order and just caps for an empty query", () => {
+		const results = [file("b.ts"), file("a.ts"), file("c.ts")];
+		expect(rankFileResults(results, "", 2)).toEqual([file("b.ts"), file("a.ts")]);
+	});
+
+	it("caps the result list", () => {
+		const results = Array.from({ length: MENTION_RESULT_CAP + 5 }, (_, i) => file(`mod${i}.ts`));
+		expect(rankFileResults(results, "mod", MENTION_RESULT_CAP).length).toBe(MENTION_RESULT_CAP);
+	});
+
+	it("breaks ties by shorter path then alphabetically", () => {
+		const results = [file("src/deep/app.ts"), file("app.ts"), file("lib/app.ts")];
+		const ranked = rankFileResults(results, "app", 10);
+		expect(ranked.map((r) => r.path)).toEqual(["app.ts", "lib/app.ts", "src/deep/app.ts"]);
+	});
+});

--- a/packages/vscode/test/session-controller.test.ts
+++ b/packages/vscode/test/session-controller.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { HostUi, HostUiPickItem } from "../src/host/host-ui.js";
+import type { HostUi, HostUiPickItem, WorkspaceSearchResult } from "../src/host/host-ui.js";
 import { type RpcClientLike, SessionController } from "../src/host/session-controller.js";
 import type { SourceLinkUi } from "../src/host/source-link-ui.js";
 import type { OpenSourceRef, SessionTreeNodeDto } from "../src/shared/protocol.js";
@@ -228,7 +228,7 @@ class FakeUi implements HostUi {
 	openReturn: string | undefined;
 	filesReturn: Array<{ fsPath: string; isDirectory: boolean }> | undefined;
 	filesCalls = 0;
-	searchReturn: Array<{ fsPath: string; isDirectory: boolean }> = [];
+	searchReturn: WorkspaceSearchResult[] = [];
 	searchQueries: string[] = [];
 	async quickPick(items: HostUiPickItem[]): Promise<string | undefined> {
 		this.pickItems = items;
@@ -247,7 +247,7 @@ class FakeUi implements HostUi {
 		this.filesCalls += 1;
 		return this.filesReturn;
 	}
-	async searchWorkspaceFiles(query: string): Promise<Array<{ fsPath: string; isDirectory: boolean }>> {
+	async searchWorkspace(query: string): Promise<WorkspaceSearchResult[]> {
 		this.searchQueries.push(query);
 		return this.searchReturn;
 	}
@@ -524,35 +524,77 @@ describe("SessionController", () => {
 		expect(updates.some((u) => u.kind === "tag-context")).toBe(false);
 	});
 
-	it("searchWorkspaceFiles returns workspace-relative, ranked, capped file DTOs", async () => {
+	it("searchWorkspace returns workspace-relative, ranked, capped file DTOs", async () => {
 		const fake = new FakeClient();
 		const ui = new FakeUi();
 		// Deliberately unranked: the deeper path and the substring-only match must
 		// sort after the filename prefix match ("app.ts").
 		ui.searchReturn = [
-			{ fsPath: "/tmp/project/src/components/wrap.ts", isDirectory: false },
-			{ fsPath: "/tmp/project/src/app.ts", isDirectory: false },
+			{ kind: "file", fsPath: "/tmp/project/src/components/wrap.ts" },
+			{ kind: "file", fsPath: "/tmp/project/src/app.ts" },
 		];
 		const controller = makeController(fake, { ui });
 		await controller.start();
 
-		const results = await controller.searchWorkspaceFiles("app");
+		const results = await controller.searchWorkspace("app");
 
 		expect(ui.searchQueries).toEqual(["app"]);
 		expect(results).toEqual([{ kind: "file", path: "src/app.ts" }]);
 	});
 
-	it("searchWorkspaceFiles caps results to the mention limit", async () => {
+	it("searchWorkspace orders folders, then files, then symbols", async () => {
+		const fake = new FakeClient();
+		const ui = new FakeUi();
+		ui.searchReturn = [
+			{ kind: "symbol", name: "AppRunner", symbolKind: "class", fsPath: "/tmp/project/src/app.ts", line: 4 },
+			{ kind: "file", fsPath: "/tmp/project/src/app.ts" },
+			{ kind: "folder", fsPath: "/tmp/project/src/app" },
+		];
+		const controller = makeController(fake, { ui });
+		await controller.start();
+
+		const results = await controller.searchWorkspace("app");
+
+		expect(results).toEqual([
+			{ kind: "file", path: "src/app", isDirectory: true },
+			{ kind: "file", path: "src/app.ts" },
+			{ kind: "symbol", name: "AppRunner", symbolKind: "class", path: "src/app.ts", line: 4 },
+		]);
+	});
+
+	it("searchWorkspace builds a workspace-relative symbol DTO from an absolute hit", async () => {
+		const fake = new FakeClient();
+		const ui = new FakeUi();
+		ui.searchReturn = [
+			{
+				kind: "symbol",
+				name: "handleClick",
+				symbolKind: "function",
+				fsPath: "/tmp/project/src/ui/button.ts",
+				line: 12,
+			},
+		];
+		const controller = makeController(fake, { ui });
+		await controller.start();
+
+		const results = await controller.searchWorkspace("handle");
+
+		expect(results).toEqual([
+			{ kind: "symbol", name: "handleClick", symbolKind: "function", path: "src/ui/button.ts", line: 12 },
+		]);
+	});
+
+	it("searchWorkspace caps results to the mention limit", async () => {
 		const fake = new FakeClient();
 		const ui = new FakeUi();
 		ui.searchReturn = Array.from({ length: 25 }, (_, i) => ({
+			kind: "file" as const,
 			fsPath: `/tmp/project/src/mod${i}.ts`,
-			isDirectory: false,
 		}));
 		const controller = makeController(fake, { ui });
 		await controller.start();
 
-		const results = await controller.searchWorkspaceFiles("mod");
+		const results = await controller.searchWorkspace("mod");
 
 		expect(results.length).toBe(10);
 		expect(results.every((r) => r.kind === "file")).toBe(true);

--- a/packages/vscode/test/session-controller.test.ts
+++ b/packages/vscode/test/session-controller.test.ts
@@ -228,6 +228,8 @@ class FakeUi implements HostUi {
 	openReturn: string | undefined;
 	filesReturn: Array<{ fsPath: string; isDirectory: boolean }> | undefined;
 	filesCalls = 0;
+	searchReturn: Array<{ fsPath: string; isDirectory: boolean }> = [];
+	searchQueries: string[] = [];
 	async quickPick(items: HostUiPickItem[]): Promise<string | undefined> {
 		this.pickItems = items;
 		return this.pickReturn;
@@ -244,6 +246,10 @@ class FakeUi implements HostUi {
 	async pickWorkspaceFiles(): Promise<Array<{ fsPath: string; isDirectory: boolean }> | undefined> {
 		this.filesCalls += 1;
 		return this.filesReturn;
+	}
+	async searchWorkspaceFiles(query: string): Promise<Array<{ fsPath: string; isDirectory: boolean }>> {
+		this.searchQueries.push(query);
+		return this.searchReturn;
 	}
 }
 
@@ -516,6 +522,40 @@ describe("SessionController", () => {
 
 		expect(ui.filesCalls).toBe(1);
 		expect(updates.some((u) => u.kind === "tag-context")).toBe(false);
+	});
+
+	it("searchWorkspaceFiles returns workspace-relative, ranked, capped file DTOs", async () => {
+		const fake = new FakeClient();
+		const ui = new FakeUi();
+		// Deliberately unranked: the deeper path and the substring-only match must
+		// sort after the filename prefix match ("app.ts").
+		ui.searchReturn = [
+			{ fsPath: "/tmp/project/src/components/wrap.ts", isDirectory: false },
+			{ fsPath: "/tmp/project/src/app.ts", isDirectory: false },
+		];
+		const controller = makeController(fake, { ui });
+		await controller.start();
+
+		const results = await controller.searchWorkspaceFiles("app");
+
+		expect(ui.searchQueries).toEqual(["app"]);
+		expect(results).toEqual([{ kind: "file", path: "src/app.ts" }]);
+	});
+
+	it("searchWorkspaceFiles caps results to the mention limit", async () => {
+		const fake = new FakeClient();
+		const ui = new FakeUi();
+		ui.searchReturn = Array.from({ length: 25 }, (_, i) => ({
+			fsPath: `/tmp/project/src/mod${i}.ts`,
+			isDirectory: false,
+		}));
+		const controller = makeController(fake, { ui });
+		await controller.start();
+
+		const results = await controller.searchWorkspaceFiles("mod");
+
+		expect(results.length).toBe(10);
+		expect(results.every((r) => r.kind === "file")).toBe(true);
 	});
 
 	it("folds a file tag into the prompt as a path reference with no contents", async () => {

--- a/packages/vscode/test/tagged-context.test.ts
+++ b/packages/vscode/test/tagged-context.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from "vitest";
-import type { FileContextDto, SelectionContextDto } from "../src/shared/protocol.js";
+import type { FileContextDto, SelectionContextDto, SymbolContextDto } from "../src/shared/protocol.js";
 import {
 	buildFileContext,
 	buildPromptWithContext,
+	buildSymbolContext,
 	buildTaggedContext,
 	formatTaggedContext,
 	MAX_INLINE_SELECTION_CHARS,
@@ -90,6 +91,36 @@ describe("buildFileContext", () => {
 	});
 });
 
+describe("buildSymbolContext", () => {
+	it("relativizes the defining file path and carries name/kind/line", () => {
+		const dto = buildSymbolContext({
+			fsPath: "/home/me/proj/src/host/session-controller.ts",
+			cwd: "/home/me/proj",
+			name: "SessionController",
+			symbolKind: "class",
+			line: 42,
+		});
+		expect(dto).toEqual({
+			kind: "symbol",
+			name: "SessionController",
+			symbolKind: "class",
+			path: "src/host/session-controller.ts",
+			line: 42,
+		});
+	});
+
+	it("uses the absolute path for a symbol defined outside the workspace", () => {
+		const dto = buildSymbolContext({
+			fsPath: "/usr/lib/node_modules/x/index.d.ts",
+			cwd: "/home/me/proj",
+			name: "Widget",
+			symbolKind: "interface",
+			line: 7,
+		});
+		expect(dto.path).toBe("/usr/lib/node_modules/x/index.d.ts");
+	});
+});
+
 describe("taggedContextLabel", () => {
 	const base: SelectionContextDto = {
 		kind: "selection",
@@ -115,6 +146,18 @@ describe("taggedContextLabel", () => {
 	it("shows a trailing slash for a folder tag", () => {
 		expect(taggedContextLabel({ kind: "file", path: "src/host", isDirectory: true })).toBe("host/");
 	});
+
+	it("shows the symbol name for a symbol tag", () => {
+		expect(
+			taggedContextLabel({
+				kind: "symbol",
+				name: "handleClick",
+				symbolKind: "function",
+				path: "src/ui.ts",
+				line: 3,
+			}),
+		).toBe("handleClick");
+	});
 });
 
 describe("taggedContextTitle", () => {
@@ -134,6 +177,12 @@ describe("taggedContextTitle", () => {
 	it("shows the path for a file and a (directory) note for a folder", () => {
 		expect(taggedContextTitle({ kind: "file", path: "src/app.ts" })).toBe("src/app.ts");
 		expect(taggedContextTitle({ kind: "file", path: "src/host", isDirectory: true })).toBe("src/host/ (directory)");
+	});
+
+	it("shows name, kind, and location for a symbol", () => {
+		expect(
+			taggedContextTitle({ kind: "symbol", name: "AppRunner", symbolKind: "class", path: "src/app.ts", line: 12 }),
+		).toBe("AppRunner — class in src/app.ts:12");
 	});
 });
 
@@ -209,6 +258,17 @@ describe("formatTaggedContext", () => {
 	it("folds an out-of-workspace file tag as its absolute path (unambiguous)", () => {
 		expect(formatTaggedContext({ kind: "file", path: "/etc/hosts" })).toBe("`/etc/hosts`");
 	});
+
+	it("folds a symbol tag as a located reference (path:line + kind + name), never the body", () => {
+		const out = formatTaggedContext({
+			kind: "symbol",
+			name: "handleClick",
+			symbolKind: "function",
+			path: "src/ui/button.ts",
+			line: 12,
+		});
+		expect(out).toBe("`src/ui/button.ts:12` (function `handleClick`)");
+	});
 });
 
 describe("buildPromptWithContext", () => {
@@ -222,6 +282,7 @@ describe("buildPromptWithContext", () => {
 	};
 	const file: FileContextDto = { kind: "file", path: "src/app.ts" };
 	const dir: FileContextDto = { kind: "file", path: "src", isDirectory: true };
+	const sym: SymbolContextDto = { kind: "symbol", name: "run", symbolKind: "function", path: "src/app.ts", line: 8 };
 
 	it("returns the text unchanged when there are no attachments", () => {
 		expect(buildPromptWithContext("hello", [])).toBe("hello");
@@ -235,6 +296,12 @@ describe("buildPromptWithContext", () => {
 	it("folds mixed selection + file + folder tags then the text", () => {
 		const out = buildPromptWithContext("compare", [sel, file, dir]);
 		expect(out).toBe("`a.ts` (line 1):\n```ts\nA\n```\n\n`src/app.ts`\n\n`src/` (directory)\n\ncompare");
+	});
+
+	it("folds a symbol tag as a located reference before the text", () => {
+		expect(buildPromptWithContext("what does this do?", [sym])).toBe(
+			"`src/app.ts:8` (function `run`)\n\nwhat does this do?",
+		);
 	});
 
 	it("returns just the blocks when the text is empty", () => {

--- a/packages/vscode/test/webview-bridge.test.ts
+++ b/packages/vscode/test/webview-bridge.test.ts
@@ -281,30 +281,51 @@ describe("connectWebview", () => {
 		expect(tagFileFromPicker).toHaveBeenCalledTimes(1);
 	});
 
-	it("routes search-files to the controller and posts file-results with the same requestId", async () => {
+	it("routes search-workspace to the controller and posts mention-results with the same requestId", async () => {
 		const fake = new BridgeFakeClient();
 		const controller = await makeController(fake);
 		const results = [
 			{ kind: "file" as const, path: "src/app.ts" },
 			{ kind: "file" as const, path: "src/host.ts" },
 		];
-		const search = vi.spyOn(controller, "searchWorkspaceFiles").mockResolvedValue(results);
+		const search = vi.spyOn(controller, "searchWorkspace").mockResolvedValue(results);
 
 		const { webview, posted, send } = makeWebview();
 		connectWebview(webview as any, controller);
 
-		send({ type: "search-files", query: "app", requestId: 7 });
+		send({ type: "search-workspace", query: "app", requestId: 7 });
 		// Let the mocked promise resolve.
 		await Promise.resolve();
 		await Promise.resolve();
 
 		expect(search).toHaveBeenCalledWith("app");
-		const fileResults = posted.find((m) => m.type === "file-results") as
-			| Extract<HostToWebview, { type: "file-results" }>
+		const mentionResults = posted.find((m) => m.type === "mention-results") as
+			| Extract<HostToWebview, { type: "mention-results" }>
 			| undefined;
-		expect(fileResults).toBeDefined();
-		expect(fileResults?.requestId).toBe(7);
-		expect(fileResults?.results).toEqual(results);
+		expect(mentionResults).toBeDefined();
+		expect(mentionResults?.requestId).toBe(7);
+		expect(mentionResults?.results).toEqual(results);
+	});
+
+	it("posts empty mention-results (same requestId) when the workspace search rejects", async () => {
+		const fake = new BridgeFakeClient();
+		const controller = await makeController(fake);
+		vi.spyOn(controller, "searchWorkspace").mockRejectedValue(new Error("findFiles failed"));
+
+		const { webview, posted, send } = makeWebview();
+		connectWebview(webview as any, controller);
+
+		send({ type: "search-workspace", query: "app", requestId: 9 });
+		// Let the rejected promise settle through the .catch.
+		await Promise.resolve();
+		await Promise.resolve();
+
+		const mentionResults = posted.find((m) => m.type === "mention-results") as
+			| Extract<HostToWebview, { type: "mention-results" }>
+			| undefined;
+		expect(mentionResults).toBeDefined();
+		expect(mentionResults?.requestId).toBe(9);
+		expect(mentionResults?.results).toEqual([]);
 	});
 
 	it("routes an open-source message to the controller with the parsed ref", async () => {

--- a/packages/vscode/test/webview-bridge.test.ts
+++ b/packages/vscode/test/webview-bridge.test.ts
@@ -281,6 +281,32 @@ describe("connectWebview", () => {
 		expect(tagFileFromPicker).toHaveBeenCalledTimes(1);
 	});
 
+	it("routes search-files to the controller and posts file-results with the same requestId", async () => {
+		const fake = new BridgeFakeClient();
+		const controller = await makeController(fake);
+		const results = [
+			{ kind: "file" as const, path: "src/app.ts" },
+			{ kind: "file" as const, path: "src/host.ts" },
+		];
+		const search = vi.spyOn(controller, "searchWorkspaceFiles").mockResolvedValue(results);
+
+		const { webview, posted, send } = makeWebview();
+		connectWebview(webview as any, controller);
+
+		send({ type: "search-files", query: "app", requestId: 7 });
+		// Let the mocked promise resolve.
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(search).toHaveBeenCalledWith("app");
+		const fileResults = posted.find((m) => m.type === "file-results") as
+			| Extract<HostToWebview, { type: "file-results" }>
+			| undefined;
+		expect(fileResults).toBeDefined();
+		expect(fileResults?.requestId).toBe(7);
+		expect(fileResults?.results).toEqual(results);
+	});
+
 	it("routes an open-source message to the controller with the parsed ref", async () => {
 		const fake = new BridgeFakeClient();
 		const controller = await makeController(fake);

--- a/packages/vscode/test/workspace-search.test.ts
+++ b/packages/vscode/test/workspace-search.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import { deriveFolderPaths, type RawSymbolHit, selectSymbols } from "../src/host/workspace-search.js";
+
+describe("deriveFolderPaths", () => {
+	const ROOT = "/home/me/proj";
+
+	it("surfaces an in-project ancestor folder whose segment matches the query", () => {
+		const hits = ["/home/me/proj/src/app/utils.ts"];
+		expect(deriveFolderPaths(hits, "app", [ROOT], 50)).toEqual(["/home/me/proj/src/app"]);
+	});
+
+	it("excludes ancestors ABOVE the workspace root even when their name matches", () => {
+		// Project lives under ~/code; typing "code" must NOT surface /home/me/code
+		// (the parent), only the in-project `codegen` folder.
+		const root = "/home/me/code/proj";
+		const hits = ["/home/me/code/proj/src/codegen/parser.ts"];
+		expect(deriveFolderPaths(hits, "code", [root], 50)).toEqual(["/home/me/code/proj/src/codegen"]);
+	});
+
+	it("returns nothing when the only matches are outside the project", () => {
+		const hits = ["/home/me/code/proj/src/app.ts"];
+		// "me" matches the /home/me ancestor, which is above the root → dropped.
+		expect(deriveFolderPaths(hits, "me", ["/home/me/code/proj"], 50)).toEqual([]);
+	});
+
+	it("matches case-insensitively on a substring of the segment", () => {
+		const hits = ["/home/me/proj/src/MyApp/index.ts"];
+		expect(deriveFolderPaths(hits, "myapp", [ROOT], 50)).toEqual(["/home/me/proj/src/MyApp"]);
+	});
+
+	it("skips the final (file) segment so a matching filename is not treated as a folder", () => {
+		const hits = ["/home/me/proj/src/app.ts"];
+		// "app" appears only in the file name; there is no matching directory.
+		expect(deriveFolderPaths(hits, "app", [ROOT], 50)).toEqual([]);
+	});
+
+	it("surfaces every matching ancestor along one path (nested folders)", () => {
+		const hits = ["/home/me/proj/app/appmodule/x.ts"];
+		expect(deriveFolderPaths(hits, "app", [ROOT], 50)).toEqual(["/home/me/proj/app", "/home/me/proj/app/appmodule"]);
+	});
+
+	it("dedupes a folder reached via multiple file hits, preserving first-seen order", () => {
+		const hits = ["/home/me/proj/src/app/a.ts", "/home/me/proj/src/app/b.ts", "/home/me/proj/lib/app/c.ts"];
+		expect(deriveFolderPaths(hits, "app", [ROOT], 50)).toEqual(["/home/me/proj/src/app", "/home/me/proj/lib/app"]);
+	});
+
+	it("caps the number of derived folders", () => {
+		const hits = Array.from({ length: 10 }, (_, i) => `/home/me/proj/app${i}/f.ts`);
+		expect(deriveFolderPaths(hits, "app", [ROOT], 3)).toHaveLength(3);
+	});
+
+	it("includes the workspace root itself when its name matches", () => {
+		const hits = ["/home/me/proj/src/x.ts"];
+		expect(deriveFolderPaths(hits, "proj", [ROOT], 50)).toEqual(["/home/me/proj"]);
+	});
+
+	it("tolerates a trailing slash on the workspace root", () => {
+		const hits = ["/home/me/proj/src/app/utils.ts"];
+		expect(deriveFolderPaths(hits, "app", ["/home/me/proj/"], 50)).toEqual(["/home/me/proj/src/app"]);
+	});
+
+	it("honors multiple workspace roots (multi-root workspace)", () => {
+		const roots = ["/home/me/api", "/home/me/web"];
+		const hits = ["/home/me/api/app/x.ts", "/home/me/web/app/y.ts", "/home/me/other/app/z.ts"];
+		// The /home/me/other hit is outside every root → excluded.
+		expect(deriveFolderPaths(hits, "app", roots, 50)).toEqual(["/home/me/api/app", "/home/me/web/app"]);
+	});
+
+	it("returns nothing when there are no workspace roots", () => {
+		const hits = ["/home/me/proj/src/app/x.ts"];
+		expect(deriveFolderPaths(hits, "app", [], 50)).toEqual([]);
+	});
+});
+
+describe("selectSymbols", () => {
+	// A representative structural-kind map (numeric keys mirror vscode.SymbolKind).
+	const LABELS = new Map<number, string>([
+		[4, "class"],
+		[11, "function"],
+		[5, "method"],
+	]);
+
+	const hit = (kind: number, name: string, line0 = 0, fsPath = "/proj/src/app.ts"): RawSymbolHit => ({
+		kind,
+		name,
+		fsPath,
+		line0,
+	});
+
+	it("keeps structural kinds and maps them to 1-based symbol results", () => {
+		const results = selectSymbols([hit(4, "AppRunner", 3)], LABELS, 50);
+		expect(results).toEqual([
+			{ kind: "symbol", name: "AppRunner", symbolKind: "class", fsPath: "/proj/src/app.ts", line: 4 },
+		]);
+	});
+
+	it("drops kinds absent from the label map (variables, fields, …)", () => {
+		// 12 = SymbolKind.Variable, not in LABELS.
+		const results = selectSymbols([hit(12, "counter"), hit(11, "run")], LABELS, 50);
+		expect(results.map((r) => r.kind === "symbol" && r.name)).toEqual(["run"]);
+	});
+
+	it("converts a 0-based provider line to a 1-based line", () => {
+		const [result] = selectSymbols([hit(5, "handle", 0)], LABELS, 50);
+		expect(result).toMatchObject({ kind: "symbol", line: 1 });
+	});
+
+	it("caps the number of symbols after filtering", () => {
+		const hits = Array.from({ length: 10 }, (_, i) => hit(11, `fn${i}`));
+		expect(selectSymbols(hits, LABELS, 3)).toHaveLength(3);
+	});
+
+	it("returns an empty list when nothing matches a structural kind", () => {
+		expect(selectSymbols([hit(12, "a"), hit(13, "b")], LABELS, 50)).toEqual([]);
+	});
+
+	it("returns an empty list for no symbols", () => {
+		expect(selectSymbols([], LABELS, 50)).toEqual([]);
+	});
+});


### PR DESCRIPTION
Closes #37

Replace the VSCode composer's `@` native-picker trigger with an inline filtering typeahead dropdown, and add `@@` for the full native file picker.

Implementation plan posted as a comment below.
