### PR TITLE
VSCode extension: rebuild resumed session transcript on start (fix empty window)

### DIFF
--- a/packages/vscode/src/host/session-controller.ts
+++ b/packages/vscode/src/host/session-controller.ts
@@ -406,6 +406,22 @@ export class SessionController {
 		this.emit({ kind: "review", review: this.reviewState });
 		await this.refreshCommands();
 		await this.refreshStatus(true);
+		// When resuming a persisted session (`--session <path>`), the RPC child
+		// loads the saved conversation into its own memory but never re-broadcasts
+		// the historical events. The transcript is built exclusively from that live
+		// event stream, so a resumed session would render a blank window. Fold the
+		// persisted branch in now (same path as restore/fork) so prior turns render
+		// immediately. Guarded on `sessionPath` so a brand-new session keeps
+		// populating from the live stream and doesn't fold on start. Best-effort: a
+		// rebuild failure logs and leaves an empty transcript rather than throwing
+		// out of `start()`.
+		if (this.options.sessionPath) {
+			try {
+				await this.rebuildTranscript();
+			} catch (err) {
+				this.logger(`resume transcript rebuild failed: ${errorText(err)}`);
+			}
+		}
 	}
 
 	/** Fetch the agent's commands and merge with host builtins.

--- a/packages/vscode/src/host/session-controller.ts
+++ b/packages/vscode/src/host/session-controller.ts
@@ -412,14 +412,26 @@ export class SessionController {
 		// event stream, so a resumed session would render a blank window. Fold the
 		// persisted branch in now (same path as restore/fork) so prior turns render
 		// immediately. Guarded on `sessionPath` so a brand-new session keeps
-		// populating from the live stream and doesn't fold on start. Best-effort: a
-		// rebuild failure logs and leaves an empty transcript rather than throwing
-		// out of `start()`.
+		// populating from the live stream and doesn't fold on start.
 		if (this.options.sessionPath) {
 			try {
 				await this.rebuildTranscript();
 			} catch (err) {
 				this.logger(`resume transcript rebuild failed: ${errorText(err)}`);
+				// A failure partway through the rebuild can leave a half-folded
+				// transcript (`foldBranchIntoState` clears items before repopulating).
+				// Reset to a clean empty state (and clear checkpoints) so the webview
+				// never shows a partial conversation, then resync so an already-live
+				// webview reflects that clean state. Finally surface a notice — parity
+				// with fork()/navigateTree() — so the user knows their prior turns are
+				// saved and will reload on reopen, rather than silently facing a blank
+				// window indistinguishable from a brand-new session. Best-effort: this
+				// never rethrows out of `start()`.
+				this.resetTranscriptState();
+				this.emitNotice(
+					"Couldn't restore the previous conversation — it's still saved and will reload when you reopen the chat.",
+				);
+				this.emit({ kind: "resync" });
 			}
 		}
 	}

--- a/packages/vscode/test/session-controller.test.ts
+++ b/packages/vscode/test/session-controller.test.ts
@@ -247,12 +247,13 @@ class FakeUi implements HostUi {
 	}
 }
 
-function makeController(fake: FakeClient, opts: { cwd?: string; ui?: HostUi } = {}) {
+function makeController(fake: FakeClient, opts: { cwd?: string; ui?: HostUi; sessionPath?: string } = {}) {
 	return new SessionController({
 		cwd: opts.cwd ?? "/tmp/project",
 		cliPath: "/cli.js",
 		clientFactory: () => fake,
 		ui: opts.ui,
+		sessionPath: opts.sessionPath,
 	});
 }
 
@@ -1445,5 +1446,48 @@ describe("SessionController session tree (Phase 6)", () => {
 		).toEqual(["u:hi", "a:hello", "u:ask-A", "a:answer-A"]);
 		// Checkpoints key to branch-A entries only (the sibling branch is absent).
 		expect(controller.getCheckpoints().map((c) => c.entryId)).toEqual(["a1", "a2a"]);
+	});
+});
+
+describe("SessionController resume (Phase 5 — rebuild transcript on start)", () => {
+	it("folds the persisted branch into the transcript on start when resuming", async () => {
+		const fake = new FakeClient();
+		fake.treeResult = twoResponseTree();
+		const controller = makeController(fake, { sessionPath: "/abs/sess.jsonl" });
+
+		await controller.start();
+
+		// The resumed child never replays historical events, so start() rebuilds
+		// the transcript from the persisted branch tree instead of leaving it blank.
+		expect(fake.treeCalls).toBeGreaterThan(0);
+		const items = controller.getTranscript().items;
+		expect(
+			items.map((i) => (i.kind === "user" ? `u:${i.text}` : i.kind === "response" ? `a:${i.answer}` : i.text)),
+		).toEqual(["u:hi", "a:hello", "u:again", "a:world"]);
+	});
+
+	it("does not fold on start for a brand-new session (no sessionPath)", async () => {
+		const fake = new FakeClient();
+		fake.treeResult = twoResponseTree();
+		const controller = makeController(fake); // no sessionPath
+
+		await controller.start();
+
+		// A fresh session keeps populating from the live event stream; start() must
+		// not fetch the tree or pre-fold any turns.
+		expect(fake.treeCalls).toBe(0);
+		expect(controller.getTranscript().items).toEqual([]);
+	});
+
+	it("still connects when the resume rebuild fails (best-effort, no throw)", async () => {
+		const fake = new FakeClient();
+		// getTree (invoked by rebuildTranscript) throws; start() must swallow it.
+		fake.callError = new Error("getTree boom");
+		const controller = makeController(fake, { sessionPath: "/abs/sess.jsonl" });
+
+		await expect(controller.start()).resolves.toBeUndefined();
+		expect(controller.getStatus().connected).toBe(true);
+		// The failed rebuild leaves an empty transcript rather than blocking startup.
+		expect(controller.getTranscript().items).toEqual([]);
 	});
 });

--- a/packages/vscode/test/session-controller.test.ts
+++ b/packages/vscode/test/session-controller.test.ts
@@ -1454,6 +1454,8 @@ describe("SessionController resume (Phase 5 — rebuild transcript on start)", (
 		const fake = new FakeClient();
 		fake.treeResult = twoResponseTree();
 		const controller = makeController(fake, { sessionPath: "/abs/sess.jsonl" });
+		const updates: Array<{ kind: string }> = [];
+		controller.onUpdate((u) => updates.push(u as never));
 
 		await controller.start();
 
@@ -1464,6 +1466,11 @@ describe("SessionController resume (Phase 5 — rebuild transcript on start)", (
 		expect(
 			items.map((i) => (i.kind === "user" ? `u:${i.text}` : i.kind === "response" ? `a:${i.answer}` : i.text)),
 		).toEqual(["u:hi", "a:hello", "u:again", "a:world"]);
+		// The rebuild resyncs an already-live webview (finding 4) and realigns the
+		// inline restore/fork controls to the folded turns (finding 5) — keyed to
+		// the branch's assistant entries, with the current leaf non-restorable.
+		expect(updates.some((u) => u.kind === "resync")).toBe(true);
+		expect(controller.getCheckpoints().map((c) => `${c.entryId}:${c.canRestore}`)).toEqual(["a1:true", "a2:false"]);
 	});
 
 	it("does not fold on start for a brand-new session (no sessionPath)", async () => {
@@ -1479,15 +1486,29 @@ describe("SessionController resume (Phase 5 — rebuild transcript on start)", (
 		expect(controller.getTranscript().items).toEqual([]);
 	});
 
-	it("still connects when the resume rebuild fails (best-effort, no throw)", async () => {
+	it("resets to a clean state and notifies the user when the resume rebuild fails", async () => {
 		const fake = new FakeClient();
 		// getTree (invoked by rebuildTranscript) throws; start() must swallow it.
 		fake.callError = new Error("getTree boom");
 		const controller = makeController(fake, { sessionPath: "/abs/sess.jsonl" });
+		const updates: Array<{ kind: string }> = [];
+		controller.onUpdate((u) => updates.push(u as never));
 
 		await expect(controller.start()).resolves.toBeUndefined();
+
+		// Best-effort: the failure does not block startup — the session stays
+		// connected and usable.
 		expect(controller.getStatus().connected).toBe(true);
-		// The failed rebuild leaves an empty transcript rather than blocking startup.
+		// The transcript is reset to a clean empty state (no half-folded turns) and
+		// checkpoints are cleared, so the webview never shows a partial conversation
+		// (finding 3).
 		expect(controller.getTranscript().items).toEqual([]);
+		expect(controller.getCheckpoints()).toEqual([]);
+		// A resync pushes that clean state to an already-live webview...
+		expect(updates.some((u) => u.kind === "resync")).toBe(true);
+		// ...and the user is told the prior conversation is saved rather than facing
+		// a silent blank window indistinguishable from a brand-new session
+		// (finding 1).
+		expect(controller.getTranscript().statusText).toMatch(/still saved/i);
 	});
 });


### PR DESCRIPTION
Closes #41

Fixes the empty chat window when resuming a persisted dreb session in the VSCode extension: on resume the transcript is rebuilt from the persisted session branch so prior turns render immediately, instead of relying on a live event stream the resumed child never replays.

Part of the VSCode extension epic (#12), Phase 5 resume (#24).

Implementation plan posted as a comment below.
