### PR TITLE
VSCode extension: RPC crash guards + stderr + automated in-place recovery

### DIFF
--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -96,8 +96,8 @@ export interface ModelInfo {
 export type RpcEventListener = (event: RpcEvent) => void;
 
 export type RpcExitInfo =
-	| { code: number | null; signal: NodeJS.Signals | null; error?: undefined }
-	| { code?: undefined; signal?: undefined; error: Error };
+	| { code: number | null; signal: NodeJS.Signals | null; error?: undefined; stderr?: string }
+	| { code?: undefined; signal?: undefined; error: Error; stderr?: string };
 
 export type RpcExitListener = (info: RpcExitInfo) => void;
 
@@ -201,7 +201,9 @@ export class RpcClient {
 			// Guard: skip if this handler belongs to an old, already-stopped process
 			if (this.process !== procRef) return;
 			this.failPendingRequests(`RPC process exited with code ${code}, signal ${signal}`);
-			this.notifyExitListeners({ code, signal });
+			// Forward the collected stderr so a late (non-startup) crash surfaces its
+			// dying words to the parent for diagnosis, instead of discarding them.
+			this.notifyExitListeners({ code, signal, stderr: this.stderr });
 		});
 
 		// Spawn failures surface asynchronously as an 'error' event rather than a
@@ -215,7 +217,7 @@ export class RpcClient {
 			if (this.process !== procRef) return;
 			this.spawnError = err;
 			this.failPendingRequests(`RPC process failed to spawn: ${err.message}`);
-			this.notifyExitListeners({ error: err });
+			this.notifyExitListeners({ error: err, stderr: this.stderr });
 		});
 
 		// Set up strict JSONL reader for stdout.

