### PR TITLE
VSCode extension: enable, display, and restore queued composer messages

### DIFF
--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -80,6 +80,12 @@ Commands owned by later phases (`/settings`, `/scoped-models`, `/fork`, `/tree`,
 
 The webview renders a compact header mirroring the TUI: **model · thinking level · cost · context usage**. Cost shows the session total (`$0.123`, `+ (sub)` on a subscription) and, when known, the larger daily total (`, today $1.23`); context usage shows `ctx 42%`. All formatting lives in the pure `shared/format.ts` so the header renders costs consistently.
 
+## Queued messages (send while working)
+
+You don't have to wait for the agent to finish before typing your next instruction. Sending a message while a turn is in flight **steers** it — the message is injected into the running turn (rather than being rejected as a mid-stream `prompt`, which would silently drop it). Queued messages show as **chips above the composer** ("2 queued messages") until they're delivered, so nothing you send is invisible.
+
+Pressing **Stop** aborts the current turn. Because an abort leaves any still-queued messages undelivered, the extension **clears the queue and restores that text back into the composer** — you decide whether to resend it, rather than losing it. The pending queue is host-authoritative (refreshed from the RPC child on run transitions and after each queued submit) so the chips survive a webview reload.
+
 ## Change review
 
 Because the agent runs out-of-process and writes edits straight to disk, the extension can't hold changes in an unsaved overlay. Instead it **snapshots a git baseline before each turn** and reviews the working tree against it (the non-interactive analogue of `git restore -p`):

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -84,7 +84,7 @@ The webview renders a compact header mirroring the TUI: **model · thinking leve
 
 You don't have to wait for the agent to finish before typing your next instruction. Sending a message while a turn is in flight **steers** it — the message is injected into the running turn (rather than being rejected as a mid-stream `prompt`, which would silently drop it). Queued messages show as **chips above the composer** ("2 queued messages") until they're delivered, so nothing you send is invisible.
 
-Pressing **Stop** aborts the current turn. Because an abort leaves any still-queued messages undelivered, the extension **clears the queue and restores that text back into the composer** — you decide whether to resend it, rather than losing it. The pending queue is host-authoritative (refreshed from the RPC child on run transitions and after each queued submit) so the chips survive a webview reload.
+Pressing **Stop** aborts the current turn. Because an abort leaves any still-queued messages undelivered, the extension **clears the queue and restores that text back into the composer** — you decide whether to resend it, rather than losing it. If you'd already started typing a new message when you hit Stop, the restored text is **prepended before your draft** (queued messages first, then your in-progress text) so neither is lost — never overwriting what you were typing. The pending queue is host-authoritative (refreshed from the RPC child on run transitions and after each queued submit) so the chips survive a webview reload.
 
 ## Change review
 

--- a/packages/vscode/src/host/session-controller.ts
+++ b/packages/vscode/src/host/session-controller.ts
@@ -12,6 +12,7 @@
  * events + status changes. The webview bridge adapts those to `postMessage`.
  */
 
+import type { ComposerPrefillMode } from "../shared/composer-prefill.js";
 import { formatSessionStats } from "../shared/format.js";
 import { MENTION_RESULT_CAP, rankMentionResults } from "../shared/mention.js";
 import {
@@ -202,8 +203,9 @@ export type ControllerUpdate =
 	| { kind: "checkpoints"; checkpoints: Checkpoint[] }
 	/** The session branch tree, in response to a `show-tree` request (Phase 6). */
 	| { kind: "tree"; tree: SessionTreeDto }
-	/** Pre-fill the composer (a user-message fork's re-ask text) (Phase 6). */
-	| { kind: "composer-prefill"; text: string }
+	/** Pre-fill the composer. `mode` (default `"replace"`) controls whether it
+	 * overwrites the composer or `"prepend"`s before any in-progress draft. */
+	| { kind: "composer-prefill"; text: string; mode?: ComposerPrefillMode }
 	/** The pending steer/follow-up queue changed — the bridge forwards it to the
 	 * webview as composer chips (empty clears them). */
 	| { kind: "pending"; messages: QueuedMessageDto[] }
@@ -587,7 +589,9 @@ export class SessionController {
 			const { steering, followUp } = await this.client.clearPendingMessages();
 			const restored = [...steering, ...followUp].filter((text) => text.trim().length > 0);
 			this.setPending([]);
-			if (restored.length > 0) this.emit({ kind: "composer-prefill", text: restored.join("\n\n") });
+			if (restored.length > 0) {
+				this.emit({ kind: "composer-prefill", text: restored.join("\n\n"), mode: "prepend" });
+			}
 		} catch (err) {
 			this.logger(`clearing pending on abort failed: ${err instanceof Error ? err.message : String(err)}`);
 		}

--- a/packages/vscode/src/host/session-controller.ts
+++ b/packages/vscode/src/host/session-controller.ts
@@ -25,6 +25,7 @@ import {
 import type {
 	HostStatus,
 	OpenSourceRef,
+	QueuedMessageDto,
 	ReviewFileDto,
 	ReviewStateDto,
 	SessionTreeDto,
@@ -96,6 +97,17 @@ export interface RpcClientLike {
 	start(): Promise<void>;
 	stop(): Promise<void>;
 	prompt(message: string, images?: unknown[]): Promise<void>;
+	/** Queue a message while the agent is streaming, injecting it into the
+	 * running turn (after the current tool calls). The plain `prompt()` throws
+	 * mid-stream, so a submit made while working must route here. */
+	steer(message: string, images?: unknown[]): Promise<void>;
+	/** Queue a message while the agent is streaming, delivered after the current
+	 * turn fully finishes. */
+	followUp(message: string, images?: unknown[]): Promise<void>;
+	/** Read the queued steer/follow-up messages without clearing them. */
+	getPendingMessages(): Promise<{ steering: string[]; followUp: string[] }>;
+	/** Clear the queued steer/follow-up messages, returning the cleared text. */
+	clearPendingMessages(): Promise<{ steering: string[]; followUp: string[] }>;
 	abort(): Promise<void>;
 	compact(customInstructions?: string): Promise<unknown>;
 	/** Toggle read-only Ask mode; resolves with the resulting state. */
@@ -192,6 +204,9 @@ export type ControllerUpdate =
 	| { kind: "tree"; tree: SessionTreeDto }
 	/** Pre-fill the composer (a user-message fork's re-ask text) (Phase 6). */
 	| { kind: "composer-prefill"; text: string }
+	/** The pending steer/follow-up queue changed — the bridge forwards it to the
+	 * webview as composer chips (empty clears them). */
+	| { kind: "pending"; messages: QueuedMessageDto[] }
 	/** Transcript was replaced host-side (e.g. `/new`, `/import`); the bridge
 	 * re-sends a fresh snapshot. */
 	| { kind: "resync" };
@@ -277,6 +292,11 @@ export class SessionController {
 	 * current transcript's response groups. Held so the bridge can include them
 	 * in the ready/resync snapshot. */
 	private checkpoints: Checkpoint[] = [];
+	/** Last-known pending steer/follow-up queue (held so the bridge can include
+	 * it in the ready snapshot — queued chips survive webview recreation).
+	 * Refreshed authoritatively from the RPC child on run transitions and after
+	 * a queued submit. */
+	private pendingMessages: QueuedMessageDto[] = [];
 	private readonly logger: (line: string) => void;
 	private readonly options: SessionControllerOptions;
 	private client: RpcClientLike | undefined;
@@ -362,6 +382,13 @@ export class SessionController {
 	 * in the ready/resync snapshot so they survive webview recreation. */
 	getCheckpoints(): Checkpoint[] {
 		return this.checkpoints;
+	}
+
+	/** The current pending steer/follow-up queue (Phase: queued composer
+	 * messages); included by the bridge in the ready snapshot so queued chips
+	 * survive webview recreation. */
+	getPending(): QueuedMessageDto[] {
+		return this.pendingMessages;
 	}
 
 	getCommandList(): SlashCommandDto[] {
@@ -509,12 +536,12 @@ export class SessionController {
 				case "empty":
 					// Reached only with attachments present (see guard above): send the
 					// folded context so a chips-only submit isn't silently dropped.
-					await this.client.prompt(buildPromptWithContext(text, attachments));
+					await this.deliver(buildPromptWithContext(text, attachments));
 					return;
 				case "prompt":
 					// Fold any tagged editor selections into the prompt as located
 					// context (attachments only apply to prompts, not slash builtins).
-					await this.client.prompt(buildPromptWithContext(decision.message, attachments));
+					await this.deliver(buildPromptWithContext(decision.message, attachments));
 					return;
 				case "builtin":
 					await this.runBuiltin(decision.command, decision.arg);
@@ -528,12 +555,41 @@ export class SessionController {
 		}
 	}
 
+	/** Send composer text to the model. While the agent is working, `prompt()`
+	 * throws ("Agent is already processing…"), which would silently swallow the
+	 * message; route it through `steer()` instead so it's queued into the running
+	 * turn, and refresh the pending chips so the queued message is visible. When
+	 * idle, dispatch it as a normal prompt. */
+	private async deliver(message: string): Promise<void> {
+		const client = this.client;
+		if (!client) return;
+		if (this.state.streaming) {
+			await client.steer(message);
+			await this.refreshPending();
+			return;
+		}
+		await client.prompt(message);
+	}
+
+	/** Abort the current turn. Any messages the user queued while the agent was
+	 * working are stranded by an abort (the agent loop exits without draining the
+	 * steer/follow-up queue), so drain and clear the RPC child's queue and restore
+	 * the queued text into the composer — the user decides whether to resend it
+	 * rather than losing it. */
 	async abort(): Promise<void> {
 		if (!this.client || !this.status.connected) return;
 		try {
 			await this.client.abort();
 		} catch (err) {
 			this.logger(`abort failed: ${err instanceof Error ? err.message : String(err)}`);
+		}
+		try {
+			const { steering, followUp } = await this.client.clearPendingMessages();
+			const restored = [...steering, ...followUp].filter((text) => text.trim().length > 0);
+			this.setPending([]);
+			if (restored.length > 0) this.emit({ kind: "composer-prefill", text: restored.join("\n\n") });
+		} catch (err) {
+			this.logger(`clearing pending on abort failed: ${err instanceof Error ? err.message : String(err)}`);
 		}
 	}
 
@@ -781,6 +837,30 @@ export class SessionController {
 		}
 	}
 
+	/** Refresh the pending steer/follow-up queue from the RPC child (authoritative
+	 * — an empty result clears the chips). Best-effort: a read failure leaves the
+	 * last-known queue in place rather than surfacing a notice. Called on run
+	 * transitions, after a queued submit, and after an abort clears the queue. */
+	private async refreshPending(): Promise<void> {
+		const client = this.client;
+		if (!client || !this.status.connected) return;
+		try {
+			const { steering, followUp } = await client.getPendingMessages();
+			this.setPending([
+				...steering.map((text): QueuedMessageDto => ({ kind: "steer", text })),
+				...followUp.map((text): QueuedMessageDto => ({ kind: "follow-up", text })),
+			]);
+		} catch (err) {
+			this.logger(`refreshPending failed: ${err instanceof Error ? err.message : String(err)}`);
+		}
+	}
+
+	/** Replace the held pending queue and publish it to the webview. */
+	private setPending(messages: QueuedMessageDto[]): void {
+		this.pendingMessages = messages;
+		this.emit({ kind: "pending", messages });
+	}
+
 	/** Clear the transcript in place (properties, not the reference) so `/new`
 	 * and `/import` present a fresh conversation after a `resync`. */
 	private resetTranscriptState(): void {
@@ -795,6 +875,9 @@ export class SessionController {
 		// first response group reuses id 1 and would otherwise match a stale
 		// `{responseId: 1}`). The subsequent `resync` re-posts this empty array.
 		this.checkpoints = [];
+		// A fresh/imported session starts with no queued messages (the RPC child
+		// clears its own queue on new_session); clear the chips to match.
+		this.setPending([]);
 	}
 
 	/** Append a persistent host-side line to the transcript (e.g. `/session`). */
@@ -1152,6 +1235,13 @@ export class SessionController {
 		// Snapshot a baseline before the first turn of a review cycle (changes
 		// then compound against it until accepted/reverted).
 		if (type === "turn_start") this.maybeCaptureBaseline();
+		// Keep the queued-message chips in sync with the RPC child's queue:
+		// a run starting/ending changes what's still pending, and a steered
+		// user message delivered mid-run drops out of the queue.
+		if (type === "agent_start" || type === "agent_end") void this.refreshPending();
+		else if (type === "message_start" && (event as { message?: { role?: string } }).message?.role === "user") {
+			void this.refreshPending();
+		}
 		// After each completed turn, refresh runtime status (cost/context/model)
 		// the way the dashboard does on the streaming→idle transition, and
 		// recompute the change-review set from the baseline.

--- a/packages/vscode/src/host/webview-bridge.ts
+++ b/packages/vscode/src/host/webview-bridge.ts
@@ -102,7 +102,7 @@ export function connectWebview(webview: vscode.Webview, controller: SessionContr
 				post({ type: "tree", tree: update.tree });
 				break;
 			case "composer-prefill":
-				post({ type: "composer-prefill", text: update.text });
+				post({ type: "composer-prefill", text: update.text, mode: update.mode });
 				break;
 			case "pending":
 				post({ type: "pending", messages: update.messages });

--- a/packages/vscode/src/host/webview-bridge.ts
+++ b/packages/vscode/src/host/webview-bridge.ts
@@ -93,6 +93,7 @@ export function connectWebview(webview: vscode.Webview, controller: SessionContr
 				});
 				post({ type: "review", review: controller.getReviewState() });
 				post({ type: "checkpoints", checkpoints: controller.getCheckpoints() });
+				post({ type: "pending", messages: controller.getPending() });
 				break;
 			case "checkpoints":
 				post({ type: "checkpoints", checkpoints: update.checkpoints });
@@ -102,6 +103,9 @@ export function connectWebview(webview: vscode.Webview, controller: SessionContr
 				break;
 			case "composer-prefill":
 				post({ type: "composer-prefill", text: update.text });
+				break;
+			case "pending":
+				post({ type: "pending", messages: update.messages });
 				break;
 		}
 	});
@@ -121,6 +125,7 @@ export function connectWebview(webview: vscode.Webview, controller: SessionContr
 				live = true;
 				post({ type: "review", review: controller.getReviewState() });
 				post({ type: "checkpoints", checkpoints: controller.getCheckpoints() });
+				post({ type: "pending", messages: controller.getPending() });
 				// Deliver any context tags added before the webview was live.
 				for (const pending of pendingTags.splice(0))
 					post({ type: "tag-context", context: pending.context, origin: pending.origin });

--- a/packages/vscode/src/shared/composer-prefill.ts
+++ b/packages/vscode/src/shared/composer-prefill.ts
@@ -1,0 +1,16 @@
+/** Pure merge logic for a host-driven composer pre-fill, shared by the webview
+ * and its unit tests. Kept vscode-free so it can be tested in isolation.
+ *
+ * A pre-fill either `"replace"`s the composer (a user-message fork's re-ask
+ * text — the user isn't mid-draft when they click a fork button) or
+ * `"prepend"`s (queued messages restored when a streaming turn is aborted).
+ * Prepend inserts the incoming text before whatever the user has already typed
+ * so an in-progress draft is never silently overwritten — the abort-restore
+ * clobber flagged in review. When the current draft is empty (the common Stop
+ * case), both modes collapse to just the incoming text. */
+export type ComposerPrefillMode = "replace" | "prepend";
+
+export function mergeComposerPrefill(mode: ComposerPrefillMode, incoming: string, current: string): string {
+	if (mode === "prepend" && current.trim().length > 0) return `${incoming}\n\n${current}`;
+	return incoming;
+}

--- a/packages/vscode/src/shared/protocol.ts
+++ b/packages/vscode/src/shared/protocol.ts
@@ -182,6 +182,15 @@ export interface SessionTreeDto {
 	leafId: string | null;
 }
 
+/** One message the user queued while the agent was working — waiting to be
+ * delivered to the model. `steer` messages inject into the running turn;
+ * `follow-up` messages are delivered after it finishes. Shown as a composer
+ * chip until delivered (see the `pending` host→webview message). */
+export interface QueuedMessageDto {
+	kind: "steer" | "follow-up";
+	text: string;
+}
+
 /** Messages sent from the host to the webview. */
 export type HostToWebview =
 	| { type: "snapshot"; state: TranscriptState; commands: SlashCommandDto[]; status: HostStatus }
@@ -203,6 +212,9 @@ export type HostToWebview =
 	 * request's `requestId` so the webview can drop stale (out-of-order)
 	 * responses. Mixes folders, files, and code symbols (in that order). */
 	| { type: "mention-results"; requestId: number; results: TaggedContextDto[] }
+	/** The queue of pending steer/follow-up messages changed — render them as
+	 * chips above the composer (empty clears the chips). */
+	| { type: "pending"; messages: QueuedMessageDto[] }
 	/** Pre-fill the composer (e.g. a user-message fork's re-ask text) (Phase 6). */
 	| { type: "composer-prefill"; text: string };
 

--- a/packages/vscode/src/shared/protocol.ts
+++ b/packages/vscode/src/shared/protocol.ts
@@ -8,6 +8,7 @@
  * node-only code — the mirror of the dashboard's `src/shared/protocol.ts`.
  */
 
+import type { ComposerPrefillMode } from "./composer-prefill.js";
 import type { Checkpoint, TranscriptState } from "./projection.js";
 
 /** A slash command offered in the composer dropdown. */
@@ -215,8 +216,11 @@ export type HostToWebview =
 	/** The queue of pending steer/follow-up messages changed — render them as
 	 * chips above the composer (empty clears the chips). */
 	| { type: "pending"; messages: QueuedMessageDto[] }
-	/** Pre-fill the composer (e.g. a user-message fork's re-ask text) (Phase 6). */
-	| { type: "composer-prefill"; text: string };
+	/** Pre-fill the composer. `mode` controls how it combines with any text the
+	 * user has already typed: `"replace"` (default — a user-message fork's re-ask
+	 * text) overwrites, while `"prepend"` (queued messages restored on abort)
+	 * inserts before the existing text so an in-progress draft is never lost. */
+	| { type: "composer-prefill"; text: string; mode?: ComposerPrefillMode };
 
 /** Messages sent from the webview to the host. */
 export type WebviewToHost =

--- a/packages/vscode/src/webview/app.tsx
+++ b/packages/vscode/src/webview/app.tsx
@@ -1,5 +1,6 @@
 import { createEffect, createMemo, createSignal, For, onCleanup, onMount, Show, untrack } from "solid-js";
 import { createStore, produce, reconcile } from "solid-js/store";
+import { type ComposerPrefillMode, mergeComposerPrefill } from "../shared/composer-prefill.js";
 import { formatContextUsage, formatCost, formatModel, formatThinking } from "../shared/format.js";
 import { activeMention, isFullPickerTrigger, mentionReference, replaceMention } from "../shared/mention.js";
 import {
@@ -50,8 +51,9 @@ export function App() {
 	// The session branch tree, shown as an overlay when the user opens it.
 	const [tree, setTree] = createSignal<SessionTreeDto | undefined>();
 	// A composer pre-fill request (a user-message fork's re-ask text). Bumped
-	// `nonce` retriggers the effect even when the text repeats.
-	const [prefill, setPrefill] = createSignal<{ text: string; nonce: number }>();
+	// `nonce` retriggers the effect even when the text repeats. `mode` controls
+	// how the pre-fill combines with any in-progress draft (replace vs prepend).
+	const [prefill, setPrefill] = createSignal<{ text: string; nonce: number; mode: ComposerPrefillMode }>();
 	// A composer inline-reference insertion request from the native `@@` picker
 	// (Phase 4c): the `@name` label to insert at the caret. `nonce` retriggers the
 	// effect for each pick even when the same label repeats.
@@ -116,7 +118,11 @@ export function App() {
 					setTree(msg.tree);
 					break;
 				case "composer-prefill":
-					setPrefill((prev) => ({ text: msg.text, nonce: (prev?.nonce ?? 0) + 1 }));
+					setPrefill((prev) => ({
+						text: msg.text,
+						nonce: (prev?.nonce ?? 0) + 1,
+						mode: msg.mode ?? "replace",
+					}));
 					break;
 				case "mention-results":
 					// Drop stale (out-of-order) responses: only the latest query's
@@ -676,7 +682,7 @@ export function Composer(props: {
 	streaming: boolean;
 	commands: SlashCommandDto[];
 	attachments: TaggedContextDto[];
-	prefill?: { text: string; nonce: number };
+	prefill?: { text: string; nonce: number; mode: ComposerPrefillMode };
 	mentionInsert?: { label: string; nonce: number };
 	mentionResults: TaggedContextDto[];
 	onRemoveAttachment: (index: number) => void;
@@ -756,11 +762,16 @@ export function Composer(props: {
 		event.preventDefault();
 	};
 
-	// Apply a host-driven pre-fill (a user-message fork's re-ask text). The
-	// `nonce` makes the effect retrigger even when the same text is sent twice.
+	// Apply a host-driven pre-fill. `"replace"` (a user-message fork's re-ask
+	// text) overwrites the composer; `"prepend"` (queued messages restored on
+	// abort) inserts before any in-progress draft so typed text is never lost.
+	// The functional `setText` updater reads the current draft without making
+	// this effect depend on `text()` (which would loop). The `nonce` makes the
+	// effect retrigger even when the same text arrives twice.
 	createEffect(() => {
 		const request = props.prefill;
-		if (request) setText(request.text);
+		if (!request) return;
+		setText((current) => mergeComposerPrefill(request.mode, request.text, current));
 	});
 
 	const menu = createMemo(() => {

--- a/packages/vscode/src/webview/app.tsx
+++ b/packages/vscode/src/webview/app.tsx
@@ -15,6 +15,7 @@ import {
 import type {
 	HostStatus,
 	OpenSourceRef,
+	QueuedMessageDto,
 	ReviewStateDto,
 	SessionTreeDto,
 	SessionTreeNodeDto,
@@ -43,6 +44,9 @@ export function App() {
 	// Inline restore/fork controls (Phase 6), aligned to response groups by id.
 	const [checkpoints, setCheckpoints] = createSignal<Checkpoint[]>([]);
 	const checkpointByResponse = createMemo(() => new Map(checkpoints().map((c) => [c.responseId, c])));
+	// Messages the user queued while the agent was working (steer/follow-up),
+	// shown as chips above the composer until they're delivered to the model.
+	const [pending, setPending] = createSignal<QueuedMessageDto[]>([]);
 	// The session branch tree, shown as an overlay when the user opens it.
 	const [tree, setTree] = createSignal<SessionTreeDto | undefined>();
 	// A composer pre-fill request (a user-message fork's re-ask text). Bumped
@@ -104,6 +108,9 @@ export function App() {
 					break;
 				case "checkpoints":
 					setCheckpoints(msg.checkpoints);
+					break;
+				case "pending":
+					setPending(msg.messages);
 					break;
 				case "tree":
 					setTree(msg.tree);
@@ -279,6 +286,22 @@ export function App() {
 						onClose={() => setTree(undefined)}
 					/>
 				)}
+			</Show>
+
+			<Show when={pending().length > 0}>
+				<div class="dreb-pending-bar" title="Queued while dreb is working — delivered to the model in order">
+					<span class="dreb-pending-title">
+						{pending().length} queued message{pending().length === 1 ? "" : "s"}
+					</span>
+					<For each={pending()}>
+						{(message) => (
+							<span class={`dreb-pending-chip ${message.kind}`} title={message.text}>
+								<span class="dreb-pending-kind">{message.kind}</span>
+								{message.text}
+							</span>
+						)}
+					</For>
+				</div>
 			</Show>
 
 			<Composer

--- a/packages/vscode/src/webview/styles.css
+++ b/packages/vscode/src/webview/styles.css
@@ -300,6 +300,44 @@ body {
 	margin-right: 0;
 }
 
+/* Queued (steer/follow-up) messages waiting to be delivered ---------------- */
+.dreb-pending-bar {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 6px;
+	padding: 6px 12px;
+	border-top: 1px solid var(--vscode-panel-border, rgba(128, 128, 128, 0.25));
+	background: var(--vscode-editorWidget-background, rgba(128, 128, 128, 0.08));
+}
+.dreb-pending-title {
+	font-size: 0.8em;
+	font-weight: 600;
+	color: var(--vscode-descriptionForeground);
+	margin-right: 4px;
+}
+.dreb-pending-chip {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	max-width: 100%;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	font-size: 0.8em;
+	padding: 1px 6px;
+	border-radius: 4px;
+	border: 1px solid var(--vscode-panel-border, rgba(128, 128, 128, 0.3));
+	background: var(--vscode-button-secondaryBackground, transparent);
+	color: var(--vscode-foreground);
+}
+.dreb-pending-kind {
+	font-size: 0.85em;
+	text-transform: uppercase;
+	letter-spacing: 0.03em;
+	color: var(--vscode-descriptionForeground);
+}
+
 
 .dreb-status-line {
 	color: var(--vscode-descriptionForeground);

--- a/packages/vscode/test/composer-prefill.test.ts
+++ b/packages/vscode/test/composer-prefill.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { mergeComposerPrefill } from "../src/shared/composer-prefill.js";
+
+describe("mergeComposerPrefill", () => {
+	it("replace overwrites the current draft", () => {
+		expect(mergeComposerPrefill("replace", "re-ask this", "half-typed thought")).toBe("re-ask this");
+	});
+
+	it("replace applies verbatim to an empty composer", () => {
+		expect(mergeComposerPrefill("replace", "re-ask this", "")).toBe("re-ask this");
+	});
+
+	it("prepend inserts the restored text before an in-progress draft (nothing lost)", () => {
+		expect(mergeComposerPrefill("prepend", "queued one\n\nqueued two", "my new thought")).toBe(
+			"queued one\n\nqueued two\n\nmy new thought",
+		);
+	});
+
+	it("prepend collapses to just the incoming text when the composer is empty", () => {
+		expect(mergeComposerPrefill("prepend", "queued one", "")).toBe("queued one");
+	});
+
+	it("prepend treats a whitespace-only draft as empty (no spurious blank block)", () => {
+		expect(mergeComposerPrefill("prepend", "queued one", "   \n  ")).toBe("queued one");
+	});
+
+	it("prepend preserves the draft's own internal/trailing whitespace when it has real content", () => {
+		expect(mergeComposerPrefill("prepend", "queued", "  keep me  ")).toBe("queued\n\n  keep me  ");
+	});
+});

--- a/packages/vscode/test/session-controller-review.test.ts
+++ b/packages/vscode/test/session-controller-review.test.ts
@@ -21,6 +21,14 @@ class MiniClient implements RpcClientLike {
 	async stop(): Promise<void> {}
 	async prompt(): Promise<void> {}
 	async abort(): Promise<void> {}
+	async steer(): Promise<void> {}
+	async followUp(): Promise<void> {}
+	async getPendingMessages(): Promise<{ steering: string[]; followUp: string[] }> {
+		return { steering: [], followUp: [] };
+	}
+	async clearPendingMessages(): Promise<{ steering: string[]; followUp: string[] }> {
+		return { steering: [], followUp: [] };
+	}
 	async compact(): Promise<unknown> {
 		return {};
 	}

--- a/packages/vscode/test/session-controller.test.ts
+++ b/packages/vscode/test/session-controller.test.ts
@@ -1216,11 +1216,13 @@ describe("SessionController", () => {
 			expect(fake.clearPendingCalls).toBe(1);
 			expect(fake.pendingSteering).toEqual([]);
 			// The queued text is restored to the composer (joined, in order) rather
-			// than silently lost.
+			// than silently lost. `mode: "prepend"` tells the composer to insert
+			// before any in-progress draft rather than overwrite it.
 			const prefill = updates.filter(
 				(u): u is Extract<ControllerUpdate, { kind: "composer-prefill" }> => u.kind === "composer-prefill",
 			);
 			expect(prefill.at(-1)?.text).toBe("first follow-up\n\nsecond follow-up");
+			expect(prefill.at(-1)?.mode).toBe("prepend");
 			// And the chips are cleared.
 			expect(controller.getPending()).toEqual([]);
 		});

--- a/packages/vscode/test/session-controller.test.ts
+++ b/packages/vscode/test/session-controller.test.ts
@@ -1613,18 +1613,22 @@ describe("SessionController session tree (Phase 6)", () => {
 		fake.forkResult = { text: "re-ask this", cancelled: false };
 		const controller = makeController(fake);
 		await controller.start();
-		const prefills: string[] = [];
+		const prefills: Array<{ text: string; mode?: string }> = [];
 		controller.onUpdate((u) => {
-			if ((u as { kind: string }).kind === "composer-prefill") prefills.push((u as { text: string }).text);
+			if ((u as { kind: string }).kind === "composer-prefill") prefills.push(u as { text: string; mode?: string });
 		});
 
 		await controller.fork("u2");
-		expect(prefills).toEqual(["re-ask this"]);
+		expect(prefills.map((p) => p.text)).toEqual(["re-ask this"]);
+		// Fork re-ask must REPLACE the composer: it omits `mode`, so the webview
+		// defaults to "replace". A "prepend" here would jam re-ask text in front of
+		// whatever the user had typed — the opposite of what a fork intends.
+		expect(prefills.at(-1)?.mode).toBeUndefined();
 
 		// Assistant fork returns "" → no composer clobber.
 		fake.forkResult = { text: "", cancelled: false };
 		await controller.fork("a1");
-		expect(prefills).toEqual(["re-ask this"]);
+		expect(prefills.map((p) => p.text)).toEqual(["re-ask this"]);
 	});
 
 	it("surfaces a notice and does not rebuild when a fork is cancelled", async () => {

--- a/packages/vscode/test/session-controller.test.ts
+++ b/packages/vscode/test/session-controller.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { HostUi, HostUiPickItem, WorkspaceSearchResult } from "../src/host/host-ui.js";
-import { type RpcClientLike, SessionController } from "../src/host/session-controller.js";
+import { type ControllerUpdate, type RpcClientLike, SessionController } from "../src/host/session-controller.js";
 import type { SourceLinkUi } from "../src/host/source-link-ui.js";
 import type { OpenSourceRef, SessionTreeNodeDto } from "../src/shared/protocol.js";
 
@@ -108,6 +108,34 @@ class FakeClient implements RpcClientLike {
 	async abort(): Promise<void> {
 		if (this.callError) throw this.callError;
 		this.aborted += 1;
+	}
+	// Queued messages (steer/follow-up). `steer`/`followUp` mirror the backend by
+	// both recording the call and appending to the pending queue that
+	// `getPendingMessages` reports and `clearPendingMessages` drains.
+	steers: string[] = [];
+	followUps: string[] = [];
+	pendingSteering: string[] = [];
+	pendingFollowUp: string[] = [];
+	clearPendingCalls = 0;
+	async steer(message: string): Promise<void> {
+		if (this.callError) throw this.callError;
+		this.steers.push(message);
+		this.pendingSteering.push(message);
+	}
+	async followUp(message: string): Promise<void> {
+		if (this.callError) throw this.callError;
+		this.followUps.push(message);
+		this.pendingFollowUp.push(message);
+	}
+	async getPendingMessages(): Promise<{ steering: string[]; followUp: string[] }> {
+		return { steering: [...this.pendingSteering], followUp: [...this.pendingFollowUp] };
+	}
+	async clearPendingMessages(): Promise<{ steering: string[]; followUp: string[] }> {
+		this.clearPendingCalls += 1;
+		const cleared = { steering: [...this.pendingSteering], followUp: [...this.pendingFollowUp] };
+		this.pendingSteering = [];
+		this.pendingFollowUp = [];
+		return cleared;
 	}
 	async compact(customInstructions?: string): Promise<unknown> {
 		if (this.callError) throw this.callError;
@@ -1112,6 +1140,105 @@ describe("SessionController", () => {
 		await controller.start();
 		await controller.dispose();
 		expect(fake.stopped).toBe(1);
+	});
+
+	describe("queued composer messages (steer + pending display + restore on abort)", () => {
+		it("queues a submit made while streaming via steer (not prompt) and shows a pending chip", async () => {
+			const fake = new FakeClient();
+			const controller = makeController(fake);
+			await controller.start();
+			const updates: ControllerUpdate[] = [];
+			controller.onUpdate((u) => updates.push(u));
+
+			fake.emit({ type: "agent_start" }); // now streaming
+			await controller.submit("keep going, also check the tests");
+
+			// Routed to steer, never to the (mid-stream-rejecting) prompt path.
+			expect(fake.steers).toEqual(["keep going, also check the tests"]);
+			expect(fake.prompts).toEqual([]);
+			// The queued message is published for display.
+			const pending = updates.filter(
+				(u): u is Extract<ControllerUpdate, { kind: "pending" }> => u.kind === "pending",
+			);
+			expect(pending.at(-1)?.messages).toEqual([{ kind: "steer", text: "keep going, also check the tests" }]);
+			expect(controller.getPending()).toEqual([{ kind: "steer", text: "keep going, also check the tests" }]);
+		});
+
+		it("sends a submit as a normal prompt when the agent is idle", async () => {
+			const fake = new FakeClient();
+			const controller = makeController(fake);
+			await controller.start();
+
+			await controller.submit("hello");
+
+			expect(fake.prompts).toEqual(["hello"]);
+			expect(fake.steers).toEqual([]);
+			expect(controller.getPending()).toEqual([]);
+		});
+
+		it("clears the pending chip once the steered message is delivered mid-run", async () => {
+			const fake = new FakeClient();
+			const controller = makeController(fake);
+			await controller.start();
+			fake.emit({ type: "agent_start" });
+			await controller.submit("keep going");
+			expect(controller.getPending()).toHaveLength(1);
+
+			const updates: ControllerUpdate[] = [];
+			controller.onUpdate((u) => updates.push(u));
+			// The backend delivers the steered message (drops it from its queue) and
+			// streams it back as a user turn.
+			fake.pendingSteering = [];
+			fake.emit({ type: "message_start", message: { role: "user", content: "keep going" } });
+			await Promise.resolve(); // let the void refreshPending() settle
+
+			const pending = updates.filter(
+				(u): u is Extract<ControllerUpdate, { kind: "pending" }> => u.kind === "pending",
+			);
+			expect(pending.at(-1)?.messages).toEqual([]);
+			expect(controller.getPending()).toEqual([]);
+		});
+
+		it("restores queued messages to the composer and clears the backend queue on abort", async () => {
+			const fake = new FakeClient();
+			const controller = makeController(fake);
+			await controller.start();
+			fake.emit({ type: "agent_start" });
+			await controller.submit("first follow-up");
+			await controller.submit("second follow-up");
+			expect(controller.getPending()).toHaveLength(2);
+
+			const updates: ControllerUpdate[] = [];
+			controller.onUpdate((u) => updates.push(u));
+			await controller.abort();
+
+			expect(fake.aborted).toBe(1);
+			expect(fake.clearPendingCalls).toBe(1);
+			expect(fake.pendingSteering).toEqual([]);
+			// The queued text is restored to the composer (joined, in order) rather
+			// than silently lost.
+			const prefill = updates.filter(
+				(u): u is Extract<ControllerUpdate, { kind: "composer-prefill" }> => u.kind === "composer-prefill",
+			);
+			expect(prefill.at(-1)?.text).toBe("first follow-up\n\nsecond follow-up");
+			// And the chips are cleared.
+			expect(controller.getPending()).toEqual([]);
+		});
+
+		it("does not prefill the composer on abort when nothing is queued", async () => {
+			const fake = new FakeClient();
+			const controller = makeController(fake);
+			await controller.start();
+			fake.emit({ type: "agent_start" });
+
+			const updates: ControllerUpdate[] = [];
+			controller.onUpdate((u) => updates.push(u));
+			await controller.abort();
+
+			expect(fake.aborted).toBe(1);
+			expect(fake.clearPendingCalls).toBe(1);
+			expect(updates.some((u) => u.kind === "composer-prefill")).toBe(false);
+		});
 	});
 
 	describe("hasFailed() (Phase 9 — reopen restarts a crashed session)", () => {

--- a/packages/vscode/test/webview-bridge.test.ts
+++ b/packages/vscode/test/webview-bridge.test.ts
@@ -563,12 +563,20 @@ describe("connectWebview", () => {
 		});
 		(controller as any).emit({ kind: "tree", tree: { roots: [], leafId: "a2" } });
 		(controller as any).emit({ kind: "composer-prefill", text: "re-ask" });
+		(controller as any).emit({ kind: "composer-prefill", text: "restored", mode: "prepend" });
 
 		expect((posted.filter((m) => m.type === "checkpoints").at(-1) as any)?.checkpoints).toEqual([
 			{ responseId: 2, entryId: "a2", canRestore: true, canFork: true },
 		]);
 		expect((posted.find((m) => m.type === "tree") as any)?.tree.leafId).toBe("a2");
+		// A replace-style prefill (fork re-ask) carries no mode; the bridge passes that through.
 		expect((posted.find((m) => m.type === "composer-prefill") as any)?.text).toBe("re-ask");
+		expect((posted.find((m) => m.type === "composer-prefill") as any)?.mode).toBeUndefined();
+		// The abort restore tags the prefill "prepend"; the bridge must forward the mode
+		// verbatim or the webview silently falls back to replace and clobbers the draft.
+		const prepend = posted.filter((m) => m.type === "composer-prefill").at(-1) as any;
+		expect(prepend?.text).toBe("restored");
+		expect(prepend?.mode).toBe("prepend");
 	});
 
 	it("re-posts checkpoints on a resync update", async () => {

--- a/packages/vscode/test/webview-bridge.test.ts
+++ b/packages/vscode/test/webview-bridge.test.ts
@@ -25,6 +25,14 @@ class BridgeFakeClient implements RpcClientLike {
 	async stop(): Promise<void> {}
 	async prompt(): Promise<void> {}
 	async abort(): Promise<void> {}
+	async steer(): Promise<void> {}
+	async followUp(): Promise<void> {}
+	async getPendingMessages(): Promise<{ steering: string[]; followUp: string[] }> {
+		return { steering: [], followUp: [] };
+	}
+	async clearPendingMessages(): Promise<{ steering: string[]; followUp: string[] }> {
+		return { steering: [], followUp: [] };
+	}
 	async compact(): Promise<unknown> {
 		return {};
 	}


### PR DESCRIPTION
Closes #45

Enables queued/pending composer messages in the VSCode extension: sending while the agent is working steers the running turn (instead of being swallowed), pending messages are displayed as chips, and on interruption the queued text is restored to the composer rather than lost.

Implementation plan posted as a comment below.
