### PR TITLE
VSCode extension: resizable composer input (drag-to-expand vertically)

### DIFF
--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -48,6 +48,7 @@ src/
                         change-review bar, and the inline restore/fork checkpoint
                         controls + branch-tree overlay (Phase 6)
     code-links.ts       grounded file/symbol linkification of answers (pure, tested)
+    composer-resize.ts  clamp helper for the drag-resizable composer height (pure, tested)
     sidebar/app.tsx     the sessions side panel — grouped list, live status, resume,
                         inline rename, pin / archive / delete
 ```
@@ -145,6 +146,15 @@ Every conversation is a **branch tree**: you can rewind to an earlier point or f
 - **Reuses the existing RPC surface.** Fork/restore/tree are wired over dreb's `fork` / `get_fork_messages` / `get_tree` / `navigate_tree` commands — no backend changes. The webview never holds session entry ids; the host derives them from the session tree and aligns them to the rendered turns.
 
 After a restore or fork moves the leaf, the host rebuilds the transcript from the target branch (`SessionController.rebuildTranscript`) and re-snapshots the webview via the same `resync` path as `/new` and `/import`. Rebuilt turns use the branch's per-entry **previews**; full answer text and tool activity are not reconstructed on a rebuild (an MVP limitation). The pure pieces — `foldBranchIntoState` (rebuild) and `alignCheckpoints` (map response groups → entry ids, anchored to the most recent turn so an interrupted run can't misalign the rest) — live in `shared/projection.ts` and are unit-tested; the inline controls and branch-tree overlay (`CheckpointBar` / `TreePanel` in `webview/app.tsx`) post to the host under the strict CSP via event delegation, and all host logic stays vscode-free (RPC-faked in tests).
+
+
+## Resizable composer
+
+The message composer can be **dragged taller** so long prompts get more room, up to ~80% of the panel height, then collapsed back to its compact two-row default.
+
+- **Top drag handle.** A thin grip along the composer's top edge (a focusable `<hr>` with the implicit ARIA **separator/splitter** role) is dragged with the pointer to set the height; **double-click** it to snap back to the natural height. Because the composer is bottom-docked, the handle sits on top rather than using a native bottom-right resize corner.
+- **Keyboard resizable.** With the handle focused, **↑/↓** grow/shrink by a step, **Home** resets to the compact default, and **End** maximizes; `aria-valuemin`/`valuemax`/`valuenow` are kept in sync for screen readers.
+- **Pure, tested clamp.** The height math is isolated in `webview/composer-resize.ts` (`clampComposerHeight`) — DOM-independent and unit-tested (including the degenerate `max < min` case) — while `app.tsx` owns the pointer/keyboard wiring and window-level listener lifecycle.
 
 
 ## Requirements

--- a/packages/vscode/src/webview/app.tsx
+++ b/packages/vscode/src/webview/app.tsx
@@ -24,6 +24,7 @@ import type {
 } from "../shared/protocol.js";
 import { taggedContextLabel, taggedContextTitle } from "../shared/tagged-context.js";
 import { buildGroundedRefs, linkifyAnswer } from "./code-links.js";
+import { clampComposerHeight } from "./composer-resize.js";
 import { renderMarkdown } from "./markdown.js";
 import { onHostMessage, postToHost } from "./vscode-api.js";
 
@@ -638,6 +639,66 @@ export function Composer(props: {
 	let inputEl: HTMLTextAreaElement | undefined;
 	let searchTimer: ReturnType<typeof setTimeout> | undefined;
 
+	// User-chosen composer height (px) from the top resize handle. `null` means
+	// "use the natural `rows={2}` height". The composer is docked at the bottom of
+	// the panel, so a top-edge handle lets the user pull the input up over the
+	// chat area for long drafts and shrink it back (drag, double-click to reset,
+	// or keyboard arrows). See `clampComposerHeight` for the drag geometry.
+	const [composerHeight, setComposerHeight] = createSignal<number | null>(null);
+	// Compact floor (~2 rows) the input can never shrink below.
+	const MIN_COMPOSER_HEIGHT = 44;
+	// Fraction of the panel height the input may grow to occupy, leaving room for
+	// the send button and some chat context above.
+	const MAX_COMPOSER_FRACTION = 0.8;
+	// Per-keystroke resize step for keyboard operation of the handle.
+	const RESIZE_KEY_STEP = 24;
+	let resizeDrag: { startY: number; startHeight: number } | null = null;
+
+	// Current ceiling in px, recomputed from the live panel height.
+	const composerMaxHeight = () =>
+		Math.max(MIN_COMPOSER_HEIGHT, Math.round(window.innerHeight * MAX_COMPOSER_FRACTION));
+	// Effective height right now (explicit override, else the measured natural
+	// height, else the floor) — used as the drag/keyboard starting point and to
+	// report `aria-valuenow`.
+	const currentComposerHeight = () => composerHeight() ?? inputEl?.offsetHeight ?? MIN_COMPOSER_HEIGHT;
+	const resizeBy = (startHeight: number, deltaY: number) =>
+		setComposerHeight(
+			clampComposerHeight({ startHeight, deltaY, min: MIN_COMPOSER_HEIGHT, max: composerMaxHeight() }),
+		);
+
+	const onResizeMove = (event: PointerEvent | MouseEvent) => {
+		if (!resizeDrag) return;
+		// Drag *up* (smaller clientY) grows the input, so delta is start − current.
+		resizeBy(resizeDrag.startHeight, resizeDrag.startY - event.clientY);
+	};
+
+	const onResizeEnd = () => {
+		resizeDrag = null;
+		window.removeEventListener("pointermove", onResizeMove);
+		window.removeEventListener("pointerup", onResizeEnd);
+	};
+
+	const onResizeStart = (event: PointerEvent | MouseEvent) => {
+		event.preventDefault();
+		resizeDrag = { startY: event.clientY, startHeight: currentComposerHeight() };
+		window.addEventListener("pointermove", onResizeMove);
+		window.addEventListener("pointerup", onResizeEnd);
+	};
+
+	// Double-clicking the handle returns the input to its compact default.
+	const onResizeReset = () => setComposerHeight(null);
+
+	// Keyboard operation for the focusable handle: arrows nudge, Home resets to
+	// the compact default, End grows to the ceiling.
+	const onResizeKeyDown = (event: KeyboardEvent) => {
+		if (event.key === "ArrowUp") resizeBy(currentComposerHeight(), RESIZE_KEY_STEP);
+		else if (event.key === "ArrowDown") resizeBy(currentComposerHeight(), -RESIZE_KEY_STEP);
+		else if (event.key === "Home") setComposerHeight(null);
+		else if (event.key === "End") setComposerHeight(composerMaxHeight());
+		else return;
+		event.preventDefault();
+	};
+
 	// Apply a host-driven pre-fill (a user-message fork's re-ask text). The
 	// `nonce` makes the effect retrigger even when the same text is sent twice.
 	createEffect(() => {
@@ -663,6 +724,8 @@ export function Composer(props: {
 	};
 	onCleanup(() => {
 		if (searchTimer) clearTimeout(searchTimer);
+		window.removeEventListener("pointermove", onResizeMove);
+		window.removeEventListener("pointerup", onResizeEnd);
 	});
 
 	// Composer input: handle `@@` escalation to the native picker, drive the
@@ -741,6 +804,19 @@ export function Composer(props: {
 
 	return (
 		<div class="dreb-composer">
+			<hr
+				class="dreb-resize-handle"
+				tabIndex={0}
+				aria-orientation="horizontal"
+				aria-label="Resize message input (drag or arrow keys to enlarge, double-click or Home to reset)"
+				aria-valuemin={MIN_COMPOSER_HEIGHT}
+				aria-valuemax={composerMaxHeight()}
+				aria-valuenow={Math.round(currentComposerHeight())}
+				title="Drag to resize · double-click to reset"
+				onPointerDown={onResizeStart}
+				onDblClick={onResizeReset}
+				onKeyDown={onResizeKeyDown}
+			/>
 			<Show when={menu().length > 0}>
 				<div class="dreb-menu">
 					<For each={menu()}>
@@ -800,6 +876,7 @@ export function Composer(props: {
 					ref={inputEl}
 					class="dreb-input"
 					rows={2}
+					style={composerHeight() != null ? { height: `${composerHeight()}px` } : undefined}
 					placeholder="Message dreb…  (/ for commands, @ for files, @@ for picker)"
 					value={text()}
 					onInput={(e) => onInput(e.currentTarget)}

--- a/packages/vscode/src/webview/composer-resize.ts
+++ b/packages/vscode/src/webview/composer-resize.ts
@@ -1,0 +1,33 @@
+/**
+ * Geometry for the composer's drag-to-resize handle, extracted as a pure
+ * function so it can be unit-tested without a DOM/layout engine.
+ *
+ * The composer is docked at the bottom of the chat panel and the handle sits on
+ * its *top* edge, so dragging the pointer up should make the input taller and
+ * dragging down should shrink it. Callers pass `deltaY = startPointerY -
+ * currentPointerY` (positive when the pointer moved up); the resulting height is
+ * clamped to `[min, max]`.
+ */
+export interface ComposerHeightInput {
+	/** Input height in px captured at pointer-down. */
+	startHeight: number;
+	/** Upward drag distance in px (`startPointerY - currentPointerY`). */
+	deltaY: number;
+	/** Smallest allowed height in px (the compact default). */
+	min: number;
+	/** Largest allowed height in px (roughly the panel-height budget). */
+	max: number;
+}
+
+/**
+ * Compute the clamped composer height for a drag gesture.
+ *
+ * Guarantees a sane result even for a degenerate range: when the panel is so
+ * short that `max` falls below `min`, the effective ceiling is raised to `min`
+ * so the return value is always within `[min, max']` and never `min > max`.
+ */
+export function clampComposerHeight({ startHeight, deltaY, min, max }: ComposerHeightInput): number {
+	const ceiling = Math.max(min, max);
+	const desired = startHeight + deltaY;
+	return Math.min(ceiling, Math.max(min, desired));
+}

--- a/packages/vscode/src/webview/styles.css
+++ b/packages/vscode/src/webview/styles.css
@@ -343,6 +343,44 @@ body {
 	padding: 8px 12px;
 }
 
+/* Top-edge drag handle: the composer is docked at the bottom of the panel, so a
+   grip on its top edge lets the user pull the input up over the chat area (and
+   double-click to reset). Spans the full width and overlays the border-top. */
+.dreb-resize-handle {
+	position: absolute;
+	top: -3px;
+	left: 0;
+	right: 0;
+	height: 9px;
+	margin: 0;
+	border: none;
+	background: transparent;
+	cursor: ns-resize;
+	touch-action: none;
+	z-index: 1;
+}
+.dreb-resize-handle:focus-visible {
+	outline: 1px solid var(--vscode-focusBorder, #007fd4);
+	outline-offset: -1px;
+}
+.dreb-resize-handle::before {
+	content: "";
+	position: absolute;
+	top: 3px;
+	left: 50%;
+	transform: translateX(-50%);
+	width: 32px;
+	height: 3px;
+	border-radius: 3px;
+	background: var(--vscode-panel-border, rgba(128, 128, 128, 0.5));
+	opacity: 0;
+	transition: opacity 0.1s ease-in-out;
+}
+.dreb-resize-handle:hover::before {
+	opacity: 1;
+	background: var(--vscode-focusBorder, rgba(128, 128, 128, 0.8));
+}
+
 .dreb-composer-row {
 	display: flex;
 	gap: 8px;
@@ -392,7 +430,11 @@ body {
 
 .dreb-input {
 	flex: 1;
-	resize: vertical;
+	/* Height is driven by the top drag handle (see `.dreb-resize-handle` and
+	   `clampComposerHeight`), so the native corner grip is disabled to avoid two
+	   competing affordances. `min-height` is the compact ~2-row floor. */
+	resize: none;
+	min-height: 44px;
 	font-family: inherit;
 	font-size: inherit;
 	color: var(--vscode-input-foreground);

--- a/packages/vscode/test/composer-resize.test.ts
+++ b/packages/vscode/test/composer-resize.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { clampComposerHeight } from "../src/webview/composer-resize.js";
+
+/**
+ * Pure geometry for the composer's top drag handle. The component wiring (real
+ * pointer events on the rendered handle) is covered in `composer.test.tsx`; this
+ * file pins the clamping math independent of any DOM/layout engine.
+ */
+describe("clampComposerHeight", () => {
+	const bounds = { min: 44, max: 600 };
+
+	it("grows the input when dragged up (positive delta)", () => {
+		expect(clampComposerHeight({ startHeight: 100, deltaY: 120, ...bounds })).toBe(220);
+	});
+
+	it("shrinks the input when dragged down (negative delta)", () => {
+		expect(clampComposerHeight({ startHeight: 300, deltaY: -120, ...bounds })).toBe(180);
+	});
+
+	it("clamps to the compact minimum when dragged far down", () => {
+		expect(clampComposerHeight({ startHeight: 100, deltaY: -500, ...bounds })).toBe(44);
+	});
+
+	it("clamps to the maximum when dragged far up", () => {
+		expect(clampComposerHeight({ startHeight: 500, deltaY: 500, ...bounds })).toBe(600);
+	});
+
+	it("respects a smaller panel-height ceiling", () => {
+		expect(clampComposerHeight({ startHeight: 100, deltaY: 400, min: 44, max: 200 })).toBe(200);
+	});
+
+	it("never returns below min for a degenerate range (max < min)", () => {
+		// A very short panel where the computed ceiling falls below the floor.
+		expect(clampComposerHeight({ startHeight: 30, deltaY: 100, min: 44, max: 20 })).toBe(44);
+	});
+});

--- a/packages/vscode/test/composer.test.tsx
+++ b/packages/vscode/test/composer.test.tsx
@@ -198,3 +198,102 @@ describe("Composer mention dropdown", () => {
 		expect(textarea.value).toBe("@app");
 	});
 });
+
+describe("Composer resize handle", () => {
+	// Drive the top drag handle with real pointer events. jsdom has no layout, so
+	// the input's `offsetHeight` is 0 and `window.innerHeight` is its 768 default;
+	// the assertions therefore key off the drag delta, exercising the wiring
+	// (handle → `clampComposerHeight` → inline `style.height`) rather than layout.
+	function handleOf(host: HTMLElement): HTMLElement {
+		return host.querySelector(".dreb-resize-handle") as HTMLElement;
+	}
+	function pointerDown(el: HTMLElement, clientY: number): void {
+		el.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true, cancelable: true, clientY }));
+	}
+	function pointerMove(clientY: number): void {
+		window.dispatchEvent(new MouseEvent("pointermove", { clientY }));
+	}
+	function pointerUp(): void {
+		window.dispatchEvent(new MouseEvent("pointerup", {}));
+	}
+
+	it("renders a discoverable, accessible top drag handle", () => {
+		const { host } = mount();
+		const handle = handleOf(host);
+		expect(handle).toBeTruthy();
+		// An <hr> carries the implicit ARIA "separator" role (satisfies a11y lint).
+		expect(handle.tagName).toBe("HR");
+		expect(handle.getAttribute("aria-orientation")).toBe("horizontal");
+		expect(handle.tabIndex).toBe(0);
+	});
+
+	it("grows the input when the handle is dragged up", () => {
+		const { host, textarea } = mount();
+		expect(textarea.style.height).toBe("");
+		pointerDown(handleOf(host), 500);
+		pointerMove(300); // dragged up 200px
+		pointerUp();
+		expect(textarea.style.height).toBe("200px");
+	});
+
+	it("shrinks toward the compact minimum when dragged down past it", () => {
+		const { host, textarea } = mount();
+		pointerDown(handleOf(host), 500);
+		pointerMove(900); // dragged down 400px → below the 44px floor
+		pointerUp();
+		expect(textarea.style.height).toBe("44px");
+	});
+
+	it("clamps growth to ~80% of the window height", () => {
+		const { host, textarea } = mount();
+		// window.innerHeight defaults to 768 in jsdom → ceiling round(768 * 0.8) = 614.
+		pointerDown(handleOf(host), 500);
+		pointerMove(-600); // an extreme upward drag
+		pointerUp();
+		expect(textarea.style.height).toBe("614px");
+	});
+
+	it("does not resize after the drag ends (listeners are torn down)", () => {
+		const { host, textarea } = mount();
+		pointerDown(handleOf(host), 500);
+		pointerMove(300);
+		pointerUp();
+		expect(textarea.style.height).toBe("200px");
+		pointerMove(100); // stray move after release must be ignored
+		expect(textarea.style.height).toBe("200px");
+	});
+
+	it("resets to the natural height on double-click", () => {
+		const { host, textarea } = mount();
+		pointerDown(handleOf(host), 500);
+		pointerMove(300);
+		pointerUp();
+		expect(textarea.style.height).toBe("200px");
+		handleOf(host).dispatchEvent(new MouseEvent("dblclick", { bubbles: true, cancelable: true }));
+		expect(textarea.style.height).toBe("");
+	});
+
+	function keyDown(el: HTMLElement, key: string): void {
+		el.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true }));
+	}
+
+	it("grows and shrinks by a step with the arrow keys", () => {
+		const { host, textarea } = mount();
+		// Establish a known height first (jsdom reports offsetHeight 0), then nudge.
+		pointerDown(handleOf(host), 500);
+		pointerMove(300); // → 200px
+		pointerUp();
+		keyDown(handleOf(host), "ArrowUp");
+		expect(textarea.style.height).toBe("224px");
+		keyDown(handleOf(host), "ArrowDown");
+		expect(textarea.style.height).toBe("200px");
+	});
+
+	it("maximizes with End and resets with Home", () => {
+		const { host, textarea } = mount();
+		keyDown(handleOf(host), "End");
+		expect(textarea.style.height).toBe("614px"); // round(768 * 0.8)
+		keyDown(handleOf(host), "Home");
+		expect(textarea.style.height).toBe("");
+	});
+});

