### PR TITLE
VS Code extension: wire /ask (read-only Ask mode) through RPC + extension host

### DIFF
--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -541,6 +541,14 @@ export class RpcClient {
 	}
 
 	/**
+	 * Toggle read-only Ask mode. Returns the resulting state.
+	 */
+	async setAskMode(enabled: boolean): Promise<{ enabled: boolean }> {
+		const response = await this.send({ type: "set_ask_mode", enabled });
+		return this.getData(response);
+	}
+
+	/**
 	 * Set auto-retry enabled/disabled.
 	 */
 	async setAutoRetry(enabled: boolean): Promise<void> {

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -295,6 +295,7 @@ export function getStateForRpc(session: AgentSession, modelFallbackMessage?: str
 		sessionId: session.sessionId,
 		sessionName: session.sessionName,
 		autoCompactionEnabled: session.autoCompactionEnabled,
+		askModeEnabled: session.askModeEnabled,
 		messageCount: session.messages.length,
 		pendingMessageCount: session.pendingMessageCount,
 		contextUsage: session.getContextUsage(),
@@ -2055,6 +2056,15 @@ export async function runRpcMode(session: AgentSession, modelFallbackMessage?: s
 			case "abort_compaction": {
 				session.abortCompaction();
 				return success(id, "abort_compaction");
+			}
+
+			// =================================================================
+			// Ask mode (read-only)
+			// =================================================================
+
+			case "set_ask_mode": {
+				const enabled = session.setAskMode(command.enabled);
+				return success(id, "set_ask_mode", { enabled });
 			}
 
 			// =================================================================

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -69,6 +69,9 @@ export type RpcCommand =
 	| { id?: string; type: "set_auto_compaction"; enabled: boolean }
 	| { id?: string; type: "abort_compaction" }
 
+	// Ask mode (read-only)
+	| { id?: string; type: "set_ask_mode"; enabled: boolean }
+
 	// Retry
 	| { id?: string; type: "set_auto_retry"; enabled: boolean }
 	| { id?: string; type: "abort_retry" }
@@ -248,6 +251,8 @@ export interface RpcSessionState {
 	sessionId: string;
 	sessionName?: string;
 	autoCompactionEnabled: boolean;
+	/** Whether read-only Ask mode is currently active. */
+	askModeEnabled: boolean;
 	messageCount: number;
 	pendingMessageCount: number;
 	/**
@@ -350,6 +355,9 @@ export type RpcResponse =
 	| { id?: string; type: "response"; command: "compact"; success: true; data: CompactionResult }
 	| { id?: string; type: "response"; command: "set_auto_compaction"; success: true }
 	| { id?: string; type: "response"; command: "abort_compaction"; success: true }
+
+	// Ask mode (read-only)
+	| { id?: string; type: "response"; command: "set_ask_mode"; success: true; data: { enabled: boolean } }
 
 	// Retry
 	| { id?: string; type: "response"; command: "set_auto_retry"; success: true }

--- a/packages/coding-agent/test/rpc-dashboard-commands.test.ts
+++ b/packages/coding-agent/test/rpc-dashboard-commands.test.ts
@@ -148,6 +148,19 @@ describe("RPC dashboard state/resources DTOs", () => {
 		}
 	});
 
+	it("reflects read-only Ask mode state in get_state data", () => {
+		const { session, cleanup } = createTestSession({ inMemory: true });
+		try {
+			expect(getStateForRpc(session).askModeEnabled).toBe(false);
+			session.setAskMode(true);
+			expect(getStateForRpc(session).askModeEnabled).toBe(true);
+			session.setAskMode(false);
+			expect(getStateForRpc(session).askModeEnabled).toBe(false);
+		} finally {
+			cleanup();
+		}
+	});
+
 	it("includes automatic retry activity in get_state data", () => {
 		const { session, cleanup } = createTestSession({ inMemory: true });
 		const retryingSession = session as unknown as {
@@ -536,6 +549,7 @@ describe("RpcClient dashboard command methods", () => {
 				followUpMode: "all",
 				sessionId: "session-1",
 				autoCompactionEnabled: false,
+				askModeEnabled: false,
 				messageCount: 0,
 				pendingMessageCount: 0,
 			},

--- a/packages/coding-agent/test/rpc-session-commands.test.ts
+++ b/packages/coding-agent/test/rpc-session-commands.test.ts
@@ -55,6 +55,19 @@ describe("toRpcSessionInfo", () => {
 });
 
 describe("RPC session commands", () => {
+	it("RpcClient.setAskMode sends the set_ask_mode command and unwraps the resulting state", async () => {
+		const client = new RpcClient() as any;
+		client.send = vi.fn().mockResolvedValue({
+			type: "response",
+			command: "set_ask_mode",
+			success: true,
+			data: { enabled: true },
+		});
+
+		await expect(client.setAskMode(true)).resolves.toEqual({ enabled: true });
+		expect(client.send).toHaveBeenCalledWith({ type: "set_ask_mode", enabled: true });
+	});
+
 	it("RpcClient.listAllSessions sends the list_all_sessions command and unwraps sessions", async () => {
 		const client = new RpcClient() as any;
 		const sessions: RpcSessionInfo[] = [

--- a/packages/vscode/src/host/session-controller.ts
+++ b/packages/vscode/src/host/session-controller.ts
@@ -508,21 +508,22 @@ export class SessionController {
 				return;
 			case "ask": {
 				const sub = arg?.trim().toLowerCase() ?? "";
-				let enable: boolean;
-				if (sub === "on") {
-					enable = true;
-				} else if (sub === "off") {
-					enable = false;
-				} else if (sub === "" || sub === "toggle") {
-					// Bare `/ask` (or `/ask toggle`) flips the current state.
-					const state = await client.getState();
-					enable = !state.askModeEnabled;
-				} else if (sub === "status") {
-					const state = await client.getState();
-					this.emitNotice(`Read-only Ask mode is currently ${state.askModeEnabled ? "ON" : "OFF"}.`);
-					return;
-				} else {
+				if (sub !== "on" && sub !== "off" && sub !== "" && sub !== "status") {
 					this.emitNotice("Usage: /ask [on | off | status] (bare /ask toggles).");
+					return;
+				}
+				// Fetch the authoritative live state once: it drives the bare-toggle
+				// direction, the `status` report, and the already-in-mode guard.
+				const current = (await client.getState()).askModeEnabled ?? false;
+				if (sub === "status") {
+					this.emitNotice(`Read-only Ask mode is currently ${current ? "ON" : "OFF"}.`);
+					return;
+				}
+				const enable = sub === "on" ? true : sub === "off" ? false : !current;
+				// Match the terminal: a no-op (already in the requested state) reports
+				// "already ON/OFF" instead of re-emitting the full activation notice.
+				if (enable === current) {
+					this.emitNotice(`Read-only Ask mode is already ${enable ? "ON" : "OFF"}.`);
 					return;
 				}
 				const { enabled } = await client.setAskMode(enable);

--- a/packages/vscode/src/host/session-controller.ts
+++ b/packages/vscode/src/host/session-controller.ts
@@ -60,6 +60,7 @@ export const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhig
 interface RpcSessionStateLike {
 	model?: { provider: string; id: string; name?: string };
 	thinkingLevel?: string;
+	askModeEnabled?: boolean;
 	usingSubscription?: boolean;
 	contextUsage?: { tokens: number | null; contextWindow: number; percent: number | null };
 	sessionFile?: string;
@@ -96,6 +97,8 @@ export interface RpcClientLike {
 	prompt(message: string, images?: unknown[]): Promise<void>;
 	abort(): Promise<void>;
 	compact(customInstructions?: string): Promise<unknown>;
+	/** Toggle read-only Ask mode; resolves with the resulting state. */
+	setAskMode(enabled: boolean): Promise<{ enabled: boolean }>;
 	getCommands(): Promise<
 		Array<{
 			name: string;
@@ -503,6 +506,33 @@ export class SessionController {
 			case "compact":
 				await client.compact(arg);
 				return;
+			case "ask": {
+				const sub = arg?.trim().toLowerCase() ?? "";
+				let enable: boolean;
+				if (sub === "on") {
+					enable = true;
+				} else if (sub === "off") {
+					enable = false;
+				} else if (sub === "" || sub === "toggle") {
+					// Bare `/ask` (or `/ask toggle`) flips the current state.
+					const state = await client.getState();
+					enable = !state.askModeEnabled;
+				} else if (sub === "status") {
+					const state = await client.getState();
+					this.emitNotice(`Read-only Ask mode is currently ${state.askModeEnabled ? "ON" : "OFF"}.`);
+					return;
+				} else {
+					this.emitNotice("Usage: /ask [on | off | status] (bare /ask toggles).");
+					return;
+				}
+				const { enabled } = await client.setAskMode(enable);
+				this.emitNotice(
+					enabled
+						? "Read-only Ask mode ON — edits/writes disabled, no shell (use the typed read-only git tool), subagents limited to read-only agents. Use /ask off to exit."
+						: "Read-only Ask mode OFF — normal tools restored.",
+				);
+				return;
+			}
 			case "model":
 				await this.pickModel();
 				return;

--- a/packages/vscode/src/host/slash-router.ts
+++ b/packages/vscode/src/host/slash-router.ts
@@ -22,6 +22,7 @@ import type { SlashCommandDto } from "../shared/protocol.js";
 export const BUILTIN_COMMANDS: SlashCommandDto[] = [
 	{ name: "model", description: "Switch the active model", source: "builtin" },
 	{ name: "compact", description: "Summarize and compact the conversation context", source: "builtin" },
+	{ name: "ask", description: "Toggle read-only Ask mode (on/off)", source: "builtin" },
 	{ name: "new", description: "Start a new session", source: "builtin" },
 	{ name: "reload", description: "Reload skills, extensions, prompts, and settings", source: "builtin" },
 	{ name: "dream", description: "Consolidate and prune memories", source: "builtin" },

--- a/packages/vscode/test/session-controller-review.test.ts
+++ b/packages/vscode/test/session-controller-review.test.ts
@@ -24,6 +24,9 @@ class MiniClient implements RpcClientLike {
 	async compact(): Promise<unknown> {
 		return {};
 	}
+	async setAskMode(enabled: boolean): Promise<{ enabled: boolean }> {
+		return { enabled };
+	}
 	async getCommands() {
 		return [];
 	}

--- a/packages/vscode/test/session-controller.test.ts
+++ b/packages/vscode/test/session-controller.test.ts
@@ -447,6 +447,38 @@ describe("SessionController", () => {
 		expect(controller.getTranscript().statusText).toMatch(/Usage: \/ask/);
 	});
 
+	it("/ask on when already ON is a no-op reporting 'already ON' (terminal parity)", async () => {
+		const fake = new FakeClient();
+		fake.state = { askModeEnabled: true };
+		const controller = makeController(fake);
+		await controller.start();
+
+		await controller.submit("/ask on");
+		expect(fake.askModeCalls).toEqual([]);
+		expect(controller.getTranscript().statusText).toMatch(/already ON/);
+	});
+
+	it("/ask off when already OFF is a no-op reporting 'already OFF' (terminal parity)", async () => {
+		const fake = new FakeClient();
+		fake.state = { askModeEnabled: false };
+		const controller = makeController(fake);
+		await controller.start();
+
+		await controller.submit("/ask off");
+		expect(fake.askModeCalls).toEqual([]);
+		expect(controller.getTranscript().statusText).toMatch(/already OFF/);
+	});
+
+	it("/ask toggle is not a keyword — shows usage and does not toggle (terminal parity)", async () => {
+		const fake = new FakeClient();
+		const controller = makeController(fake);
+		await controller.start();
+
+		await controller.submit("/ask toggle");
+		expect(fake.askModeCalls).toEqual([]);
+		expect(controller.getTranscript().statusText).toMatch(/Usage: \/ask/);
+	});
+
 	it("folds tagged attachments into the prompt as located context", async () => {
 		const fake = new FakeClient();
 		const controller = makeController(fake);

--- a/packages/vscode/test/session-controller.test.ts
+++ b/packages/vscode/test/session-controller.test.ts
@@ -26,6 +26,7 @@ class FakeClient implements RpcClientLike {
 	state: {
 		model?: { provider: string; id: string; name?: string };
 		thinkingLevel?: string;
+		askModeEnabled?: boolean;
 		usingSubscription?: boolean;
 		contextUsage?: { tokens: number | null; contextWindow: number; percent: number | null };
 		sessionFile?: string;
@@ -109,6 +110,15 @@ class FakeClient implements RpcClientLike {
 		if (this.callError) throw this.callError;
 		this.compactions.push(customInstructions);
 		return {};
+	}
+	// Ask mode (read-only). Tracks each requested value; mirrors the RPC verb by
+	// updating `state.askModeEnabled` and returning the resulting state.
+	askModeCalls: boolean[] = [];
+	async setAskMode(enabled: boolean): Promise<{ enabled: boolean }> {
+		if (this.callError) throw this.callError;
+		this.askModeCalls.push(enabled);
+		this.state.askModeEnabled = enabled;
+		return { enabled };
 	}
 	async getCommands() {
 		return this.commandsResult;
@@ -387,6 +397,54 @@ describe("SessionController", () => {
 
 		expect(fake.prompts).toEqual(["hello"]);
 		expect(fake.compactions).toEqual(["now"]);
+	});
+
+	it("/ask on and /ask off toggle read-only Ask mode over RPC", async () => {
+		const fake = new FakeClient();
+		const controller = makeController(fake);
+		await controller.start();
+
+		await controller.submit("/ask on");
+		expect(fake.askModeCalls).toEqual([true]);
+		expect(controller.getTranscript().statusText).toMatch(/Ask mode ON/);
+
+		await controller.submit("/ask off");
+		expect(fake.askModeCalls).toEqual([true, false]);
+		expect(controller.getTranscript().statusText).toMatch(/Ask mode OFF/);
+	});
+
+	it("bare /ask toggles based on the current state", async () => {
+		const fake = new FakeClient();
+		fake.state = { askModeEnabled: false };
+		const controller = makeController(fake);
+		await controller.start();
+
+		await controller.submit("/ask");
+		expect(fake.askModeCalls).toEqual([true]);
+
+		await controller.submit("/ask");
+		expect(fake.askModeCalls).toEqual([true, false]);
+	});
+
+	it("/ask status reports the current state without changing it", async () => {
+		const fake = new FakeClient();
+		fake.state = { askModeEnabled: true };
+		const controller = makeController(fake);
+		await controller.start();
+
+		await controller.submit("/ask status");
+		expect(fake.askModeCalls).toEqual([]);
+		expect(controller.getTranscript().statusText).toMatch(/currently ON/);
+	});
+
+	it("/ask with an invalid argument shows usage and does not toggle", async () => {
+		const fake = new FakeClient();
+		const controller = makeController(fake);
+		await controller.start();
+
+		await controller.submit("/ask bogus");
+		expect(fake.askModeCalls).toEqual([]);
+		expect(controller.getTranscript().statusText).toMatch(/Usage: \/ask/);
 	});
 
 	it("folds tagged attachments into the prompt as located context", async () => {

--- a/packages/vscode/test/slash-router.test.ts
+++ b/packages/vscode/test/slash-router.test.ts
@@ -27,6 +27,13 @@ describe("slash-router", () => {
 		expect(routeInput("/model")).toEqual({ kind: "builtin", command: "model", arg: undefined });
 	});
 
+	it("routes /ask (with on/off/bare) to the ask builtin", () => {
+		expect(routeInput("/ask")).toEqual({ kind: "builtin", command: "ask", arg: undefined });
+		expect(routeInput("/ask on")).toEqual({ kind: "builtin", command: "ask", arg: "on" });
+		expect(routeInput("/ask off")).toEqual({ kind: "builtin", command: "ask", arg: "off" });
+		expect(routeInput("/ask status")).toEqual({ kind: "builtin", command: "ask", arg: "status" });
+	});
+
 	it("prefers the builtin mapping over a same-named agent command", () => {
 		// A builtin like /compact must map to the RPC method, never be sent as a
 		// prompt, even if get_commands also advertised it.

--- a/packages/vscode/test/webview-bridge.test.ts
+++ b/packages/vscode/test/webview-bridge.test.ts
@@ -28,6 +28,9 @@ class BridgeFakeClient implements RpcClientLike {
 	async compact(): Promise<unknown> {
 		return {};
 	}
+	async setAskMode(enabled: boolean): Promise<{ enabled: boolean }> {
+		return { enabled };
+	}
 	async getCommands(): Promise<any[]> {
 		return [];
 	}


### PR DESCRIPTION
Closes #36

Wire `/ask` (read-only Ask mode) through the RPC layer so the VS Code extension can actually toggle it. Ask mode already exists in the engine (terminal-only); this adds the shared RPC verb and the extension handler.

Implementation plan posted as a comment below.
