### PR TITLE
VSCode extension: sticky-bottom chat auto-scroll (don't jump when scrolled up)

### DIFF
--- a/packages/vscode/src/webview/app.tsx
+++ b/packages/vscode/src/webview/app.tsx
@@ -25,6 +25,7 @@ import type {
 import { taggedContextLabel, taggedContextTitle } from "../shared/tagged-context.js";
 import { buildGroundedRefs, linkifyAnswer } from "./code-links.js";
 import { renderMarkdown } from "./markdown.js";
+import { bindStickToBottom, createStickToBottom } from "./scrolling.js";
 import { onHostMessage, postToHost } from "./vscode-api.js";
 
 export function App() {
@@ -59,9 +60,12 @@ export function App() {
 	const [tick, setTick] = createSignal(0);
 
 	let scrollEl: HTMLDivElement | undefined;
-	const scrollToBottom = () => {
-		if (scrollEl) scrollEl.scrollTop = scrollEl.scrollHeight;
-	};
+	let transcriptInnerEl: HTMLDivElement | undefined;
+	// Sticky-bottom autoscroll: follow new output only while the user is at the
+	// bottom. A manual scroll-up releases follow (so the view stays put as more
+	// output streams in); a deliberate scroll back to the bottom re-engages it.
+	// Shared controller vendored from the dashboard — see ./scrolling.ts.
+	const stickToBottom = createStickToBottom({ scroller: () => scrollEl });
 
 	onMount(() => {
 		const off = onHostMessage((msg) => {
@@ -107,11 +111,24 @@ export function App() {
 		onCleanup(off);
 	});
 
-	// Keep the transcript pinned to the latest output on any update.
+	// Follow the latest output on any update, but only while the user is pinned to
+	// the bottom. The controller re-reads the live follow state at fire time, so a
+	// manual scroll-up is respected even as more output streams in.
 	createEffect(() => {
 		tick();
-		queueMicrotask(scrollToBottom);
+		stickToBottom.notifyContentChanged();
 	});
+	// Re-pin when content grows asynchronously (e.g. late markdown/syntax
+	// rendering after a store update) and when the scroll viewport resizes
+	// (surrounding chrome — review bar, composer — changing clientHeight with no
+	// content change and no scroll event). Bind the scroll/wheel/key/touch
+	// listeners that drive follow-release detection once the scroller exists.
+	onMount(() => {
+		stickToBottom.observeContent(transcriptInnerEl);
+		stickToBottom.observeViewport(scrollEl);
+		if (scrollEl) onCleanup(bindStickToBottom(stickToBottom, scrollEl, { keyboard: "window" }));
+	});
+	onCleanup(() => stickToBottom.dispose());
 
 	const respondUi = (response: UiResponse) => postToHost({ type: "ui-response", response });
 
@@ -211,28 +228,32 @@ export function App() {
 			</Show>
 
 			<div class="dreb-transcript" ref={scrollEl}>
-				<For each={state.items}>
-					{(item) =>
-						item.kind === "user" ? (
-							<div class="dreb-user">{item.text}</div>
-						) : item.kind === "system" ? (
-							<pre class="dreb-system">{item.text}</pre>
-						) : (
-							<>
-								<ResponseView group={item} />
-								<Show when={checkpointByResponse().get(item.id)}>
-									{(checkpoint) => <CheckpointBar checkpoint={checkpoint()} />}
-								</Show>
-							</>
-						)
-					}
-				</For>
+				<div class="dreb-transcript-inner" ref={transcriptInnerEl}>
+					<For each={state.items}>
+						{(item) =>
+							item.kind === "user" ? (
+								<div class="dreb-user">{item.text}</div>
+							) : item.kind === "system" ? (
+								<pre class="dreb-system">{item.text}</pre>
+							) : (
+								<>
+									<ResponseView group={item} />
+									<Show when={checkpointByResponse().get(item.id)}>
+										{(checkpoint) => <CheckpointBar checkpoint={checkpoint()} />}
+									</Show>
+								</>
+							)
+						}
+					</For>
 
-				<For each={state.uiRequests}>{(request) => <UiRequestView request={request} onRespond={respondUi} />}</For>
+					<For each={state.uiRequests}>
+						{(request) => <UiRequestView request={request} onRespond={respondUi} />}
+					</For>
 
-				<Show when={state.statusText}>
-					<div class="dreb-status-line">{state.statusText}</div>
-				</Show>
+					<Show when={state.statusText}>
+						<div class="dreb-status-line">{state.statusText}</div>
+					</Show>
+				</div>
 			</div>
 
 			<Show when={tree()}>

--- a/packages/vscode/src/webview/scrolling.ts
+++ b/packages/vscode/src/webview/scrolling.ts
@@ -1,0 +1,613 @@
+/**
+ * Scroll helpers shared by live transcript surfaces.
+ *
+ * Vendored copy of `packages/dashboard/src/client/scrolling.ts`. The VSCode
+ * extension mirrors dashboard client patterns per-package (like
+ * `packages/vscode/src/shared/format.ts`) rather than depending on the full
+ * `@dreb/dashboard` package, so this controller lives here verbatim. Keep the
+ * two files in sync when either changes.
+ */
+
+export interface CoalescedBottomScrollerOptions<T extends { scrollTop: number; scrollHeight: number }> {
+	element: () => T | undefined;
+	shouldScroll: () => boolean;
+	requestAnimationFrame?: typeof requestAnimationFrame;
+	cancelAnimationFrame?: typeof cancelAnimationFrame;
+}
+
+export interface CoalescedBottomScroller {
+	request: () => void;
+	cancel: () => void;
+}
+
+/**
+ * Schedule a single double-rAF bottom scroll. Repeated requests while either
+ * frame is pending are coalesced; the live conditions are re-read only at fire
+ * time so stale effects cannot force a scroll after the user scrolls away.
+ */
+export function createCoalescedBottomScroller<T extends { scrollTop: number; scrollHeight: number }>(
+	options: CoalescedBottomScrollerOptions<T>,
+): CoalescedBottomScroller {
+	const raf = options.requestAnimationFrame ?? requestAnimationFrame;
+	const cancelRaf = options.cancelAnimationFrame ?? cancelAnimationFrame;
+	let firstFrame: number | undefined;
+	let secondFrame: number | undefined;
+
+	function cancel(): void {
+		if (firstFrame !== undefined) cancelRaf(firstFrame);
+		if (secondFrame !== undefined) cancelRaf(secondFrame);
+		firstFrame = undefined;
+		secondFrame = undefined;
+	}
+
+	function request(): void {
+		if (firstFrame !== undefined || secondFrame !== undefined) return;
+		firstFrame = raf(() => {
+			firstFrame = undefined;
+			secondFrame = raf(() => {
+				secondFrame = undefined;
+				const element = options.element();
+				if (element && options.shouldScroll()) element.scrollTop = element.scrollHeight;
+			});
+		});
+	}
+
+	return { request, cancel };
+}
+
+export interface StickToBottomOptions {
+	/** The element that actually scrolls (its `scrollTop` is driven to the bottom). */
+	scroller: () => HTMLElement | undefined;
+	/** Distance from the bottom (px) still treated as "at the bottom". */
+	threshold?: number;
+	requestAnimationFrame?: typeof requestAnimationFrame;
+	cancelAnimationFrame?: typeof cancelAnimationFrame;
+	/** Injectable for tests; defaults to the global `ResizeObserver` when present. */
+	ResizeObserverImpl?: typeof ResizeObserver;
+	/** Injectable clock (ms) for the upward-intent fallback window; defaults to `Date.now`. */
+	now?: () => number;
+	/**
+	 * Bounded FALLBACK for how long (ms) a discrete upward input (wheel-up /
+	 * scroll-up key / lifted upward touch) can still authorize a follow release
+	 * when the platform never delivers a `scrollend`. The primary clearing
+	 * mechanism is sequence-scoped: `handleScrollEnd` (the scroll sequence
+	 * settled) and any downward movement clear intent immediately. Defaults to
+	 * 400ms.
+	 */
+	intentWindowMs?: number;
+}
+
+export interface StickToBottomController {
+	/** Call whenever transcript content changes (e.g. per store revision). */
+	notifyContentChanged: () => void;
+	/** Bind to the scroller's `scroll` event. */
+	handleScroll: () => void;
+	/**
+	 * Bind to the scroller's `scrollend` event — the scroll sequence settled, so
+	 * any discrete upward intent is consumed and cleared.
+	 */
+	handleScrollEnd: () => void;
+	/**
+	 * Bind to the scroller's `wheel` event — arms upward intent when scrolling
+	 * up. Pass the event target: a wheel over a nested inner scroller (e.g. a
+	 * bash-output `<pre>` that can still scroll up) is consumed by that inner
+	 * element and must NOT arm intent on this controller.
+	 */
+	handleWheel: (deltaY: number, target?: EventTarget | null) => void;
+	/**
+	 * Bind to a `keydown` event — arms directional user intent for scroll
+	 * navigation keys. Pass the event target so a nested scrollable that will
+	 * consume an upward key does not arm the outer controller. The caller is
+	 * responsible for not forwarding keys consumed by an editable target.
+	 */
+	handleKeyDown: (key: string, shiftKey?: boolean, target?: EventTarget | null) => void;
+	/**
+	 * Bind to the scroller's `pointerdown`. Pass `onScrollbar: true` only when
+	 * the press landed on the scrollbar region — a plain click / text-selection
+	 * press must NOT arm upward intent (a concurrent layout reflow would
+	 * otherwise be misread as a scrollbar up-drag).
+	 */
+	handlePointerDown: (onScrollbar: boolean) => void;
+	/** Bind to `pointerup`/`pointercancel` (window-level so state cannot stick). */
+	handlePointerUp: () => void;
+	/** Bind to the scroller's `touchstart` event (suspends pinning during a drag). */
+	handleTouchStart: (clientY?: number) => void;
+	/**
+	 * Bind to the scroller's `touchmove` event with the touch's `clientY` and
+	 * event target. Directional: a finger moving DOWN the screen (clientY
+	 * increasing) drags the content down, i.e. scrolls UP — that arms upward
+	 * intent unless a nested scroller consumes it. Movement in the other
+	 * direction arms downward intent under the same routing rule.
+	 */
+	handleTouchMove: (clientY: number, target?: EventTarget | null) => void;
+	/** Bind to the scroller's `touchend` event (ends the drag and replays the pin). */
+	handleTouchEnd: () => void;
+	/** Bind to the scroller's `touchcancel` event (same finish path as touchend). */
+	handleTouchCancel: () => void;
+	/** Observe a content element so async growth (e.g. late tool output) re-pins. */
+	observeContent: (element: Element | undefined) => void;
+	/**
+	 * Observe the scroll *viewport* element so that surrounding-chrome resizes
+	 * (tasks list / subagent strip toggling, composer textarea auto-growing) that
+	 * change `clientHeight` — without a content change or a scroll event — re-pin.
+	 */
+	observeViewport: (element: Element | undefined) => void;
+	/** Current follow state — exposed for tests and diagnostics. */
+	isFollowing: () => boolean;
+	/** Tear down observers and pending frames. */
+	dispose: () => void;
+}
+
+/**
+ * Walk from an input event's target up to (but excluding) the scroller looking
+ * for a nested scrollable element that can consume that direction. Both wheel
+ * and keyboard events bubble from the focusable tool-output `<pre>`; when that
+ * nested element will move, the outer scroller must not inherit its intent.
+ */
+function inputConsumedByNestedScroller(
+	target: EventTarget | null | undefined,
+	scroller: HTMLElement,
+	direction: "up" | "down",
+): boolean {
+	let node: Node | null = target instanceof Node ? target : null;
+	while (node && node !== scroller) {
+		if (node instanceof HTMLElement && node.scrollHeight > node.clientHeight + 1) {
+			const canConsume =
+				direction === "up" ? node.scrollTop > 0 : node.scrollTop + node.clientHeight < node.scrollHeight - 1;
+			const overflowY = typeof getComputedStyle === "function" ? getComputedStyle(node).overflowY : "";
+			if (canConsume && (overflowY === "auto" || overflowY === "scroll")) return true;
+		}
+		node = node.parentNode;
+	}
+	return false;
+}
+
+/**
+ * Stick-to-bottom follow controller shared by live transcript surfaces.
+ *
+ * Follow intent is released only on a genuine user **up-scroll**, and never
+ * re-derived from absolute at-bottom geometry. A release requires BOTH signals:
+ *
+ *  1. the scroller's `scrollTop` actually decreased (`top < lastTop - 1`), and
+ *  2. a genuine upward user input authorized it — an upward touch drag, an
+ *     active scrollbar drag, or a recent wheel-up / scroll-up key press whose
+ *     scroll sequence has not yet settled.
+ *
+ * Requirement 1 alone is not enough: at an assistant→tool boundary the outer
+ * transcript reflows (the streamed message is replaced by its authoritative
+ * full-markdown render and a tool card is appended below), and the browser can
+ * *lower* `scrollTop` during that relayout with no user input. Treating that
+ * layout-induced decrease as a user up-scroll is exactly the silent follow
+ * drop-out this controller exists to remove.
+ *
+ * Requirement 2 is **sequence-scoped**, not merely time-windowed:
+ *  - a wheel-up arms intent only when the outer scroller (not a nested inner
+ *    scroller that can still scroll up) will consume it;
+ *  - intent is cleared as soon as the scroll sequence settles (`scrollend`) or
+ *    any downward movement occurs;
+ *  - a bounded time window remains only as a fallback for platforms without
+ *    `scrollend`.
+ *  - touch is directional: intent arms only while the finger movement would
+ *    lower `scrollTop`, and survives past `touchend` through the inertial
+ *    scroll until the sequence settles;
+ *  - a pointer press arms only when it lands on the scrollbar region — plain
+ *    clicks and text-selection drags never authorize a release.
+ *
+ * Appended content grows `scrollHeight` without decreasing `scrollTop`, so it
+ * can never reach the release branch either way. Two `ResizeObserver`s keep the
+ * view pinned when geometry changes without a scroll event: `observeContent`
+ * re-pins when the transcript *content* grows after the last envelope (e.g.
+ * throttled syntax highlighting of a long tool output), and `observeViewport`
+ * re-pins when the scroll *viewport* itself resizes (surrounding chrome such as
+ * the tasks list, subagent strip, or auto-growing composer changes
+ * `clientHeight`). An active touch drag suspends pinning so the view never
+ * yanks out from under the user's finger.
+ */
+export function createStickToBottom(options: StickToBottomOptions): StickToBottomController {
+	const threshold = options.threshold ?? 40;
+	const now = options.now ?? (() => Date.now());
+	const intentWindowMs = options.intentWindowMs ?? 400;
+	const ResizeObserverImpl =
+		options.ResizeObserverImpl ?? (globalThis as { ResizeObserver?: typeof ResizeObserver }).ResizeObserver;
+	let following = true;
+	let gestureActive = false;
+	// Directional touch state: the finger's last known clientY, and whether the
+	// most recent movement expressed an up-scroll (finger moving DOWN the screen
+	// lowers scrollTop). Only an upward touch authorizes a release; a stationary
+	// hold or a downward drag never does.
+	let lastTouchY: number | undefined;
+	let touchUpwardIntent = false;
+	let touchDownwardIntent = false;
+	// True while a scrollbar drag is active (pointer pressed on the scrollbar
+	// region). Plain clicks / text-selection presses do NOT set this.
+	let scrollbarDragActive = false;
+	// Timestamps of the last discrete input. Sequence-scoped clearing (scrollend
+	// and movement in the opposite direction) is primary; these stamps plus
+	// intentWindowMs are only the bounded fallback for platforms without scrollend.
+	let lastUpwardIntentAt = Number.NEGATIVE_INFINITY;
+	let lastDownwardIntentAt = Number.NEGATIVE_INFINITY;
+	let lastTop = 0;
+	// Keep the start of an upward sequence separate from lastTop. Precision
+	// trackpads can emit fractional (or exactly 1px) decreases; advancing lastTop
+	// after each of those jitter-sized events used to discard their cumulative
+	// deliberate movement before it could release follow.
+	let upwardSequenceBaseline = 0;
+	let contentObserver: ResizeObserver | undefined;
+	let viewportObserver: ResizeObserver | undefined;
+	let warnedMissingObserver = false;
+
+	const scroller = createCoalescedBottomScroller({
+		element: options.scroller,
+		shouldScroll: () => {
+			if (!(following && !gestureActive)) return false;
+			// About to pin to the bottom: record the *resting* scrollTop the browser
+			// will settle at after `scrollTop = scrollHeight` (it clamps to
+			// `scrollHeight - clientHeight`), NOT the raw scrollHeight. `lastTop` is
+			// compared against real `scrollTop` values in handleScroll; seeding it
+			// with a height leaves it ~clientHeight too high, so the pin's own async
+			// echo scroll event — or a concurrent content growth before that echo
+			// fires — reads as a user up-scroll and silently latches follow off.
+			const el = options.scroller();
+			if (el) {
+				lastTop = Math.max(0, el.scrollHeight - el.clientHeight);
+				upwardSequenceBaseline = lastTop;
+			}
+			return true;
+		},
+		requestAnimationFrame: options.requestAnimationFrame,
+		cancelAnimationFrame: options.cancelAnimationFrame,
+	});
+
+	function armUpwardIntent(): void {
+		// A new upward input supersedes any prior downward sequence.
+		clearDownwardDiscreteIntent();
+		if (now() - lastUpwardIntentAt > intentWindowMs) {
+			// A first user input can precede this controller's first scroll event.
+			// Seed from the live position, not the default zero, so its initial tiny
+			// scroll deltas still accumulate against the true resting point.
+			const top = options.scroller()?.scrollTop ?? lastTop;
+			// Event listeners normally run before the browser applies the scroll, but
+			// programmatic callers/tests may present the moved position first. The
+			// higher known position is the only valid start for an up-scroll sequence.
+			upwardSequenceBaseline = Math.max(lastTop, top);
+		}
+		lastUpwardIntentAt = now();
+	}
+	function armDownwardIntent(): void {
+		// A new downward input supersedes any prior upward discrete sequence before
+		// its scroll event arrives; otherwise a reflow between opposite-direction
+		// keys/wheels could still consume the stale upward authorization.
+		clearUpwardDiscreteIntent();
+		upwardSequenceBaseline = lastTop;
+		lastDownwardIntentAt = now();
+	}
+	function clearUpwardDiscreteIntent(): void {
+		lastUpwardIntentAt = Number.NEGATIVE_INFINITY;
+	}
+	function clearDownwardDiscreteIntent(): void {
+		lastDownwardIntentAt = Number.NEGATIVE_INFINITY;
+	}
+	function resetUpwardSequence(top: number): void {
+		clearUpwardDiscreteIntent();
+		upwardSequenceBaseline = top;
+	}
+	// A follow release is authorized only by a genuine upward user input: an
+	// upward touch drag, an active scrollbar drag, or a discrete wheel/keyboard
+	// up-scroll whose scroll sequence has not yet settled.
+	function upwardIntentActive(): boolean {
+		return (
+			(gestureActive && touchUpwardIntent) || scrollbarDragActive || now() - lastUpwardIntentAt <= intentWindowMs
+		);
+	}
+	// A released reader only re-engages after genuine downward input and an actual
+	// downward scroll arrival at the bottom. Geometry-only clamp events caused by
+	// content shrink must never turn follow back on.
+	function downwardIntentActive(): boolean {
+		return (
+			(gestureActive && touchDownwardIntent) || scrollbarDragActive || now() - lastDownwardIntentAt <= intentWindowMs
+		);
+	}
+
+	function notifyContentChanged(): void {
+		if (following && !gestureActive) scroller.request();
+	}
+	function handleScroll(): void {
+		const el = options.scroller();
+		if (!el) return;
+		const top = el.scrollTop;
+		const anyDownwardMovement = top > lastTop;
+		const atBottom = top + el.clientHeight >= el.scrollHeight - threshold;
+		if (atBottom && (following || (anyDownwardMovement && downwardIntentActive()))) {
+			// Initial/programmatic following stays engaged. Once released, however,
+			// only a real downward user return to the bottom may re-engage it. Do not
+			// consume an already-armed upward input merely because its first scroll
+			// event still lies within the bottom threshold.
+			following = true;
+			if (!upwardIntentActive() || anyDownwardMovement) resetUpwardSequence(top);
+		} else if (following && top < upwardSequenceBaseline - 1 && upwardIntentActive()) {
+			// Moved up cumulatively from a stable sequence baseline AND a genuine
+			// upward input authorized it — release follow. The separate baseline lets
+			// fractional/exact-1px scroll events accumulate past the jitter threshold.
+			following = false;
+		} else if (anyDownwardMovement) {
+			// Downward movement ends any upward sequence: a stale wheel-up/key stamp
+			// must not survive an intervening down-scroll to authorize a later
+			// layout-induced decrease.
+			resetUpwardSequence(top);
+		} else if (!upwardIntentActive()) {
+			// With no live upward sequence, layout movement is merely a new resting
+			// baseline; it must not contaminate a later genuine input sequence.
+			upwardSequenceBaseline = top;
+		}
+		lastTop = top;
+	}
+	function handleScrollEnd(): void {
+		// The scroll sequence settled — discrete input is consumed. This is the
+		// primary clearing mechanism; intentWindowMs is only a fallback.
+		clearUpwardDiscreteIntent();
+		clearDownwardDiscreteIntent();
+		upwardSequenceBaseline = lastTop;
+	}
+
+	const SCROLL_UP_KEYS = new Set(["ArrowUp", "PageUp", "Home"]);
+	function handleWheel(deltaY: number, target?: EventTarget | null): void {
+		const el = options.scroller();
+		if (deltaY < 0) {
+			// Wheel/trackpad up. This only *arms* intent; a release still requires the
+			// outer scroller's scrollTop to actually decrease. Additionally, a wheel
+			// over a nested inner scroller (e.g. a bash-output <pre>) that can still
+			// scroll up is consumed by that inner element — the outer scroller will not
+			// move — so arming here would leave a live intent stamp that an unrelated
+			// layout reflow could later hijack into a false release.
+			if (el && target && inputConsumedByNestedScroller(target, el, "up")) return;
+			armUpwardIntent();
+		} else if (deltaY > 0) {
+			if (el && target && inputConsumedByNestedScroller(target, el, "down")) return;
+			armDownwardIntent();
+		}
+	}
+	function handleKeyDown(key: string, shiftKey = false, target?: EventTarget | null): void {
+		const el = options.scroller();
+		if (SCROLL_UP_KEYS.has(key) || (shiftKey && key === " ")) {
+			if (el && target && inputConsumedByNestedScroller(target, el, "up")) return;
+			armUpwardIntent();
+		} else if (key === "ArrowDown" || key === "PageDown" || key === "End" || (!shiftKey && key === " ")) {
+			if (el && target && inputConsumedByNestedScroller(target, el, "down")) return;
+			armDownwardIntent();
+		}
+	}
+	function handlePointerDown(onScrollbar: boolean): void {
+		// Only a scrollbar-region press can express scroll intent. A plain click or
+		// text-selection press must not — otherwise a layout-induced scrollTop
+		// decrease while the pointer happens to be held would falsely release.
+		if (onScrollbar) scrollbarDragActive = true;
+	}
+	function handlePointerUp(): void {
+		scrollbarDragActive = false;
+	}
+
+	function handleTouchStart(clientY?: number): void {
+		gestureActive = true;
+		lastTouchY = Number.isFinite(clientY) ? clientY : undefined;
+		touchUpwardIntent = false;
+		touchDownwardIntent = false;
+	}
+
+	function handleTouchMove(clientY: number, target?: EventTarget | null): void {
+		if (!gestureActive || !Number.isFinite(clientY)) return;
+		if (lastTouchY !== undefined) {
+			const el = options.scroller();
+			// Finger moving DOWN the screen drags content down = scrolls UP.
+			if (clientY > lastTouchY + 1) {
+				if (el && target && inputConsumedByNestedScroller(target, el, "up")) {
+					touchUpwardIntent = false;
+					touchDownwardIntent = false;
+					clearUpwardDiscreteIntent();
+					clearDownwardDiscreteIntent();
+				} else {
+					touchUpwardIntent = true;
+					touchDownwardIntent = false;
+					armUpwardIntent();
+				}
+			} else if (clientY < lastTouchY - 1) {
+				if (el && target && inputConsumedByNestedScroller(target, el, "down")) {
+					touchUpwardIntent = false;
+					touchDownwardIntent = false;
+					clearUpwardDiscreteIntent();
+					clearDownwardDiscreteIntent();
+				} else {
+					touchUpwardIntent = false;
+					touchDownwardIntent = true;
+					armDownwardIntent();
+				}
+			}
+		}
+		lastTouchY = clientY;
+	}
+
+	function finishGesture(): void {
+		gestureActive = false;
+		lastTouchY = undefined;
+		if (touchUpwardIntent) {
+			// The finger lifted mid-up-scroll: inertial scrolling continues AFTER
+			// touchend, and its first significant decrease must still be able to
+			// release. Convert the directional touch intent into a discrete stamp
+			// that survives until the sequence settles (scrollend) or the bounded
+			// fallback expires.
+			armUpwardIntent();
+		} else if (touchDownwardIntent) {
+			// Preserve a downward fling long enough for an actual arrival at bottom
+			// to re-engage an intentionally released transcript.
+			armDownwardIntent();
+		}
+		touchUpwardIntent = false;
+		touchDownwardIntent = false;
+		// Do NOT re-derive follow from absolute at-bottom geometry — that is the
+		// latch-off bug this controller exists to remove. handleScroll (which fires
+		// during the drag) already owns follow state via up-scroll detection, so if
+		// the user did not scroll up, `following` is still true even when content
+		// grew during the gesture. Just replay the pin that gestureActive suppressed.
+		if (following) scroller.request();
+	}
+
+	function handleTouchEnd(): void {
+		finishGesture();
+	}
+
+	function handleTouchCancel(): void {
+		// touchcancel (system gesture takeover, too many touch points, etc.) fires
+		// *instead of* touchend. Without clearing gestureActive here it would stay
+		// true forever, silently suppressing every pin until the next complete touch
+		// sequence — a real mobile follow drop-out. Same finish path as touchend.
+		finishGesture();
+	}
+
+	function makeObserver(element: Element): ResizeObserver | undefined {
+		if (!ResizeObserverImpl) {
+			// The observer-driven re-pin is a core part of the follow fix; if the
+			// platform lacks ResizeObserver we lose it silently. Surface that rather
+			// than degrading quietly (repo convention: loud failure over silent
+			// fallback). ResizeObserver is baseline in all target browsers, so this
+			// should never fire in practice. Warn once per controller so a screen
+			// with both content and viewport observers doesn't double-log.
+			if (!warnedMissingObserver) {
+				warnedMissingObserver = true;
+				console.warn(
+					"[dashboard] ResizeObserver unavailable — stick-to-bottom async re-pin disabled; the transcript may lag behind live output until the next envelope arrives.",
+				);
+			}
+			return undefined;
+		}
+		const created = new ResizeObserverImpl(() => notifyContentChanged());
+		created.observe(element);
+		return created;
+	}
+
+	function observeContent(element: Element | undefined): void {
+		if (!element) return;
+		contentObserver?.disconnect();
+		contentObserver = makeObserver(element);
+	}
+
+	function observeViewport(element: Element | undefined): void {
+		if (!element) return;
+		viewportObserver?.disconnect();
+		viewportObserver = makeObserver(element);
+	}
+
+	function dispose(): void {
+		contentObserver?.disconnect();
+		viewportObserver?.disconnect();
+		contentObserver = undefined;
+		viewportObserver = undefined;
+		scroller.cancel();
+	}
+
+	return {
+		notifyContentChanged,
+		handleScroll,
+		handleScrollEnd,
+		handleWheel,
+		handleKeyDown,
+		handlePointerDown,
+		handlePointerUp,
+		handleTouchStart,
+		handleTouchMove,
+		handleTouchEnd,
+		handleTouchCancel,
+		observeContent,
+		observeViewport,
+		isFollowing: () => following,
+		dispose,
+	};
+}
+
+export interface BindStickToBottomOptions {
+	/**
+	 * Live gate — when it returns false the events are ignored (e.g. a tool
+	 * output pre whose auto-scroll preference is off).
+	 */
+	enabled?: () => boolean;
+	/**
+	 * Where to listen for scroll-up navigation keys:
+	 *  - "window": a window-level listener with editable-target exclusion — used
+	 *    by full-screen transcripts where the browser may scroll the transcript
+	 *    from a key press that targets `body` or unrelated chrome.
+	 *  - "element": listen on the scroller itself — used by nested scrollers
+	 *    (focusable tool-output pres).
+	 */
+	keyboard: "window" | "element";
+}
+
+function isEditableTarget(target: EventTarget | null): boolean {
+	return target instanceof Element && target.closest("input, textarea, select, [contenteditable]") !== null;
+}
+
+/**
+ * Bind a StickToBottomController to a live DOM scroller. This is THE wiring —
+ * shared by the session screen, the subagent screen, the tool-output pre, and
+ * the real-browser regression harness, so the exact listeners the app installs
+ * are the ones the browser test exercises.
+ *
+ * Wiring notes:
+ *  - `pointerdown` detects scrollbar presses via `offsetX >= clientWidth`
+ *    (the vertical scrollbar renders outside the client box); `pointerup` /
+ *    `pointercancel` are window-level so a press-in/release-out drag can never
+ *    leave the drag state stuck on.
+ *  - keyboard uses editable-target exclusion so keys consumed by the composer
+ *    (or any input) never arm scroll intent.
+ *
+ * Returns a cleanup function that removes every listener.
+ */
+export function bindStickToBottom(
+	controller: StickToBottomController,
+	scroller: HTMLElement,
+	options: BindStickToBottomOptions,
+): () => void {
+	const enabled = options.enabled ?? (() => true);
+	const cleanups: Array<() => void> = [];
+	function on<K extends keyof HTMLElementEventMap>(
+		target: HTMLElement | Window,
+		type: K,
+		listener: (event: HTMLElementEventMap[K]) => void,
+	): void {
+		const wrapped = ((event: Event) => {
+			if (enabled()) listener(event as HTMLElementEventMap[K]);
+		}) as EventListener;
+		target.addEventListener(type, wrapped, { passive: true });
+		cleanups.push(() => target.removeEventListener(type, wrapped));
+	}
+
+	on(scroller, "scroll", () => controller.handleScroll());
+	on(scroller, "scrollend", () => controller.handleScrollEnd());
+	on(scroller, "wheel", (event) => controller.handleWheel(event.deltaY, event.target));
+	on(scroller, "touchstart", (event) => controller.handleTouchStart(event.touches?.[0]?.clientY));
+	on(scroller, "touchmove", (event) => {
+		const y = event.touches?.[0]?.clientY;
+		if (y !== undefined) controller.handleTouchMove(y, event.target);
+	});
+	on(scroller, "touchend", () => controller.handleTouchEnd());
+	on(scroller, "touchcancel", () => controller.handleTouchCancel());
+	on(scroller, "pointerdown", (event) => {
+		controller.handlePointerDown(event.pointerType === "mouse" && event.offsetX >= scroller.clientWidth);
+	});
+	// Window-level: a scrollbar drag released outside the element (or canceled by
+	// the system) must still end the drag state.
+	on(window, "pointerup", () => controller.handlePointerUp());
+	on(window, "pointercancel", () => controller.handlePointerUp());
+	if (options.keyboard === "window") {
+		on(window, "keydown", (event) => {
+			if (isEditableTarget(event.target)) return;
+			controller.handleKeyDown(event.key, event.shiftKey, event.target);
+		});
+	} else {
+		on(scroller, "keydown", (event) => {
+			if (isEditableTarget(event.target)) return;
+			controller.handleKeyDown(event.key, event.shiftKey, event.target);
+		});
+	}
+
+	return () => {
+		for (const cleanup of cleanups) cleanup();
+	};
+}

--- a/packages/vscode/src/webview/styles.css
+++ b/packages/vscode/src/webview/styles.css
@@ -84,6 +84,9 @@ body {
 	flex: 1;
 	overflow-y: auto;
 	padding: 12px;
+}
+
+.dreb-transcript-inner {
 	display: flex;
 	flex-direction: column;
 	gap: 12px;

--- a/packages/vscode/test/scrolling.test.tsx
+++ b/packages/vscode/test/scrolling.test.tsx
@@ -1,0 +1,1060 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from "vitest";
+import { bindStickToBottom, createCoalescedBottomScroller, createStickToBottom } from "../src/webview/scrolling.js";
+
+function flushNextFrame(callbacks: FrameRequestCallback[]): void {
+	const callback = callbacks.shift();
+	if (!callback) throw new Error("no frame scheduled");
+	callback(0);
+}
+
+interface QueuedFrame {
+	handle: number;
+	callback: FrameRequestCallback;
+}
+
+function createManualAnimationFrameQueue() {
+	let nextHandle = 1;
+	const callbacks: QueuedFrame[] = [];
+	const raf = vi.fn((callback: FrameRequestCallback) => {
+		const handle = nextHandle++;
+		callbacks.push({ handle, callback });
+		return handle;
+	});
+	const cancelRaf = vi.fn((handle: number) => {
+		const index = callbacks.findIndex((frame) => frame.handle === handle);
+		if (index !== -1) callbacks.splice(index, 1);
+	});
+	const flushNext = () => {
+		const frame = callbacks.shift();
+		if (!frame) throw new Error("no frame scheduled");
+		frame.callback(0);
+	};
+	const flushAll = () => {
+		while (callbacks.length > 0) flushNext();
+	};
+	return { callbacks, raf, cancelRaf, flushNext, flushAll };
+}
+
+describe("createCoalescedBottomScroller", () => {
+	it("coalesces rapid requests and re-checks conditions at fire time", () => {
+		const callbacks: FrameRequestCallback[] = [];
+		const raf = vi.fn((callback: FrameRequestCallback) => {
+			callbacks.push(callback);
+			return callbacks.length;
+		});
+		const cancelRaf = vi.fn();
+		let shouldScroll = true;
+		const element = { scrollTop: 0, scrollHeight: 900 };
+		const scroller = createCoalescedBottomScroller({
+			element: () => element,
+			shouldScroll: () => shouldScroll,
+			requestAnimationFrame: raf,
+			cancelAnimationFrame: cancelRaf,
+		});
+
+		for (let i = 0; i < 20; i++) scroller.request();
+		expect(raf).toHaveBeenCalledTimes(1);
+
+		flushNextFrame(callbacks);
+		expect(raf).toHaveBeenCalledTimes(2);
+		scroller.request();
+		expect(raf).toHaveBeenCalledTimes(2);
+
+		shouldScroll = false;
+		flushNextFrame(callbacks);
+		expect(element.scrollTop).toBe(0);
+
+		shouldScroll = true;
+		scroller.request();
+		expect(raf).toHaveBeenCalledTimes(3);
+		flushNextFrame(callbacks);
+		flushNextFrame(callbacks);
+		expect(element.scrollTop).toBe(900);
+	});
+
+	it("cancels a pending first frame without scrolling or scheduling another frame", () => {
+		const queue = createManualAnimationFrameQueue();
+		const element = { scrollTop: 0, scrollHeight: 900 };
+		const scroller = createCoalescedBottomScroller({
+			element: () => element,
+			shouldScroll: () => true,
+			requestAnimationFrame: queue.raf,
+			cancelAnimationFrame: queue.cancelRaf,
+		});
+
+		scroller.request();
+		expect(queue.raf).toHaveBeenCalledTimes(1);
+		expect(queue.callbacks.map((frame) => frame.handle)).toEqual([1]);
+
+		scroller.cancel();
+		expect(queue.cancelRaf).toHaveBeenCalledTimes(1);
+		expect(queue.cancelRaf).toHaveBeenCalledWith(1);
+
+		queue.flushAll();
+		expect(element.scrollTop).toBe(0);
+		expect(queue.raf).toHaveBeenCalledTimes(1);
+		expect(queue.callbacks).toHaveLength(0);
+	});
+
+	it("cancels a pending second frame without scrolling", () => {
+		const queue = createManualAnimationFrameQueue();
+		const element = { scrollTop: 0, scrollHeight: 900 };
+		const scroller = createCoalescedBottomScroller({
+			element: () => element,
+			shouldScroll: () => true,
+			requestAnimationFrame: queue.raf,
+			cancelAnimationFrame: queue.cancelRaf,
+		});
+
+		scroller.request();
+		queue.flushNext();
+		expect(queue.raf).toHaveBeenCalledTimes(2);
+		expect(queue.callbacks.map((frame) => frame.handle)).toEqual([2]);
+
+		scroller.cancel();
+		expect(queue.cancelRaf).toHaveBeenCalledTimes(1);
+		expect(queue.cancelRaf).toHaveBeenCalledWith(2);
+
+		queue.flushAll();
+		expect(element.scrollTop).toBe(0);
+		expect(queue.raf).toHaveBeenCalledTimes(2);
+		expect(queue.callbacks).toHaveLength(0);
+	});
+
+	it("allows a fresh request after cancel", () => {
+		const queue = createManualAnimationFrameQueue();
+		const element = { scrollTop: 0, scrollHeight: 900 };
+		const scroller = createCoalescedBottomScroller({
+			element: () => element,
+			shouldScroll: () => true,
+			requestAnimationFrame: queue.raf,
+			cancelAnimationFrame: queue.cancelRaf,
+		});
+
+		scroller.request();
+		scroller.cancel();
+		expect(queue.cancelRaf).toHaveBeenCalledWith(1);
+
+		scroller.request();
+		expect(queue.raf).toHaveBeenCalledTimes(2);
+		expect(queue.callbacks.map((frame) => frame.handle)).toEqual([2]);
+
+		queue.flushAll();
+		expect(element.scrollTop).toBe(900);
+		expect(queue.raf).toHaveBeenCalledTimes(3);
+		expect(queue.callbacks).toHaveLength(0);
+	});
+});
+
+interface FakeScrollElement {
+	scrollTop: number;
+	scrollHeight: number;
+	clientHeight: number;
+}
+
+/** Minimal controllable ResizeObserver: exposes the registered callback for manual firing. */
+function createFakeResizeObserver() {
+	let callback: ResizeObserverCallback | undefined;
+	let observed = 0;
+	let disconnected = 0;
+	class FakeResizeObserver {
+		constructor(cb: ResizeObserverCallback) {
+			callback = cb;
+		}
+		observe(): void {
+			observed++;
+		}
+		unobserve(): void {}
+		disconnect(): void {
+			disconnected++;
+		}
+	}
+	return {
+		Impl: FakeResizeObserver as unknown as typeof ResizeObserver,
+		fire: () => callback?.([], {} as ResizeObserver),
+		observedCount: () => observed,
+		disconnectedCount: () => disconnected,
+	};
+}
+
+describe("createStickToBottom", () => {
+	it("keeps following through content growth when the user has not scrolled up", () => {
+		const queue = createManualAnimationFrameQueue();
+		const element: FakeScrollElement = { scrollTop: 400, scrollHeight: 500, clientHeight: 100 };
+		const controller = createStickToBottom({
+			scroller: () => element as unknown as HTMLElement,
+			requestAnimationFrame: queue.raf,
+			cancelAnimationFrame: queue.cancelRaf,
+		});
+
+		// User is at the bottom.
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(true);
+
+		// Content grows below without the user scrolling; a spurious scroll event
+		// fires while the viewport now measures "not at bottom" (the old latch bug).
+		element.scrollHeight = 900;
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(true);
+
+		// Next content notification pins back to the new bottom.
+		controller.notifyContentChanged();
+		queue.flushAll();
+		expect(element.scrollTop).toBe(900);
+	});
+
+	it("releases follow on a user up-scroll and re-engages at the bottom", () => {
+		const queue = createManualAnimationFrameQueue();
+		const element: FakeScrollElement = { scrollTop: 400, scrollHeight: 500, clientHeight: 100 };
+		const controller = createStickToBottom({
+			scroller: () => element as unknown as HTMLElement,
+			requestAnimationFrame: queue.raf,
+			cancelAnimationFrame: queue.cancelRaf,
+		});
+		controller.handleScroll();
+
+		// User scrolls up (scrollTop decreases) with a genuine wheel-up — follow releases.
+		element.scrollHeight = 900;
+		element.scrollTop = 200;
+		controller.handleWheel(-1);
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(false);
+
+		// Growth no longer pins while released.
+		controller.notifyContentChanged();
+		queue.flushAll();
+		expect(element.scrollTop).toBe(200);
+
+		// User returns to the bottom with deliberate downward input — follow
+		// re-engages and pins resume.
+		controller.handleWheel(1);
+		element.scrollTop = 800;
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(true);
+		element.scrollHeight = 1000;
+		controller.notifyContentChanged();
+		queue.flushAll();
+		expect(element.scrollTop).toBe(1000);
+	});
+
+	it("suspends pinning during an active touch drag", () => {
+		const queue = createManualAnimationFrameQueue();
+		const element: FakeScrollElement = { scrollTop: 400, scrollHeight: 500, clientHeight: 100 };
+		const controller = createStickToBottom({
+			scroller: () => element as unknown as HTMLElement,
+			requestAnimationFrame: queue.raf,
+			cancelAnimationFrame: queue.cancelRaf,
+		});
+
+		controller.handleTouchStart();
+		element.scrollHeight = 900;
+		controller.notifyContentChanged();
+		queue.flushAll();
+		// Finger down: no yank even though still following.
+		expect(element.scrollTop).toBe(400);
+
+		// Lifting the finger at the bottom re-enables pinning.
+		element.scrollTop = 860;
+		controller.handleTouchEnd();
+		expect(controller.isFollowing()).toBe(true);
+		controller.notifyContentChanged();
+		queue.flushAll();
+		expect(element.scrollTop).toBe(900);
+	});
+
+	it("re-pins on ResizeObserver growth while following but not after release", () => {
+		const queue = createManualAnimationFrameQueue();
+		const ro = createFakeResizeObserver();
+		const element: FakeScrollElement = { scrollTop: 400, scrollHeight: 500, clientHeight: 100 };
+		const controller = createStickToBottom({
+			scroller: () => element as unknown as HTMLElement,
+			requestAnimationFrame: queue.raf,
+			cancelAnimationFrame: queue.cancelRaf,
+			ResizeObserverImpl: ro.Impl,
+		});
+		controller.observeContent({} as Element);
+		expect(ro.observedCount()).toBe(1);
+
+		// Async growth with no envelope re-pins.
+		element.scrollHeight = 900;
+		ro.fire();
+		queue.flushAll();
+		expect(element.scrollTop).toBe(900);
+
+		// After a user up-scroll, observer growth must not yank the view back.
+		element.scrollTop = 300;
+		controller.handleWheel(-1);
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(false);
+		element.scrollHeight = 1400;
+		ro.fire();
+		queue.flushAll();
+		expect(element.scrollTop).toBe(300);
+
+		controller.dispose();
+		expect(ro.disconnectedCount()).toBeGreaterThanOrEqual(1);
+	});
+
+	it("keeps following when a pin's echo scroll fires after further growth (browser clamp mechanism)", () => {
+		// Reproduces the real-browser mechanism the jsdom screen tests cannot: a
+		// programmatic pin clamps `scrollTop` to `scrollHeight - clientHeight` and
+		// fires an async echo `scroll` event. If content grows again before that
+		// echo arrives, the echo must NOT be misread as a user up-scroll.
+		const queue = createManualAnimationFrameQueue();
+		const element: FakeScrollElement = { scrollTop: 0, scrollHeight: 500, clientHeight: 100 };
+		const controller = createStickToBottom({
+			scroller: () => element as unknown as HTMLElement,
+			requestAnimationFrame: queue.raf,
+			cancelAnimationFrame: queue.cancelRaf,
+		});
+
+		// Parked at the resting bottom (scrollHeight - clientHeight).
+		element.scrollTop = 400;
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(true);
+
+		// A long tool output lands: content grows and the pin fires.
+		element.scrollHeight = 900;
+		controller.notifyContentChanged();
+		queue.flushAll();
+		// The browser clamps `scrollTop = scrollHeight` to `scrollHeight - clientHeight`.
+		element.scrollTop = element.scrollHeight - element.clientHeight; // 800
+
+		// Late syntax highlighting grows the block again BEFORE the pin's async echo
+		// scroll event is delivered.
+		element.scrollHeight = 1100;
+
+		// The echo scroll arrives with the clamped (unchanged) scrollTop against the
+		// grown height. The old code seeded `lastTop = scrollHeight` (900), so
+		// `800 < 899` released follow here — the silent drop-out reported after a
+		// `read` tool call. The fix seeds `lastTop = scrollHeight - clientHeight`.
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(true);
+
+		// Follow survives, so the next growth re-pins to the true bottom.
+		controller.notifyContentChanged();
+		queue.flushAll();
+		expect(element.scrollTop).toBe(1100);
+	});
+
+	it("touch end keeps following when content grew during the drag without an up-scroll", () => {
+		const queue = createManualAnimationFrameQueue();
+		const element: FakeScrollElement = { scrollTop: 400, scrollHeight: 500, clientHeight: 100 };
+		const controller = createStickToBottom({
+			scroller: () => element as unknown as HTMLElement,
+			requestAnimationFrame: queue.raf,
+			cancelAnimationFrame: queue.cancelRaf,
+		});
+		controller.handleScroll(); // at bottom → following
+		controller.handleTouchStart();
+
+		// Content grows while the finger is down; the user never scrolls up, so the
+		// viewport measures "not at bottom" purely because of the growth.
+		element.scrollHeight = 900;
+
+		// Lifting the finger must NOT re-derive follow from absolute at-bottom
+		// geometry (the old bug), and must replay the pin suppressed during the drag.
+		controller.handleTouchEnd();
+		expect(controller.isFollowing()).toBe(true);
+		queue.flushAll();
+		expect(element.scrollTop).toBe(900);
+	});
+
+	it("observeContent rebinds to a replacement element and ignores undefined", () => {
+		const queue = createManualAnimationFrameQueue();
+		const ro = createFakeResizeObserver();
+		const element: FakeScrollElement = { scrollTop: 400, scrollHeight: 500, clientHeight: 100 };
+		const controller = createStickToBottom({
+			scroller: () => element as unknown as HTMLElement,
+			requestAnimationFrame: queue.raf,
+			cancelAnimationFrame: queue.cancelRaf,
+			ResizeObserverImpl: ro.Impl,
+		});
+
+		// Undefined element (ref not ready yet) is a safe no-op.
+		controller.observeContent(undefined);
+		expect(ro.observedCount()).toBe(0);
+
+		// First real element.
+		controller.observeContent({} as Element);
+		expect(ro.observedCount()).toBe(1);
+
+		// Rebinding disconnects the prior observer and observes the replacement.
+		controller.observeContent({} as Element);
+		expect(ro.disconnectedCount()).toBe(1);
+		expect(ro.observedCount()).toBe(2);
+
+		// Only the current observer drives re-pins.
+		element.scrollHeight = 900;
+		ro.fire();
+		queue.flushAll();
+		expect(element.scrollTop).toBe(900);
+	});
+
+	it("warns loudly instead of silently disabling re-pin when ResizeObserver is unavailable", () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const element: FakeScrollElement = { scrollTop: 400, scrollHeight: 500, clientHeight: 100 };
+		const controller = createStickToBottom({
+			scroller: () => element as unknown as HTMLElement,
+			ResizeObserverImpl: undefined,
+		});
+		controller.observeContent({} as Element);
+		expect(warn).toHaveBeenCalledTimes(1);
+		expect(warn.mock.calls[0]?.[0]).toContain("ResizeObserver unavailable");
+		warn.mockRestore();
+	});
+
+	it("warns only once when both content and viewport observers are attached without ResizeObserver", () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const element: FakeScrollElement = { scrollTop: 400, scrollHeight: 500, clientHeight: 100 };
+		const controller = createStickToBottom({
+			scroller: () => element as unknown as HTMLElement,
+			ResizeObserverImpl: undefined,
+		});
+		// A screen attaches both a content and a viewport observer; the missing-RO
+		// diagnostic must not double-log.
+		controller.observeContent({} as Element);
+		controller.observeViewport({} as Element);
+		expect(warn).toHaveBeenCalledTimes(1);
+		warn.mockRestore();
+	});
+
+	it("re-pins on viewport resize while following but not after release (observeViewport)", () => {
+		// A dock/chrome resize (tasks list, subagent strip, composer auto-grow)
+		// changes the scroller's clientHeight without a content change or a scroll
+		// event. Only the viewport observer catches it.
+		const queue = createManualAnimationFrameQueue();
+		const ro = createFakeResizeObserver();
+		const element: FakeScrollElement = { scrollTop: 400, scrollHeight: 900, clientHeight: 100 };
+		const controller = createStickToBottom({
+			scroller: () => element as unknown as HTMLElement,
+			requestAnimationFrame: queue.raf,
+			cancelAnimationFrame: queue.cancelRaf,
+			ResizeObserverImpl: ro.Impl,
+		});
+		controller.observeViewport({} as Element);
+		expect(ro.observedCount()).toBe(1);
+
+		// Viewport grows (dock shrank) — clientHeight increased with no scroll event.
+		// While following, the observer must re-pin to the new resting bottom.
+		element.clientHeight = 300;
+		ro.fire();
+		queue.flushAll();
+		expect(element.scrollTop).toBe(900);
+
+		// After a user up-scroll, a later viewport resize must not yank the view back.
+		element.scrollTop = 200;
+		controller.handleWheel(-1);
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(false);
+		element.clientHeight = 100;
+		ro.fire();
+		queue.flushAll();
+		expect(element.scrollTop).toBe(200);
+	});
+
+	it("touch cancel clears the gesture and re-enables pinning (touchcancel)", () => {
+		const queue = createManualAnimationFrameQueue();
+		const element: FakeScrollElement = { scrollTop: 400, scrollHeight: 500, clientHeight: 100 };
+		const controller = createStickToBottom({
+			scroller: () => element as unknown as HTMLElement,
+			requestAnimationFrame: queue.raf,
+			cancelAnimationFrame: queue.cancelRaf,
+		});
+		controller.handleScroll(); // at bottom → following
+		controller.handleTouchStart();
+
+		// Finger down suppresses pinning even while following.
+		element.scrollHeight = 900;
+		controller.notifyContentChanged();
+		queue.flushAll();
+		expect(element.scrollTop).toBe(400);
+
+		// The gesture is canceled (system takeover) instead of ending cleanly.
+		// gestureActive must clear so pinning resumes — otherwise every future pin
+		// is silently suppressed.
+		controller.handleTouchCancel();
+		controller.notifyContentChanged();
+		queue.flushAll();
+		expect(element.scrollTop).toBe(900);
+	});
+
+	it("dispose cancels a pending pin so a detached scroller is never mutated", () => {
+		const queue = createManualAnimationFrameQueue();
+		const element: FakeScrollElement = { scrollTop: 400, scrollHeight: 900, clientHeight: 100 };
+		const controller = createStickToBottom({
+			scroller: () => element as unknown as HTMLElement,
+			requestAnimationFrame: queue.raf,
+			cancelAnimationFrame: queue.cancelRaf,
+		});
+		controller.handleScroll(); // following
+
+		// Schedule a pin, then dispose before either frame fires.
+		controller.notifyContentChanged();
+		controller.dispose();
+		queue.flushAll();
+		// The pin was cancelled — scrollTop is untouched.
+		expect(element.scrollTop).toBe(400);
+	});
+
+	it("dispose disconnects both the content and viewport observers", () => {
+		const ro = createFakeResizeObserver();
+		const element: FakeScrollElement = { scrollTop: 400, scrollHeight: 500, clientHeight: 100 };
+		const controller = createStickToBottom({
+			scroller: () => element as unknown as HTMLElement,
+			ResizeObserverImpl: ro.Impl,
+		});
+		controller.observeContent({} as Element);
+		controller.observeViewport({} as Element);
+		expect(ro.observedCount()).toBe(2);
+
+		controller.dispose();
+		expect(ro.disconnectedCount()).toBe(2);
+	});
+
+	it("keeps following on a layout-induced scrollTop decrease with no user input (assistant→tool boundary)", () => {
+		// The core residual bug: at an assistant→tool boundary the transcript
+		// reflows (streamed message replaced by full markdown, assistant-turn DOM
+		// recreated) and the browser lowers scrollTop while a tool card is appended
+		// below. That is NOT a user up-scroll — no wheel/touch/pointer/key input —
+		// so follow must survive even though scrollTop decreased and the new bottom
+		// is far away.
+		const queue = createManualAnimationFrameQueue();
+		const intentClock = 1000;
+		const element: FakeScrollElement = { scrollTop: 800, scrollHeight: 900, clientHeight: 100 };
+		const controller = createStickToBottom({
+			scroller: () => element as unknown as HTMLElement,
+			requestAnimationFrame: queue.raf,
+			cancelAnimationFrame: queue.cancelRaf,
+			now: () => intentClock,
+		});
+
+		// Parked at the resting bottom, following.
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(true);
+
+		// Reflow: assistant completion lowers scrollTop by 300 and a tool card adds
+		// content far below (new bottom is 1400, >40px from the clamped top). No
+		// input event preceded this scroll.
+		element.scrollHeight = 1500;
+		element.scrollTop = 500;
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(true);
+
+		// The next content notification re-pins to the true new bottom.
+		controller.notifyContentChanged();
+		queue.flushAll();
+		expect(element.scrollTop).toBe(1500);
+	});
+
+	it("releases on a wheel-up whose scroll sequence has not settled, but not after scrollend", () => {
+		const intentClock = 1000;
+		const element: FakeScrollElement = { scrollTop: 800, scrollHeight: 900, clientHeight: 100 };
+		const controller = createStickToBottom({
+			scroller: () => element as unknown as HTMLElement,
+			now: () => intentClock,
+		});
+		controller.handleScroll(); // following at bottom
+
+		// A wheel-up whose scroll has not landed yet: no decrease, no release.
+		controller.handleWheel(-1);
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(true);
+
+		// The outer scroller then moves up under the same gesture — releases.
+		element.scrollTop = 400;
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(false);
+	});
+
+	it("scrollend consumes discrete upward intent (sequence-scoped, not merely time-windowed)", () => {
+		const intentClock = 1000;
+		const element: FakeScrollElement = { scrollTop: 800, scrollHeight: 900, clientHeight: 100 };
+		const controller = createStickToBottom({
+			scroller: () => element as unknown as HTMLElement,
+			now: () => intentClock, // frozen clock — the 400ms fallback can NEVER expire
+		});
+		controller.handleScroll();
+
+		// A wheel-up arms intent, its (no-op) scroll sequence settles…
+		controller.handleWheel(-1);
+		controller.handleScrollEnd();
+
+		// …then a layout-induced reflow lowers scrollTop. Even though the fallback
+		// window never expired (frozen clock), scrollend already consumed the
+		// intent, so this must NOT release.
+		element.scrollHeight = 1500;
+		element.scrollTop = 500;
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(true);
+	});
+
+	it("downward movement clears discrete upward intent", () => {
+		const intentClock = 1000;
+		const element: FakeScrollElement = { scrollTop: 800, scrollHeight: 2000, clientHeight: 100 };
+		const controller = createStickToBottom({
+			scroller: () => element as unknown as HTMLElement,
+			now: () => intentClock,
+		});
+		element.scrollTop = 800;
+		controller.handleScroll(); // not at bottom (2000-100=1900), lastTop=800
+		expect(controller.isFollowing()).toBe(true);
+
+		// Wheel-up arms, but the user then scrolls DOWN (still above the bottom).
+		controller.handleWheel(-1);
+		element.scrollTop = 1000;
+		controller.handleScroll();
+		// A later layout-induced decrease must not be released by the stale stamp.
+		element.scrollTop = 700;
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(true);
+	});
+
+	it("wheel-up over a nested inner scroller that can still scroll up does NOT arm outer intent", () => {
+		// The false-release coincidence: a wheel over the nested bash <pre> bubbles
+		// to the outer scroller but is consumed by the pre (it scrolls up instead).
+		// If that armed outer intent, an unrelated assistant→tool reflow within the
+		// fallback window would satisfy both release conditions — the original
+		// silent drop-out. The wheel handler must detect the consuming inner
+		// scroller from the event target and refuse to arm.
+		const intentClock = 1000;
+		const outer = document.createElement("div");
+		const inner = document.createElement("pre");
+		inner.style.overflowY = "auto";
+		outer.appendChild(inner);
+		document.body.appendChild(outer);
+		Object.defineProperty(inner, "scrollHeight", { configurable: true, value: 600 });
+		Object.defineProperty(inner, "clientHeight", { configurable: true, value: 100 });
+		inner.scrollTop = 250; // can still scroll up → consumes the wheel
+		let outerScrollTop = 800;
+		const element = {
+			get scrollTop() {
+				return outerScrollTop;
+			},
+			set scrollTop(v: number) {
+				outerScrollTop = v;
+			},
+			scrollHeight: 900,
+			clientHeight: 100,
+		};
+		const controller = createStickToBottom({
+			scroller: () => element as unknown as HTMLElement,
+			now: () => intentClock,
+		});
+		controller.handleScroll(); // following at bottom
+
+		controller.handleWheel(-1, inner);
+		// Reflow lowers outer scrollTop within the (frozen, never-expiring) window.
+		element.scrollHeight = 1500;
+		outerScrollTop = 500;
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(true);
+
+		// Same wheel but the inner pre is already at its top → it cannot consume,
+		// the outer will scroll, so intent DOES arm and a real decrease releases.
+		inner.scrollTop = 0;
+		outerScrollTop = 1400;
+		controller.handleScroll(); // re-engage at the new bottom
+		expect(controller.isFollowing()).toBe(true);
+		controller.handleWheel(-1, inner);
+		outerScrollTop = 900;
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(false);
+		outer.remove();
+	});
+
+	it("touch is directional: an upward drag releases, a stationary hold plus reflow does not", () => {
+		// Upward drag: finger moves DOWN the screen (clientY increases) → content
+		// drags down → scrollTop decreases → release.
+		const upEl: FakeScrollElement = { scrollTop: 800, scrollHeight: 900, clientHeight: 100 };
+		const upCtl = createStickToBottom({ scroller: () => upEl as unknown as HTMLElement });
+		upCtl.handleScroll();
+		upCtl.handleTouchStart(300);
+		upCtl.handleTouchMove(340);
+		upEl.scrollTop = 700;
+		upCtl.handleScroll();
+		expect(upCtl.isFollowing()).toBe(false);
+
+		// Stationary hold: finger down, no movement — a concurrent layout reflow
+		// lowers scrollTop. That is NOT an up-scroll; follow must survive.
+		const holdEl: FakeScrollElement = { scrollTop: 800, scrollHeight: 900, clientHeight: 100 };
+		const holdCtl = createStickToBottom({ scroller: () => holdEl as unknown as HTMLElement });
+		holdCtl.handleScroll();
+		holdCtl.handleTouchStart(300);
+		holdEl.scrollHeight = 1500;
+		holdEl.scrollTop = 500;
+		holdCtl.handleScroll();
+		expect(holdCtl.isFollowing()).toBe(true);
+
+		// Downward drag (finger moving UP the screen scrolls down): a concurrent
+		// reflow decrease must not release either.
+		const downEl: FakeScrollElement = { scrollTop: 800, scrollHeight: 2000, clientHeight: 100 };
+		const downCtl = createStickToBottom({ scroller: () => downEl as unknown as HTMLElement });
+		downEl.scrollTop = 1900;
+		downCtl.handleScroll();
+		downCtl.handleTouchStart(300);
+		downCtl.handleTouchMove(260); // finger up = scroll down intent
+		downEl.scrollHeight = 2600;
+		downEl.scrollTop = 1700; // layout-induced decrease during the drag
+		downCtl.handleScroll();
+		expect(downCtl.isFollowing()).toBe(true);
+	});
+
+	it("touch intent survives past touchend through the inertial scroll until scrollend", () => {
+		const intentClock = 1000;
+		const element: FakeScrollElement = { scrollTop: 800, scrollHeight: 900, clientHeight: 100 };
+		const controller = createStickToBottom({
+			scroller: () => element as unknown as HTMLElement,
+			now: () => intentClock,
+		});
+		controller.handleScroll();
+
+		// Upward flick: drag up, lift — the FIRST significant decrease arrives only
+		// during post-touch inertia, after gestureActive already cleared.
+		controller.handleTouchStart(300);
+		controller.handleTouchMove(320);
+		controller.handleTouchEnd();
+		element.scrollTop = 600; // inertial decrease after the finger lifted
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(false);
+
+		// Return deliberately to the bottom, then settle: a later layout-induced
+		// decrease cannot release.
+		controller.handleWheel(1);
+		element.scrollTop = 800;
+		controller.handleScroll(); // back at bottom → re-engage
+		controller.handleScrollEnd();
+		element.scrollHeight = 1500;
+		element.scrollTop = 500;
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(true);
+	});
+
+	it("a plain (non-scrollbar) pointer press never authorizes a release", () => {
+		const element: FakeScrollElement = { scrollTop: 800, scrollHeight: 900, clientHeight: 100 };
+		const controller = createStickToBottom({ scroller: () => element as unknown as HTMLElement });
+		controller.handleScroll();
+
+		// Click / text-selection press (not on the scrollbar) while a reflow lowers
+		// scrollTop — must NOT be misread as a scrollbar up-drag.
+		controller.handlePointerDown(false);
+		element.scrollHeight = 1500;
+		element.scrollTop = 500;
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(true);
+		controller.handlePointerUp();
+	});
+
+	it("does not release when the upward intent has gone stale", () => {
+		let intentClock = 1000;
+		const element: FakeScrollElement = { scrollTop: 800, scrollHeight: 900, clientHeight: 100 };
+		const controller = createStickToBottom({
+			scroller: () => element as unknown as HTMLElement,
+			now: () => intentClock,
+			intentWindowMs: 400,
+		});
+		controller.handleScroll();
+
+		// A wheel-up happened long ago; by the time a layout-induced decrease fires
+		// the intent window has elapsed, so it must not authorize a release.
+		controller.handleWheel(-1);
+		intentClock += 1000; // 1000ms later, window is 400ms
+		element.scrollTop = 400;
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(true);
+	});
+
+	it("releases on a scroll-up key press and on an active pointer (scrollbar) drag", () => {
+		const intentClock = 1000;
+		// Keyboard: at bottom first to seed lastTop, then a PageUp + decrease.
+		const keyEl: FakeScrollElement = { scrollTop: 800, scrollHeight: 900, clientHeight: 100 };
+		const keyCtl = createStickToBottom({ scroller: () => keyEl as unknown as HTMLElement, now: () => intentClock });
+		keyCtl.handleScroll();
+		keyCtl.handleKeyDown("PageUp");
+		keyEl.scrollTop = 300;
+		keyCtl.handleScroll();
+		expect(keyCtl.isFollowing()).toBe(false);
+
+		// Scrollbar drag: pointerdown on the scrollbar region, then an up movement.
+		const ptrEl: FakeScrollElement = { scrollTop: 800, scrollHeight: 900, clientHeight: 100 };
+		const ptrCtl = createStickToBottom({ scroller: () => ptrEl as unknown as HTMLElement, now: () => intentClock });
+		ptrCtl.handleScroll();
+		ptrCtl.handlePointerDown(true);
+		ptrEl.scrollTop = 300;
+		ptrCtl.handleScroll();
+		expect(ptrCtl.isFollowing()).toBe(false);
+
+		// After the pointer lifts, a later layout-induced decrease must not release.
+		ptrCtl.handlePointerUp();
+		ptrCtl.handleWheel(1);
+		ptrEl.scrollTop = 800;
+		ptrCtl.handleScroll(); // back at bottom → re-engage
+		expect(ptrCtl.isFollowing()).toBe(true);
+		ptrEl.scrollHeight = 2000;
+		ptrEl.scrollTop = 500;
+		ptrCtl.handleScroll();
+		expect(ptrCtl.isFollowing()).toBe(true);
+	});
+
+	it("accumulates fractional and exact-1px upward scrolls against a stable baseline", () => {
+		const fractional: FakeScrollElement = { scrollTop: 800, scrollHeight: 2000, clientHeight: 100 };
+		const fractionalCtl = createStickToBottom({ scroller: () => fractional as unknown as HTMLElement });
+		fractionalCtl.handleScroll();
+		fractionalCtl.handleWheel(-1);
+		fractional.scrollTop = 799.6;
+		fractionalCtl.handleScroll();
+		expect(fractionalCtl.isFollowing()).toBe(true);
+		fractional.scrollTop = 799.1;
+		fractionalCtl.handleScroll();
+		expect(fractionalCtl.isFollowing()).toBe(true);
+		fractional.scrollTop = 798.5;
+		fractionalCtl.handleScroll();
+		expect(fractionalCtl.isFollowing()).toBe(false);
+
+		const exactPixel: FakeScrollElement = { scrollTop: 800, scrollHeight: 2000, clientHeight: 100 };
+		const exactPixelCtl = createStickToBottom({ scroller: () => exactPixel as unknown as HTMLElement });
+		exactPixelCtl.handleScroll();
+		exactPixelCtl.handleWheel(-1);
+		exactPixel.scrollTop = 799;
+		exactPixelCtl.handleScroll();
+		expect(exactPixelCtl.isFollowing()).toBe(true);
+		exactPixel.scrollTop = 798;
+		exactPixelCtl.handleScroll();
+		expect(exactPixelCtl.isFollowing()).toBe(false);
+	});
+
+	it("does not re-engage a released reader after a shrink clamp without a real downward return", () => {
+		const queue = createManualAnimationFrameQueue();
+		const element: FakeScrollElement = { scrollTop: 800, scrollHeight: 900, clientHeight: 100 };
+		const controller = createStickToBottom({
+			scroller: () => element as unknown as HTMLElement,
+			requestAnimationFrame: queue.raf,
+			cancelAnimationFrame: queue.cancelRaf,
+		});
+		controller.handleScroll();
+		controller.handleWheel(-1);
+		element.scrollTop = 300;
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(false);
+
+		// Content below the reader disappears; Chrome clamps the position to the
+		// new bottom and emits scroll. Geometry alone must not re-arm follow.
+		element.scrollHeight = 350;
+		element.scrollTop = 250;
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(false);
+		element.scrollHeight = 900;
+		controller.notifyContentChanged();
+		queue.flushAll();
+		expect(element.scrollTop).toBe(250);
+
+		// A genuine downward wheel plus actual arrival at bottom re-engages follow.
+		controller.handleWheel(1);
+		element.scrollTop = 800;
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(true);
+		element.scrollHeight = 1000;
+		controller.notifyContentChanged();
+		queue.flushAll();
+		expect(element.scrollTop).toBe(1000);
+	});
+
+	it("re-engages when a deliberate downward return crosses the threshold in a 1px step", () => {
+		const element: FakeScrollElement = { scrollTop: 800, scrollHeight: 900, clientHeight: 100 };
+		const controller = createStickToBottom({ scroller: () => element as unknown as HTMLElement });
+		controller.handleScroll();
+		controller.handleWheel(-1);
+		element.scrollTop = 758;
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(false);
+
+		controller.handleWheel(1);
+		element.scrollTop = 759;
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(false);
+		element.scrollTop = 760; // enters the 40px at-bottom threshold by exactly 1px
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(true);
+	});
+
+	it("does not inherit downward keyboard intent consumed by a nested scroller", () => {
+		const outer = document.createElement("div");
+		const inner = document.createElement("pre");
+		inner.style.overflowY = "auto";
+		outer.appendChild(inner);
+		document.body.appendChild(outer);
+		Object.defineProperties(inner, {
+			scrollHeight: { configurable: true, value: 600 },
+			clientHeight: { configurable: true, value: 100 },
+		});
+		inner.scrollTop = 250;
+		let outerTop = 800;
+		const element = {
+			get scrollTop() {
+				return outerTop;
+			},
+			set scrollTop(value: number) {
+				outerTop = value;
+			},
+			scrollHeight: 900,
+			clientHeight: 100,
+		};
+		const controller = createStickToBottom({ scroller: () => element as unknown as HTMLElement });
+		controller.handleScroll();
+		controller.handleWheel(-1);
+		outerTop = 758;
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(false);
+
+		// The focused inner pre consumes PageDown, so a coincident outer movement
+		// into the bottom threshold must not re-engage the released transcript.
+		controller.handleKeyDown("PageDown", false, inner);
+		outerTop = 760;
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(false);
+
+		// At the inner bottom, PageDown chains to the outer scroller and can
+		// legitimately re-engage it after actual downward movement.
+		inner.scrollTop = 500;
+		outerTop = 758;
+		controller.handleScroll();
+		controller.handleKeyDown("PageDown", false, inner);
+		outerTop = 760;
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(true);
+		outer.remove();
+	});
+
+	it("does not inherit touch intent consumed by a nested scroller", () => {
+		const queue = createManualAnimationFrameQueue();
+		const outer = document.createElement("div");
+		const inner = document.createElement("pre");
+		inner.style.overflowY = "auto";
+		outer.appendChild(inner);
+		document.body.appendChild(outer);
+		Object.defineProperties(inner, {
+			scrollHeight: { configurable: true, value: 600 },
+			clientHeight: { configurable: true, value: 100 },
+		});
+		inner.scrollTop = 250;
+		let outerTop = 800;
+		let outerHeight = 900;
+		Object.defineProperties(outer, {
+			scrollTop: {
+				configurable: true,
+				get: () => outerTop,
+				set: (value: number) => {
+					outerTop = value;
+				},
+			},
+			scrollHeight: { configurable: true, get: () => outerHeight },
+			clientHeight: { configurable: true, value: 100 },
+		});
+		const controller = createStickToBottom({
+			scroller: () => outer,
+			requestAnimationFrame: queue.raf,
+			cancelAnimationFrame: queue.cancelRaf,
+		});
+		controller.handleScroll();
+
+		// The inner pre consumes the upward touch drag. A coincident outer layout
+		// decrease must not inherit that intent and release outer follow.
+		controller.handleTouchStart(300);
+		controller.handleTouchMove(340, inner);
+		outerHeight = 1500;
+		outerTop = 500;
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(true);
+		controller.handleTouchCancel();
+		queue.flushAll();
+
+		// Release outer follow genuinely, then verify a downward drag consumed by
+		// the inner pre cannot re-engage it on coincident outer movement.
+		outerHeight = 900;
+		outerTop = 800;
+		controller.handleScroll();
+		controller.handleWheel(-1, outer);
+		outerTop = 758;
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(false);
+		controller.handleTouchStart(300);
+		controller.handleTouchMove(260, inner);
+		outerTop = 760;
+		controller.handleScroll();
+		expect(controller.isFollowing()).toBe(false);
+		outer.remove();
+	});
+
+	it("binds touchcancel through the production listener and resumes outer pinning", () => {
+		const queue = createManualAnimationFrameQueue();
+		const scroller = document.createElement("div");
+		Object.defineProperties(scroller, {
+			clientHeight: { configurable: true, value: 100 },
+			scrollHeight: { configurable: true, value: 500 },
+		});
+		scroller.scrollTop = 400;
+		const controller = createStickToBottom({
+			scroller: () => scroller,
+			requestAnimationFrame: queue.raf,
+			cancelAnimationFrame: queue.cancelRaf,
+		});
+		const cleanup = bindStickToBottom(controller, scroller, { keyboard: "window" });
+		scroller.dispatchEvent(new Event("scroll"));
+		const touch = (type: "touchstart" | "touchcancel") => {
+			const event = new Event(type) as Event & { touches: Array<{ clientY: number }> };
+			event.touches = [{ clientY: 300 }];
+			return event;
+		};
+		scroller.dispatchEvent(touch("touchstart"));
+		Object.defineProperty(scroller, "scrollHeight", { configurable: true, value: 900 });
+		controller.notifyContentChanged();
+		queue.flushAll();
+		expect(scroller.scrollTop).toBe(400);
+		scroller.dispatchEvent(touch("touchcancel"));
+		queue.flushAll();
+		expect(scroller.scrollTop).toBe(900);
+		cleanup();
+	});
+
+	it("binds scrollbar-region pointer intent and clears outside pointerup/pointercancel", () => {
+		const pointer = (type: "pointerdown" | "pointerup" | "pointercancel", offsetX = 0) => {
+			const event = new Event(type, { bubbles: true }) as Event & { pointerType: string; offsetX: number };
+			event.pointerType = "mouse";
+			event.offsetX = offsetX;
+			return event;
+		};
+		const makeBoundController = () => {
+			const scroller = document.createElement("div");
+			Object.defineProperties(scroller, {
+				clientHeight: { configurable: true, value: 100 },
+				clientWidth: { configurable: true, value: 100 },
+				scrollHeight: { configurable: true, writable: true, value: 900 },
+			});
+			scroller.scrollTop = 800;
+			const controller = createStickToBottom({ scroller: () => scroller });
+			const cleanup = bindStickToBottom(controller, scroller, { keyboard: "window" });
+			scroller.dispatchEvent(new Event("scroll"));
+			return { scroller, controller, cleanup };
+		};
+
+		const active = makeBoundController();
+		active.scroller.dispatchEvent(pointer("pointerdown", 100));
+		active.scroller.scrollTop = 300;
+		active.scroller.dispatchEvent(new Event("scroll"));
+		expect(active.controller.isFollowing()).toBe(false);
+		active.cleanup();
+
+		for (const endType of ["pointerup", "pointercancel"] as const) {
+			const releasedOutside = makeBoundController();
+			releasedOutside.scroller.dispatchEvent(pointer("pointerdown", 100));
+			window.dispatchEvent(pointer(endType)); // release outside the scrollbar
+			(releasedOutside.scroller as unknown as FakeScrollElement).scrollHeight = 1500;
+			releasedOutside.scroller.scrollTop = 500;
+			releasedOutside.scroller.dispatchEvent(new Event("scroll"));
+			expect(releasedOutside.controller.isFollowing()).toBe(true);
+			releasedOutside.cleanup();
+		}
+	});
+});


### PR DESCRIPTION
Closes #48

Make the VSCode extension chat auto-scroll "sticky": only follow new output to the bottom when the user is already at the bottom; stay put when the user has scrolled up; resume following once the user scrolls back to the bottom.

Implementation plan posted as a comment below.