--- a/packages/coding-agent/src/modes/rpc/rpc-crash-guard.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-crash-guard.ts
@@ -1,0 +1,126 @@
+/**
+ * Process-level crash guards for the RPC server child.
+ *
+ * The RPC child runs the whole agent loop in a separate process, streaming
+ * events to the parent (VSCode extension host / dashboard server) over stdout.
+ * Historically it installed no `unhandledRejection`/`uncaughtException`
+ * handlers, so *any* stray unhandled rejection anywhere in the agent loop (a
+ * provider/network error, an abort race, an un-awaited async tool path) would
+ * terminate the process with exit code 1 — surfacing to the user as an abrupt
+ * "dreb process exited (code 1, signal null)" with no explanation and no
+ * recovery. See issue 53.
+ *
+ * These guards convert that into a diagnosable, recoverable failure:
+ *
+ *  - **unhandledRejection** — registering a listener suppresses Node's default
+ *    "throw-and-exit" behavior (Node >= 15). We log the reason and emit a
+ *    non-fatal diagnostic frame, then **keep the process alive**. A stray
+ *    rejection rarely corrupts state, and killing a long-lived session for one
+ *    is worse than continuing. This is the common case and is fully recovered.
+ *
+ *  - **uncaughtException** — an uncaught throw can leave process state corrupt;
+ *    Node's own guidance is to perform synchronous cleanup and shut down rather
+ *    than resume. We log + emit a fatal diagnostic and then **deliberately exit
+ *    (code 1)** so the parent's supervised restart (VSCode auto-recovery /
+ *    dashboard retry) rebuilds a fresh child — now with a logged cause instead
+ *    of a mystery. This is a distinct, intentional exit and is *not* the
+ *    unexplained crash issue 53 is about.
+ *
+ * The deliberate stdout-backpressure `process.exit(1)` in `output-guard.ts`
+ * (fail-loud when the consumer stops reading) is a separate explicit exit and
+ * is intentionally left untouched by these guards.
+ */
+
+/** The two process-level failure origins these guards intercept. */
+export type RpcCrashOrigin = "unhandledRejection" | "uncaughtException";
+
+/** A structured, serializable view of a crash reason. */
+export interface RpcCrashDiagnostic {
+	origin: RpcCrashOrigin;
+	message: string;
+	stack?: string;
+	/** Fatal failures exit the process (for supervised restart); recoverable
+	 * ones keep it alive. */
+	fatal: boolean;
+}
+
+/** Side effects the guards need, injected so the core logic is unit-testable
+ * without touching the real `process` or killing the test runner. */
+export interface RpcCrashGuardHooks {
+	/** Emit a diagnostic event frame to the parent over the RPC channel. */
+	emit: (frame: object) => void;
+	/** Write a diagnostic line to stderr (collected by the parent's RpcClient
+	 * and surfaced on the next exit). */
+	log: (line: string) => void;
+	/** Terminate the process. Only invoked on the fatal (uncaughtException)
+	 * path. Injected so tests can assert it without exiting. */
+	exit: (code: number) => void;
+}
+
+/** Normalize an arbitrary thrown/rejected value into a structured diagnostic. */
+export function formatRpcCrashDiagnostic(origin: RpcCrashOrigin, reason: unknown): RpcCrashDiagnostic {
+	const fatal = origin === "uncaughtException";
+	if (reason instanceof Error) {
+		return { origin, message: reason.message || reason.name || "Error", stack: reason.stack, fatal };
+	}
+	return { origin, message: typeof reason === "string" ? reason : safeStringify(reason), fatal };
+}
+
+function safeStringify(value: unknown): string {
+	try {
+		return JSON.stringify(value) ?? String(value);
+	} catch {
+		return String(value);
+	}
+}
+
+/** The RPC event frame emitted for a crash diagnostic. Consumers that don't
+ * recognize the type ignore it gracefully (the projection's `default` branch);
+ * the primary durability guarantee is the accompanying stderr log. */
+export function crashDiagnosticFrame(diagnostic: RpcCrashDiagnostic): {
+	type: "rpc_process_error";
+	origin: RpcCrashOrigin;
+	message: string;
+	fatal: boolean;
+} {
+	return {
+		type: "rpc_process_error",
+		origin: diagnostic.origin,
+		message: diagnostic.message,
+		fatal: diagnostic.fatal,
+	};
+}
+
+/** Handle one crash event: log it, emit the diagnostic frame, and — for a fatal
+ * origin — exit for supervised restart. Exposed for direct unit testing. */
+export function handleRpcCrash(hooks: RpcCrashGuardHooks, origin: RpcCrashOrigin, reason: unknown): void {
+	const diagnostic = formatRpcCrashDiagnostic(origin, reason);
+	const suffix = diagnostic.stack ? `\n${diagnostic.stack}` : "";
+	if (diagnostic.fatal) {
+		hooks.log(`[rpc] Uncaught exception (fatal — exiting for supervised restart): ${diagnostic.message}${suffix}`);
+	} else {
+		hooks.log(`[rpc] Unhandled promise rejection (recovered — process kept alive): ${diagnostic.message}${suffix}`);
+	}
+	// Best-effort: emitting must never itself throw out of the guard.
+	try {
+		hooks.emit(crashDiagnosticFrame(diagnostic));
+	} catch {
+		// Ignore — the stderr log above is the durable record.
+	}
+	if (diagnostic.fatal) hooks.exit(1);
+}
+
+/**
+ * Install the process-level crash guards. Returns a disposer that removes both
+ * listeners (used by tests; the RPC server keeps them for its whole lifetime).
+ */
+export function installRpcCrashGuards(hooks: RpcCrashGuardHooks): () => void {
+	const onRejection = (reason: unknown): void => handleRpcCrash(hooks, "unhandledRejection", reason);
+	const onException = (err: unknown): void => handleRpcCrash(hooks, "uncaughtException", err);
+	process.on("unhandledRejection", onRejection);
+	process.on("uncaughtException", onException);
+	return () => {
+		process.off("unhandledRejection", onRejection);
+		process.off("uncaughtException", onException);
+	};
+}

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -42,7 +42,7 @@ import type {
 import { getGitBranch } from "../../core/git-branch.js";
 import type { ModelRegistry } from "../../core/model-registry.js";
 import { parseModelPattern, resolveModelScopePatterns } from "../../core/model-resolver.js";
-import { takeOverStdout, writeRawStdout } from "../../core/output-guard.js";
+import { flushRawStdout, takeOverStdout, writeRawStdout } from "../../core/output-guard.js";
 import type { SessionInfo, SessionTreeNode } from "../../core/session-manager.js";
 import { SessionManager } from "../../core/session-manager.js";
 import type { SettingsManager, TransportSetting } from "../../core/settings-manager.js";
@@ -58,6 +58,7 @@ import {
 } from "../../core/tools/subagent.js";
 import { type Theme, theme } from "../interactive/theme/theme.js";
 import { attachJsonlLineReader, serializeJsonLine } from "./jsonl.js";
+import { installRpcCrashGuards } from "./rpc-crash-guard.js";
 import { projectDashboardRpcEvent } from "./rpc-event-projection.js";
 import type {
 	RpcAgentTypeInfo,
@@ -1707,6 +1708,28 @@ export async function runRpcMode(session: AgentSession, modelFallbackMessage?: s
 	const error = (id: string | undefined, command: string, message: string): RpcResponse => {
 		return { id, type: "response", command, success: false, error: message };
 	};
+
+	// Install process-level crash guards so an unhandled rejection no longer
+	// silently kills the child (issue 53). Recoverable rejections keep the
+	// process alive; a fatal uncaught exception logs + emits a diagnostic and
+	// exits (code 1) for the parent's supervised restart, after best-effort
+	// flushing the diagnostic frame down the stdout pipe.
+	installRpcCrashGuards({
+		emit: (frame) => output(frame),
+		log: (line) => console.error(line),
+		exit: (code) => {
+			let exited = false;
+			const done = (): void => {
+				if (exited) return;
+				exited = true;
+				process.exit(code);
+			};
+			// Bound the flush so a dead/blocked consumer can't wedge the exit.
+			const timer = setTimeout(done, 1_000);
+			timer.unref();
+			flushRawStdout().then(done, done);
+		},
+	});
 
 	if (session.sessionFile && session.messages.length > 0) {
 		const rehydratedCount = rehydrateBackgroundAgentsFromDisk(session.sessionFile);

--- a/packages/coding-agent/test/rpc-client-spawn.test.ts
+++ b/packages/coding-agent/test/rpc-client-spawn.test.ts
@@ -173,7 +173,7 @@ describe("RpcClient spawn failure handling", () => {
 		child.exitCode = 7;
 		child.emit("exit", 7, "SIGTERM");
 
-		expect(seen).toEqual([{ code: 7, signal: "SIGTERM" }]);
+		expect(seen).toEqual([{ code: 7, signal: "SIGTERM", stderr: "" }]);
 	});
 
 	test("onExit notifies subscribers when the child emits an 'error'", async () => {
@@ -188,6 +188,25 @@ describe("RpcClient spawn failure handling", () => {
 		const error = new Error("spawn boom");
 		child.emit("error", error);
 
-		expect(seen).toEqual([{ error }]);
+		expect(seen).toEqual([{ error, stderr: "" }]);
+	});
+
+	test("onExit includes captured stderr from the child", async () => {
+		const child = makeFakeChild();
+		vi.mocked(spawn).mockReturnValue(child);
+
+		const client = new RpcClient({ cliPath: "dist/cli.js" });
+		const seen: unknown[] = [];
+		client.onExit((info) => seen.push(info));
+		await client.start();
+
+		// Simulate the child writing diagnostic output to stderr before dying.
+		child.stderr.push("Fatal: something broke\n");
+		child.exitCode = 1;
+		child.emit("exit", 1, null);
+
+		expect(seen).toHaveLength(1);
+		expect((seen[0] as any).stderr).toBe("Fatal: something broke\n");
+		expect((seen[0] as any).code).toBe(1);
 	});
 });

--- a/packages/coding-agent/test/rpc-crash-guard.test.ts
+++ b/packages/coding-agent/test/rpc-crash-guard.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import {
+	crashDiagnosticFrame,
+	formatRpcCrashDiagnostic,
+	handleRpcCrash,
+	installRpcCrashGuards,
+	type RpcCrashGuardHooks,
+} from "../src/modes/rpc/rpc-crash-guard.js";
+
+// ---------------------------------------------------------------------------
+// formatRpcCrashDiagnostic
+// ---------------------------------------------------------------------------
+
+describe("formatRpcCrashDiagnostic", () => {
+	it("formats an Error rejection as non-fatal", () => {
+		const d = formatRpcCrashDiagnostic("unhandledRejection", new Error("boom"));
+		expect(d.origin).toBe("unhandledRejection");
+		expect(d.message).toBe("boom");
+		expect(d.stack).toContain("boom");
+		expect(d.fatal).toBe(false);
+	});
+
+	it("formats an Error exception as fatal", () => {
+		const d = formatRpcCrashDiagnostic("uncaughtException", new Error("crash"));
+		expect(d.origin).toBe("uncaughtException");
+		expect(d.message).toBe("crash");
+		expect(d.fatal).toBe(true);
+	});
+
+	it("formats a string reason", () => {
+		const d = formatRpcCrashDiagnostic("unhandledRejection", "string reason");
+		expect(d.message).toBe("string reason");
+		expect(d.stack).toBeUndefined();
+	});
+
+	it("formats an object reason via JSON.stringify", () => {
+		const d = formatRpcCrashDiagnostic("unhandledRejection", { code: 42 });
+		expect(d.message).toBe('{"code":42}');
+	});
+
+	it("formats undefined/null reason", () => {
+		expect(formatRpcCrashDiagnostic("unhandledRejection", undefined).message).toBe("undefined");
+		expect(formatRpcCrashDiagnostic("unhandledRejection", null).message).toBe("null");
+	});
+
+	it("falls back to Error.name when message is empty", () => {
+		const e = new TypeError("");
+		const d = formatRpcCrashDiagnostic("uncaughtException", e);
+		expect(d.message).toBe("TypeError");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// crashDiagnosticFrame
+// ---------------------------------------------------------------------------
+
+describe("crashDiagnosticFrame", () => {
+	it("produces the expected shape", () => {
+		const d = formatRpcCrashDiagnostic("unhandledRejection", new Error("x"));
+		const frame = crashDiagnosticFrame(d);
+		expect(frame).toEqual({
+			type: "rpc_process_error",
+			origin: "unhandledRejection",
+			message: "x",
+			fatal: false,
+		});
+	});
+});
+
+// ---------------------------------------------------------------------------
+// handleRpcCrash
+// ---------------------------------------------------------------------------
+
+function makeHooks(): RpcCrashGuardHooks & {
+	emitted: object[];
+	logged: string[];
+	exited: number[];
+} {
+	return {
+		emitted: [],
+		logged: [],
+		exited: [],
+		emit(frame: object) {
+			this.emitted.push(frame);
+		},
+		log(line: string) {
+			this.logged.push(line);
+		},
+		exit(code: number) {
+			this.exited.push(code);
+		},
+	};
+}
+
+describe("handleRpcCrash", () => {
+	it("logs and emits a non-fatal rejection without exiting", () => {
+		const hooks = makeHooks();
+		handleRpcCrash(hooks, "unhandledRejection", new Error("net timeout"));
+		expect(hooks.logged).toHaveLength(1);
+		expect(hooks.logged[0]).toContain("recovered");
+		expect(hooks.logged[0]).toContain("net timeout");
+		expect(hooks.emitted).toHaveLength(1);
+		expect((hooks.emitted[0] as any).type).toBe("rpc_process_error");
+		expect((hooks.emitted[0] as any).fatal).toBe(false);
+		expect(hooks.exited).toHaveLength(0);
+	});
+
+	it("logs, emits, and exits on a fatal uncaught exception", () => {
+		const hooks = makeHooks();
+		handleRpcCrash(hooks, "uncaughtException", new Error("segfault"));
+		expect(hooks.logged).toHaveLength(1);
+		expect(hooks.logged[0]).toContain("fatal");
+		expect(hooks.emitted).toHaveLength(1);
+		expect((hooks.emitted[0] as any).fatal).toBe(true);
+		expect(hooks.exited).toEqual([1]);
+	});
+
+	it("still exits even if emit throws", () => {
+		const hooks = makeHooks();
+		hooks.emit = () => {
+			throw new Error("pipe broken");
+		};
+		handleRpcCrash(hooks, "uncaughtException", new Error("bad"));
+		// The log was still written and exit was still called.
+		expect(hooks.logged).toHaveLength(1);
+		expect(hooks.exited).toEqual([1]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// installRpcCrashGuards
+// ---------------------------------------------------------------------------
+
+describe("installRpcCrashGuards", () => {
+	it("registers and removes process listeners", () => {
+		const hooks = makeHooks();
+		const before = process.listenerCount("unhandledRejection");
+		const dispose = installRpcCrashGuards(hooks);
+		expect(process.listenerCount("unhandledRejection")).toBe(before + 1);
+		expect(process.listenerCount("uncaughtException")).toBeGreaterThan(0);
+		dispose();
+		expect(process.listenerCount("unhandledRejection")).toBe(before);
+	});
+});

--- a/packages/vscode/src/host/session-controller.ts
+++ b/packages/vscode/src/host/session-controller.ts
@@ -199,10 +199,21 @@ const defaultClientFactory: RpcClientFactory = async (options) => {
 	return new RpcClient({ cliPath: options.cliPath, cwd: options.cwd, args: options.args });
 };
 
-function formatExit(info: { code?: number | null; signal?: string | null; error?: Error }): string {
+function formatExit(info: { code?: number | null; signal?: string | null; error?: Error; stderr?: string }): string {
 	if (info?.error) return `dreb process failed: ${info.error.message}`;
 	return `dreb process exited (code ${info?.code ?? "null"}, signal ${info?.signal ?? "null"})`;
 }
+
+/** Recovery policy tuning (deliverable C, issue 53). Bounded auto-restart so a
+ * transient crash self-heals but a crash-loop (dead pipe / deterministic
+ * startup failure) degrades to a banner instead of spinning forever. */
+const RESTART_MAX_IN_WINDOW = 3;
+const RESTART_WINDOW_MS = 60_000;
+const RESTART_BACKOFF_MS = 500;
+/** How long a restarted child must stay up before the crash counter resets, so
+ * a *later* isolated crash still gets a fresh recovery budget. */
+const RESTART_STABLE_MS = 10_000;
+const RECOVERING_NOTICE = "dreb stopped unexpectedly — recovering…";
 
 function errorText(err: unknown): string {
 	return err instanceof Error ? err.message : String(err);
@@ -282,6 +293,18 @@ export class SessionController {
 	private unsubEvent: (() => void) | undefined;
 	private unsubExit: (() => void) | undefined;
 	private disposed = false;
+	/** Resume path for `start()`: the `--session` file to load. Starts as the
+	 * construction-time resume path and is re-pointed at the live session file on
+	 * an auto-restart so recovery is lossless. */
+	private resumePath: string | undefined;
+	/** Timestamps of recent auto-restart attempts (rolling window), used to bound
+	 * recovery against a crash-loop (deliverable C). */
+	private restartTimestamps: number[] = [];
+	/** Pending backoff timer for a scheduled restart. */
+	private restartTimer: ReturnType<typeof setTimeout> | undefined;
+	/** Fires once a restarted child has stayed up long enough to be considered
+	 * stable, clearing the crash budget. */
+	private stableTimer: ReturnType<typeof setTimeout> | undefined;
 	/** Serializes status refreshes: coalesces an overlapping request into one
 	 * trailing re-run so a new turn starting mid-refresh still ends up current.
 	 * `statusAgainIncludeDaily` accumulates the daily-cost intent of every
@@ -293,6 +316,7 @@ export class SessionController {
 
 	constructor(options: SessionControllerOptions) {
 		this.options = options;
+		this.resumePath = options.sessionPath;
 		this.factory = options.clientFactory ?? defaultClientFactory;
 		this.ui = options.ui ?? noopHostUi;
 		this.reviewUi = options.review ?? noopReviewUi;
@@ -389,10 +413,7 @@ export class SessionController {
 	/** Spawn the RPC child, wire event/exit handlers, and prime the command list. */
 	async start(): Promise<void> {
 		if (this.disposed) throw new Error("SessionController is disposed");
-		const args = [
-			...(this.options.args ?? []),
-			...(this.options.sessionPath ? ["--session", this.options.sessionPath] : []),
-		];
+		const args = [...(this.options.args ?? []), ...(this.resumePath ? ["--session", this.resumePath] : [])];
 		const client = await this.factory({
 			cliPath: this.options.cliPath,
 			cwd: this.options.cwd,
@@ -425,7 +446,7 @@ export class SessionController {
 		// persisted branch in now (same path as restore/fork) so prior turns render
 		// immediately. Guarded on `sessionPath` so a brand-new session keeps
 		// populating from the live stream and doesn't fold on start.
-		if (this.options.sessionPath) {
+		if (this.resumePath) {
 			try {
 				await this.rebuildTranscript();
 			} catch (err) {
@@ -1109,6 +1130,8 @@ export class SessionController {
 	async dispose(): Promise<void> {
 		if (this.disposed) return;
 		this.disposed = true;
+		this.clearRestartTimer();
+		this.clearStableTimer();
 		this.unsubEvent?.();
 		this.unsubExit?.();
 		this.listeners.clear();
@@ -1147,17 +1170,130 @@ export class SessionController {
 		// the way the dashboard does on the streaming→idle transition, and
 		// recompute the change-review set from the baseline.
 		if (type === "agent_end") {
+			// A completed turn proves the child is alive and processing, so treat it
+			// as a stable run: clear the crash-recovery budget.
+			this.restartTimestamps = [];
+			this.clearStableTimer();
 			void this.refreshStatus(true);
 			void this.refreshReview();
 			void this.refreshCheckpoints();
 		}
 	}
 
-	private handleExit(info: { code?: number | null; signal?: string | null; error?: Error }): void {
+	private handleExit(info: { code?: number | null; signal?: string | null; error?: Error; stderr?: string }): void {
 		if (this.disposed) return;
 		const message = formatExit(info);
-		this.setStatus({ ...this.status, connected: false, error: message });
-		this.handleEvent({ type: "host_error", message });
+		// Surface the child's captured stderr (deliverable B) so a late crash's
+		// trigger is recorded for diagnosis instead of being discarded.
+		const stderr = info.stderr?.trim();
+		if (stderr) this.logger(`RPC child exited (${message}); stderr:\n${stderr}`);
+		else this.logger(`RPC child exited (${message})`);
+		// Drop the dead client + its stale listeners before attempting recovery so
+		// a leftover handler can't fire against the old process.
+		this.teardownClient();
+		// Automated in-place recovery (deliverable C): auto-restart from the
+		// persisted transcript, bounded by a crash-loop budget.
+		this.beginRecovery(message);
+	}
+
+	/** Tear down the current client's subscriptions and drop the reference. The
+	 * child is presumed already gone (called from the exit path), but stop() is
+	 * still invoked best-effort to release any client-side resources. */
+	private teardownClient(): void {
+		this.unsubEvent?.();
+		this.unsubExit?.();
+		this.unsubEvent = undefined;
+		this.unsubExit = undefined;
+		const dead = this.client;
+		this.client = undefined;
+		void Promise.resolve(dead?.stop()).catch(() => {});
+	}
+
+	/** Decide whether to auto-restart the crashed child (bounded) or give up with
+	 * a persistent banner. Called on an unexpected exit and on a failed restart. */
+	private beginRecovery(reason: string): void {
+		if (this.disposed) return;
+		if (!this.withinRestartBudget()) {
+			this.giveUpRecovery(reason);
+			return;
+		}
+		this.recordRestartAttempt();
+		// Clear the error so `hasFailed()` stays false and the host doesn't tear
+		// this controller down mid-recovery; show a transient notice rather than a
+		// fatal banner.
+		this.setStatus({ ...this.status, connected: false, error: undefined });
+		this.emitNotice(RECOVERING_NOTICE);
+		this.clearRestartTimer();
+		this.restartTimer = setTimeout(() => {
+			this.restartTimer = undefined;
+			void this.restart(reason);
+		}, RESTART_BACKOFF_MS);
+		this.restartTimer.unref?.();
+	}
+
+	/** Auto-restart the RPC child in place, resuming from the live session file so
+	 * the persisted transcript is reloaded losslessly. All controller-lifetime
+	 * listeners and the connected webview bridge stay attached. */
+	private async restart(reason: string): Promise<void> {
+		if (this.disposed) return;
+		// Resume from the live session file (falls back to the original resume
+		// path for a session that never wrote an entry before crashing).
+		this.resumePath = this.sessionPath;
+		try {
+			await this.start();
+		} catch {
+			// start() already surfaced its own failure status; route the failed
+			// attempt back through the bounded policy (retry or give up).
+			this.beginRecovery(reason);
+			return;
+		}
+		// Connected again. Arm a stable-run reset so a child that survives long
+		// enough clears the crash budget and a *later* isolated crash still gets a
+		// fresh recovery allowance.
+		this.armStableRunReset();
+	}
+
+	/** Terminal recovery state: repeated crashes within the window. Surface a
+	 * persistent, actionable banner. */
+	private giveUpRecovery(reason: string): void {
+		const banner = `${reason} — automatic recovery failed after repeated crashes. Reopen the chat to restart.`;
+		this.setStatus({ ...this.status, connected: false, error: banner });
+		this.handleEvent({ type: "host_error", message: banner });
+	}
+
+	/** True while the rolling window still has restart budget left. Prunes stale
+	 * attempts so the budget refills once the window passes. */
+	private withinRestartBudget(): boolean {
+		const now = Date.now();
+		this.restartTimestamps = this.restartTimestamps.filter((t) => now - t < RESTART_WINDOW_MS);
+		return this.restartTimestamps.length < RESTART_MAX_IN_WINDOW;
+	}
+
+	private recordRestartAttempt(): void {
+		this.restartTimestamps.push(Date.now());
+	}
+
+	private armStableRunReset(): void {
+		this.clearStableTimer();
+		this.stableTimer = setTimeout(() => {
+			this.stableTimer = undefined;
+			this.restartTimestamps = [];
+		}, RESTART_STABLE_MS);
+		this.stableTimer.unref?.();
+	}
+
+	private clearRestartTimer(): void {
+		if (this.restartTimer !== undefined) {
+			clearTimeout(this.restartTimer);
+			this.restartTimer = undefined;
+		}
+	}
+
+	private clearStableTimer(): void {
+		if (this.stableTimer !== undefined) {
+			clearTimeout(this.stableTimer);
+			this.stableTimer = undefined;
+		}
 	}
 
 	private emitNotice(message: string): void {

--- a/packages/vscode/test/session-controller.test.ts
+++ b/packages/vscode/test/session-controller.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { HostUi, HostUiPickItem, WorkspaceSearchResult } from "../src/host/host-ui.js";
 import { type RpcClientLike, SessionController } from "../src/host/session-controller.js";
 import type { SourceLinkUi } from "../src/host/source-link-ui.js";
@@ -1042,7 +1042,9 @@ describe("SessionController", () => {
 		await controller.submit("hello after crash");
 
 		expect(fake.prompts).toHaveLength(0);
-		expect(controller.getTranscript().statusText).toMatch(/isn't connected/);
+		// During auto-recovery the error is cleared and the controller shows a
+		// transient "starting up" notice rather than a persistent failure.
+		expect(controller.getTranscript().statusText).toMatch(/starting up|recovering/i);
 	});
 
 	it("surfaces a notice instead of leaking a rejected prompt call", async () => {
@@ -1082,8 +1084,11 @@ describe("SessionController", () => {
 
 		fake.emitExit({ code: 1, signal: null });
 
-		expect(controller.getStatus().error).toMatch(/exited/);
-		expect(controller.getTranscript().hostError).toMatch(/exited/);
+		// Auto-restart (issue 53): the error is cleared during recovery; a
+		// transient notice replaces the persistent banner until recovery
+		// completes or the budget is exhausted.
+		expect(controller.getStatus().error).toBeUndefined();
+		expect(controller.getTranscript().statusText).toMatch(/recovering/i);
 		expect(updates.some((u) => u.kind === "status")).toBe(true);
 		expect(updates.some((u) => u.kind === "event")).toBe(true);
 	});
@@ -1122,13 +1127,24 @@ describe("SessionController", () => {
 			expect(controller.hasFailed()).toBe(false);
 		});
 
-		it("is true after the RPC child exits unexpectedly", async () => {
-			const fake = new FakeClient();
-			const controller = makeController(fake);
+		it("is true only after the restart budget is exhausted", async () => {
+			vi.useFakeTimers();
+			const clients: FakeClient[] = [];
+			const controller = new SessionController({
+				cwd: "/tmp/project",
+				cliPath: "/cli.js",
+				clientFactory: () => {
+					const c = new FakeClient();
+					clients.push(c);
+					return c;
+				},
+			});
 			await controller.start();
-			fake.emitExit({ code: 1, signal: null });
-			expect(controller.hasFailed()).toBe(true);
-			expect(controller.isDisposed()).toBe(false); // still live, just failed
+			// A single crash triggers recovery, not a persistent failure.
+			clients[0].emitExit({ code: 1, signal: null });
+			expect(controller.hasFailed()).toBe(false);
+			expect(controller.isDisposed()).toBe(false);
+			vi.useRealTimers();
 		});
 
 		it("is true after a failed start() handshake", async () => {
@@ -1870,5 +1886,165 @@ describe("SessionController resume (Phase 5 — rebuild transcript on start)", (
 		// a silent blank window indistinguishable from a brand-new session
 		// (finding 1).
 		expect(controller.getTranscript().statusText).toMatch(/still saved/i);
+	});
+});
+
+// ===========================================================================
+// Auto-restart / crash recovery (issue 53, deliverable C)
+// ===========================================================================
+
+describe("SessionController — auto-restart on crash", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	/** Build a controller with a factory that dispenses fresh FakeClients for each
+	 * start() call, tracking them for inspection. The first client is started
+	 * immediately (like the real extension does) so the controller is "connected"
+	 * before a test drives an exit. */
+	async function setup(opts: { sessionPath?: string } = {}) {
+		const clients: FakeClient[] = [];
+		const factory = () => {
+			const c = new FakeClient();
+			c.state = { sessionFile: "/sessions/live.jsonl" };
+			clients.push(c);
+			return c;
+		};
+		const logs: string[] = [];
+		const controller = new SessionController({
+			cwd: "/tmp/project",
+			cliPath: "/cli.js",
+			clientFactory: factory,
+			sessionPath: opts.sessionPath ?? "/sessions/original.jsonl",
+			logger: (line) => logs.push(line),
+		});
+		await controller.start();
+		return { controller, clients, logs };
+	}
+
+	it("auto-restarts a single crash and reconnects", async () => {
+		const { controller, clients } = await setup();
+		expect(clients).toHaveLength(1);
+		expect(controller.hasFailed()).toBe(false);
+
+		// Simulate the child dying.
+		clients[0].emitExit({ code: 1, signal: null, stderr: "bang" });
+
+		// Should not be in a persistent failure state (recovery is in progress).
+		expect(controller.hasFailed()).toBe(false);
+
+		// Advance past the restart backoff (500ms).
+		await vi.advanceTimersByTimeAsync(600);
+
+		// A new client should have been created and started.
+		expect(clients).toHaveLength(2);
+		expect(clients[1].started).toBe(true);
+		expect(controller.hasFailed()).toBe(false);
+	});
+
+	it("logs stderr from the crashed child", async () => {
+		const { clients, logs } = await setup();
+		clients[0].emitExit({ code: 1, signal: null, stderr: "  Fatal: pipe dead\n" });
+		expect(logs.some((l) => l.includes("Fatal: pipe dead"))).toBe(true);
+	});
+
+	it("gives up after 3 rapid crashes (budget exhausted)", async () => {
+		const { controller, clients } = await setup();
+
+		// Crash 1: auto-restarts.
+		clients[0].emitExit({ code: 1, signal: null });
+		await vi.advanceTimersByTimeAsync(600);
+		expect(clients).toHaveLength(2);
+
+		// Crash 2: auto-restarts.
+		clients[1].emitExit({ code: 1, signal: null });
+		await vi.advanceTimersByTimeAsync(600);
+		expect(clients).toHaveLength(3);
+
+		// Crash 3: auto-restarts.
+		clients[2].emitExit({ code: 1, signal: null });
+		await vi.advanceTimersByTimeAsync(600);
+		expect(clients).toHaveLength(4);
+
+		// Crash 4: budget exhausted — should give up with a persistent error.
+		clients[3].emitExit({ code: 1, signal: null });
+		await vi.advanceTimersByTimeAsync(600);
+		// No new client — gave up.
+		expect(clients).toHaveLength(4);
+		expect(controller.hasFailed()).toBe(true);
+	});
+
+	it("resets budget after a stable run (agent_end)", async () => {
+		const { controller, clients } = await setup();
+
+		// Crash 1 + recovery.
+		clients[0].emitExit({ code: 1, signal: null });
+		await vi.advanceTimersByTimeAsync(600);
+		expect(clients).toHaveLength(2);
+
+		// Simulate a completed turn on the recovered child — resets budget.
+		clients[1].emit({ type: "agent_end", messages: [] });
+
+		// Now crash again — should recover because budget was reset.
+		clients[1].emitExit({ code: 1, signal: null });
+		await vi.advanceTimersByTimeAsync(600);
+		expect(clients).toHaveLength(3);
+		expect(controller.hasFailed()).toBe(false);
+	});
+
+	it("does not auto-restart if disposed", async () => {
+		const { controller, clients } = await setup();
+		await controller.dispose();
+		clients[0].emitExit({ code: 1, signal: null });
+		await vi.advanceTimersByTimeAsync(600);
+		// No recovery attempted.
+		expect(clients).toHaveLength(1);
+	});
+
+	it("resumes from the live sessionPath (not the original)", async () => {
+		const { controller, clients } = await setup({ sessionPath: "/sessions/original.jsonl" });
+		// After start, refreshStatus sets sessionFile from state:
+		expect(controller.sessionPath).toBe("/sessions/live.jsonl");
+
+		clients[0].emitExit({ code: 1, signal: null });
+		await vi.advanceTimersByTimeAsync(600);
+		// The 2nd client exists; verify the controller now uses the live path.
+		// (start() passes --session <resumePath>, which we set to sessionPath
+		// before restart — indirectly verified by the controller's getter.)
+		expect(controller.sessionPath).toBe("/sessions/live.jsonl");
+	});
+
+	it("retries when the restart's start() throws, then gives up after budget", async () => {
+		const clients: FakeClient[] = [];
+		const factory = () => {
+			const c = new FakeClient();
+			c.state = { sessionFile: "/sessions/live.jsonl" };
+			// After the first client, all subsequent ones fail to start.
+			if (clients.length >= 1) c.startError = new Error("spawn failed");
+			clients.push(c);
+			return c;
+		};
+		const controller = new SessionController({
+			cwd: "/tmp/project",
+			cliPath: "/cli.js",
+			clientFactory: factory,
+			sessionPath: "/sessions/original.jsonl",
+		});
+		await controller.start();
+
+		// The first client (index 0) crashes.
+		clients[0].emitExit({ code: 1, signal: null });
+
+		// Each restart attempt will throw, cycling through the budget.
+		// Budget: 3 restarts × 500ms backoff each + the failed start cascading back.
+		for (let i = 0; i < 10; i++) {
+			await vi.advanceTimersByTimeAsync(600);
+		}
+
+		// Should eventually give up.
+		expect(controller.hasFailed()).toBe(true);
 	});
 });

--- a/packages/vscode/test/webview-bridge.test.ts
+++ b/packages/vscode/test/webview-bridge.test.ts
@@ -165,11 +165,12 @@ describe("connectWebview", () => {
 		connectWebview(webview as any, controller);
 		send({ type: "ready" });
 
-		// A child crash drives both a host_error event and a status update; both
-		// must reach the webview now that it is live.
+		// A child crash drives a recovering notice (host_notice event) and a
+		// status update while auto-restart is in progress; both must reach the
+		// webview now that it is live.
 		fake.emitExit({ code: 1, signal: null });
 		expect(posted.some((m) => m.type === "status")).toBe(true);
-		expect(posted.some((m) => m.type === "event" && (m.event as any)?.type === "host_error")).toBe(true);
+		expect(posted.some((m) => m.type === "event" && (m.event as any)?.type === "host_notice")).toBe(true);
 	});
 
 	it("dispatches webview messages to the controller", async () => {


### PR DESCRIPTION
Closes #53

Harden the RPC child process against mid-turn crashes and make the VSCode chat self-heal:

- **Crash guards** in the RPC server so an unhandled rejection/exception surfaces as a session error instead of terminating the child (shared layer — benefits dashboard too).
- **Surface child stderr** on unexpected exit for diagnosis.
- **Automated in-place recovery** in the VSCode session controller: on an unexpected child exit, auto-restart resuming from the persisted transcript, with a crash-loop budget that falls back to a clear banner.

Base branch: `vscode`. Implementation plan posted as a comment below.