--- a/packages/vscode/test/composer.test.tsx
+++ b/packages/vscode/test/composer.test.tsx
@@ -296,4 +296,34 @@ describe("Composer resize handle", () => {
 		keyDown(handleOf(host), "Home");
 		expect(textarea.style.height).toBe("");
 	});
+
+	it("keeps aria-value* in sync as the input is resized (finding 6)", () => {
+		const { host } = mount();
+		const handle = handleOf(host);
+		// Static bounds: floor is MIN_COMPOSER_HEIGHT; ceiling is round(768 * 0.8).
+		expect(handle.getAttribute("aria-valuemin")).toBe("44");
+		expect(handle.getAttribute("aria-valuemax")).toBe("614");
+		// A drag updates the reactive binding — a static/untracked read would fail here.
+		pointerDown(handle, 500);
+		pointerMove(300); // → 200px
+		pointerUp();
+		expect(handle.getAttribute("aria-valuenow")).toBe("200");
+		// End grows to the ceiling; valuenow must reach valuemax.
+		keyDown(handle, "End");
+		expect(handle.getAttribute("aria-valuenow")).toBe("614");
+		expect(handle.getAttribute("aria-valuenow")).toBe(handle.getAttribute("aria-valuemax"));
+	});
+
+	it("starts a drag from the input's measured height, not jsdom's 0 (finding 8)", () => {
+		const { host, textarea } = mount();
+		// In a real browser the 2-row textarea has a natural height (~52px); jsdom
+		// reports offsetHeight 0, which would silently mask the `inputEl.offsetHeight`
+		// branch of `currentComposerHeight` and let a "drag always starts from 0"
+		// regression pass. Stub a realistic height so the drag is measured from it.
+		Object.defineProperty(textarea, "offsetHeight", { configurable: true, value: 52 });
+		pointerDown(handleOf(host), 500);
+		pointerMove(300); // dragged up 200px from the measured 52px
+		pointerUp();
+		expect(textarea.style.height).toBe("252px"); // 52 + 200, not 200
+	});
 });


### PR DESCRIPTION
Closes #44

Make the VSCode extension chat composer input vertically resizable via a discoverable top drag handle, so long inputs can be expanded toward the window height and shrunk back.

Implementation plan posted as a comment below.
