### PR TITLE
VSCode review: serve raw working-tree baseline so single-line edits diff correctly

### DIFF
--- a/packages/vscode/src/host/git-snapshot.ts
+++ b/packages/vscode/src/host/git-snapshot.ts
@@ -24,7 +24,7 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { existsSync, lstatSync, mkdtempSync, rmSync, statSync, unlinkSync, writeFileSync } from "node:fs";
+import { existsSync, lstatSync, mkdtempSync, renameSync, rmSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { parseFileDiff, sliceHunkPatch } from "./diff-hunks.js";
@@ -328,14 +328,17 @@ function lstatSafe(p: string): ReturnType<typeof lstatSync> | undefined {
  * mistaken for "absent from baseline" and trigger a destructive delete/truncate.
  *
  * The working-tree entry is inspected with `lstat` (never following symlinks).
- * We remove it before recreating the file only when leaving it in place would
- * be unsafe: a symlink (whose `'w'` write would follow the link and clobber its
- * target — possibly a file outside the repository) or a hard link (`nlink > 1`,
- * whose in-place `'w'` truncate would corrupt every other name sharing that
- * inode, again possibly outside the repository). An ordinary, singly-linked
- * regular file is overwritten in place so its mode bits (e.g. the exec bit) are
- * preserved. In the "absent" branch we remove any lingering entry (including a
- * broken symlink, which `existsSync` would have mis-reported as already gone).
+ * When leaving the entry in place would be unsafe — a symlink (whose `'w'` write
+ * would follow the link and clobber its target, possibly outside the repository)
+ * or a hard link (`nlink > 1`, whose in-place `'w'` truncate would corrupt every
+ * other name sharing that inode) — we write the baseline bytes to a sibling temp
+ * file and atomically `rename` it over the path. The rename replaces the entry
+ * without following it, and (unlike unlink-then-write) never leaves the path
+ * deleted if the write fails: the original survives until the rename succeeds.
+ * An ordinary, singly-linked regular file is overwritten in place so its mode
+ * bits (e.g. the exec bit) are preserved. In the "absent" branch we remove any
+ * lingering entry (including a broken symlink, which `existsSync` would have
+ * mis-reported as already gone).
  */
 export function revertFile(cwd: string, baselineTree: string, path: string): boolean {
 	const root = findGitRoot(cwd);
@@ -349,11 +352,29 @@ export function revertFile(cwd: string, baselineTree: string, path: string): boo
 			if (entry) unlinkSync(abs);
 			return true;
 		}
-		// Drop the entry first only when writing in place would be unsafe: a
-		// symlink (would follow the link) or a hard link (would truncate a shared
-		// inode). An ordinary single-link regular file is overwritten in place so
-		// its mode bits are preserved.
-		if (entry && (!entry.isFile() || entry.nlink > 1)) unlinkSync(abs);
+		// When an in-place write would be unsafe (symlink → followed; hard link →
+		// shared-inode truncate), stage the baseline bytes in a sibling temp file
+		// and atomically rename over the entry. The rename swaps the entry without
+		// following it and, unlike unlink-then-write, never leaves the path deleted
+		// on a mid-write failure (ENOSPC, EPERM, read-only remount): the original
+		// entry persists until the rename lands.
+		if (entry && (!entry.isFile() || entry.nlink > 1)) {
+			const tmp = `${abs}.dreb-revert-${process.pid}-${Date.now()}`;
+			try {
+				writeFileSync(tmp, read.buf);
+				renameSync(tmp, abs);
+			} catch (err) {
+				try {
+					if (lstatSafe(tmp)) unlinkSync(tmp);
+				} catch {
+					// best-effort temp cleanup
+				}
+				throw err;
+			}
+			return true;
+		}
+		// An ordinary single-link regular file is overwritten in place so its mode
+		// bits are preserved.
 		writeFileSync(abs, read.buf);
 		return true;
 	} catch {

--- a/packages/vscode/src/host/git-snapshot.ts
+++ b/packages/vscode/src/host/git-snapshot.ts
@@ -128,9 +128,65 @@ function readBaselineBlob(root: string, tree: string, path: string): BlobRead {
 }
 
 /**
+ * Replace every regular-file blob staged in `indexFile` with a hash of its
+ * **raw working-tree bytes**, bypassing git's clean/EOL/attribute filters.
+ *
+ * `git add` applies `.gitattributes` (`text`/`text=auto`/`eol=…`) and
+ * `core.autocrlf` normalization when staging, so the stored blob can differ from
+ * the on-disk file (classically CRLF→LF). The change-review surface serves this
+ * blob as the diff's left side and quick-diff reference while the right side is
+ * the untouched working file, so a normalized baseline mismatches the working
+ * file on *every* line — rendering a one-line edit as a whole-file rewrite
+ * (issue 57). Snapshotting raw bytes keeps the baseline byte-identical to disk,
+ * so unchanged lines read as unchanged and the tree-to-tree diff/hunk/revert
+ * paths stay consistent with what the editor shows.
+ *
+ * Only regular files (mode 100644/100755) are re-hashed; symlinks (120000) and
+ * gitlinks (160000) have no filterable on-disk text and are left as staged.
+ * Best-effort: any git failure or output desync leaves the (normalized) index
+ * untouched rather than aborting the snapshot — a normalized baseline is still
+ * functional, just subject to the original mismatch.
+ */
+function rehashRawBytes(root: string, indexFile: string): void {
+	const listed = runGit(root, ["ls-files", "-s", "-z"], { indexFile });
+	if (listed.status !== 0 || listed.stdout.length === 0) return;
+	// `-s -z` entry: "<mode> <sha> <stage>\t<path>" (NUL-terminated). The path may
+	// contain any byte except NUL — including tabs/spaces — so split on the FIRST
+	// tab only (mode/sha/stage never contain a tab).
+	const files: { mode: string; path: string }[] = [];
+	for (const entry of listed.stdout.split("\0")) {
+		if (entry.length === 0) continue;
+		const tab = entry.indexOf("\t");
+		if (tab < 0) continue;
+		const mode = entry.slice(0, tab).split(" ")[0];
+		if (mode === "100644" || mode === "100755") files.push({ mode, path: entry.slice(tab + 1) });
+	}
+	if (files.length === 0) return;
+	// Hash raw bytes in path-argument chunks (robust to any path characters; kept
+	// well under ARG_MAX). One sha per path is emitted in order.
+	const CHUNK = 256;
+	const info: string[] = [];
+	for (let i = 0; i < files.length; i += CHUNK) {
+		const chunk = files.slice(i, i + CHUNK);
+		const hashed = runGit(root, ["hash-object", "-w", "--no-filters", "--", ...chunk.map((f) => f.path)]);
+		if (hashed.status !== 0) return;
+		const shas = hashed.stdout.split("\n").filter((s) => s.length > 0);
+		if (shas.length !== chunk.length) return;
+		for (let j = 0; j < chunk.length; j++) info.push(`${chunk[j].mode} ${shas[j]}\t${chunk[j].path}`);
+	}
+	// `-z --index-info`: NUL-terminated "<mode> <sha>\t<path>" records overwrite
+	// the normalized blobs with the raw ones in a single pass.
+	runGit(root, ["update-index", "-z", "--index-info"], { indexFile, input: info.map((l) => `${l}\0`).join("") });
+}
+
+/**
  * Snapshot the current working tree into a git tree object via a throwaway index
  * (so the user's real index/working tree are untouched). Returns the tree SHA,
  * or null if the snapshot could not be taken (e.g. not a git repo).
+ *
+ * The staged blobs are re-hashed from raw working-tree bytes (see
+ * {@link rehashRawBytes}) so the tree mirrors on-disk content exactly, rather
+ * than git's clean/EOL-normalized form.
  *
  * All git operations run from the repository root (resolved via `findGitRoot`),
  * so the resulting tree — and every path derived from diffing it — is
@@ -145,6 +201,7 @@ export function captureTree(cwd: string): string | null {
 	try {
 		const add = runGit(root, ["add", "-A"], { indexFile });
 		if (add.status !== 0) return null;
+		rehashRawBytes(root, indexFile);
 		const write = runGit(root, ["write-tree"], { indexFile });
 		if (write.status !== 0) return null;
 		const tree = write.stdout.trim();

--- a/packages/vscode/src/host/git-snapshot.ts
+++ b/packages/vscode/src/host/git-snapshot.ts
@@ -158,7 +158,7 @@ function rehashRawBytes(root: string, indexFile: string): void {
 		if (entry.length === 0) continue;
 		const tab = entry.indexOf("\t");
 		if (tab < 0) continue;
-		const mode = entry.slice(0, tab).split(" ")[0];
+		const mode = entry.split(" ")[0];
 		if (mode === "100644" || mode === "100755") files.push({ mode, path: entry.slice(tab + 1) });
 	}
 	if (files.length === 0) return;

--- a/packages/vscode/test/git-snapshot.test.ts
+++ b/packages/vscode/test/git-snapshot.test.ts
@@ -21,7 +21,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	baselineContent,
 	captureTree,
@@ -475,5 +475,37 @@ describe("git-snapshot — raw-bytes baseline (EOL normalization, issue 57)", ()
 		// ("file.txt"), not the CRLF contents of the file it points at — proving
 		// the mode guard left it out of the raw re-hash.
 		expect(baselineContent(repo, base, "link.txt")).toBe("file.txt");
+	});
+
+	it("keeps the original entry intact and returns false when the replacement write fails", () => {
+		// Reproduces the exact round-1 failure scenario for an unsafe entry: the
+		// replacement write fails AFTER the working tree is otherwise untouched. The
+		// fix stages the baseline bytes in a sibling temp file and only swaps it in
+		// with an atomic rename, so a failed write must leave the original entry in
+		// place (the pre-fix unlink-then-write would have deleted it first).
+		writeFileSync(join(repo, "real.txt"), "REAL\n");
+		symlinkSync("real.txt", join(repo, "link.txt")); // unsafe entry (symlink)
+		commitAll(repo, "init");
+		const base = captureTree(repo) as string;
+
+		// Force the temp write to fail deterministically while the directory stays
+		// writable: pin Date.now() so the temp path is predictable, then occupy that
+		// exact path with a directory so writeFileSync throws EISDIR. Because the
+		// directory is writable, a regression to unlink-then-write WOULD succeed in
+		// deleting the symlink first — this asserts the atomic path does not.
+		const fixed = 1234567890;
+		const nowSpy = vi.spyOn(Date, "now").mockReturnValue(fixed);
+		const tmp = join(repo, `link.txt.dreb-revert-${process.pid}-${fixed}`);
+		mkdirSync(tmp);
+		try {
+			expect(revertFile(repo, base, "link.txt")).toBe(false);
+		} finally {
+			nowSpy.mockRestore();
+			rmSync(tmp, { recursive: true, force: true });
+		}
+		// The symlink survived the failed revert: still a symlink, still resolving
+		// to real.txt — not deleted, not replaced with a partial/empty file.
+		expect(lstatSync(join(repo, "link.txt")).isSymbolicLink()).toBe(true);
+		expect(readFileSync(join(repo, "link.txt"), "utf-8")).toBe("REAL\n");
 	});
 });

--- a/packages/vscode/test/git-snapshot.test.ts
+++ b/packages/vscode/test/git-snapshot.test.ts
@@ -455,4 +455,25 @@ describe("git-snapshot — raw-bytes baseline (EOL normalization, issue 57)", ()
 		// CRLF endings survive the reverse-patch (no normalization crept in).
 		expect(readFileSync(join(repo, "file.txt"), "utf-8")).toContain("\r\n");
 	});
+
+	it("leaves a tracked symlink uncorrupted while re-hashing a CRLF file", () => {
+		// The raw re-hash re-hashes only regular files (100644/100755). A tracked
+		// symlink (mode 120000) must be skipped: `hash-object --no-filters` on the
+		// link path would FOLLOW the link and store the target file's bytes as the
+		// symlink blob, silently corrupting the tree.
+		writeFileSync(join(repo, ".gitattributes"), "* text=auto\n");
+		const before = crlf(["line1", "line2", "line3"]);
+		writeFileSync(join(repo, "file.txt"), before);
+		symlinkSync("file.txt", join(repo, "link.txt")); // tracked symlink → file.txt
+		commitAll(repo, "init");
+
+		const base = captureTree(repo) as string;
+		expect(base).not.toBeNull();
+		// The regular file is re-hashed to its raw CRLF bytes…
+		expect(baselineContent(repo, base, "file.txt")).toBe(before);
+		// …while the symlink's baseline blob is still its target PATH string
+		// ("file.txt"), not the CRLF contents of the file it points at — proving
+		// the mode guard left it out of the raw re-hash.
+		expect(baselineContent(repo, base, "link.txt")).toBe("file.txt");
+	});
 });

--- a/packages/vscode/test/git-snapshot.test.ts
+++ b/packages/vscode/test/git-snapshot.test.ts
@@ -343,3 +343,116 @@ describe("git-snapshot", () => {
 		expect(() => lstatSync(join(repo, "link.txt"))).toThrow();
 	});
 });
+
+/**
+ * Issue 57 regression: the baseline snapshot must mirror the on-disk file
+ * byte-for-byte, bypassing git's clean/EOL/attribute normalization. Otherwise a
+ * CRLF working file under `text=auto`/`core.autocrlf`/`eol=…` is stored as LF,
+ * so the served baseline mismatches the working file on EVERY line and a
+ * one-line edit renders as a whole-file rewrite.
+ */
+describe("git-snapshot — raw-bytes baseline (EOL normalization, issue 57)", () => {
+	let repo: string;
+
+	beforeEach(() => {
+		repo = mkdtempSync(join(tmpdir(), "dreb-eol-"));
+		initRepo(repo);
+	});
+
+	afterEach(() => {
+		rmSync(repo, { recursive: true, force: true });
+	});
+
+	/** Join lines with CRLF terminators (including a trailing CRLF). */
+	const crlf = (ls: string[]): string => ls.map((l) => `${l}\r\n`).join("");
+
+	function commitAll(dir: string, msg: string): void {
+		git(["add", "-A"], dir);
+		git(["commit", "-m", msg], dir);
+	}
+
+	it("serves a CRLF baseline byte-for-byte under `* text=auto` (not normalized to LF)", () => {
+		writeFileSync(join(repo, ".gitattributes"), "* text=auto\n");
+		const before = crlf(["line1", "line2", "line3", "line4"]);
+		writeFileSync(join(repo, "file.txt"), before);
+		commitAll(repo, "init crlf");
+
+		const base = captureTree(repo) as string;
+		expect(base).not.toBeNull();
+		// The served baseline is the exact on-disk bytes — CRLF preserved — so the
+		// diff editor's left side matches the working file instead of differing on
+		// every line (the whole-file "recreated" symptom).
+		expect(baselineContent(repo, base, "file.txt")).toBe(before);
+		expect(baselineContent(repo, base, "file.txt")).toContain("\r\n");
+	});
+
+	it("shows a single-line CRLF edit as one modified hunk, not a whole-file rewrite", () => {
+		writeFileSync(join(repo, ".gitattributes"), "* text=auto\n");
+		const before = crlf(["line1", "line2", "line3", "line4"]);
+		writeFileSync(join(repo, "file.txt"), before);
+		commitAll(repo, "init");
+
+		const base = captureTree(repo) as string;
+		// Agent edits ONE line, preserving the file's CRLF endings.
+		writeFileSync(join(repo, "file.txt"), crlf(["line1", "AGENT", "line3", "line4"]));
+
+		// Classified as a modified single-hunk change (NOT added/recreated).
+		expect(changedFiles(repo, base)).toEqual([{ path: "file.txt", status: "modified", hunkCount: 1 }]);
+		// The baseline still matches the PRE-edit file byte-for-byte, so unchanged
+		// lines (line1/line3/line4) read as unchanged in the editor.
+		expect(baselineContent(repo, base, "file.txt")).toBe(before);
+	});
+
+	it("preserves CRLF under core.autocrlf=true", () => {
+		git(["config", "--local", "core.autocrlf", "true"], repo);
+		const before = crlf(["a", "b", "c"]);
+		writeFileSync(join(repo, "file.txt"), before);
+		commitAll(repo, "init");
+
+		const base = captureTree(repo) as string;
+		expect(baselineContent(repo, base, "file.txt")).toBe(before);
+	});
+
+	it("preserves CRLF under an explicit `eol=crlf` attribute", () => {
+		writeFileSync(join(repo, ".gitattributes"), "*.txt text eol=crlf\n");
+		const before = crlf(["a", "b", "c"]);
+		writeFileSync(join(repo, "file.txt"), before);
+		commitAll(repo, "init");
+
+		const base = captureTree(repo) as string;
+		expect(baselineContent(repo, base, "file.txt")).toBe(before);
+	});
+
+	it("revertFile restores exact CRLF bytes after a normalizing edit", () => {
+		writeFileSync(join(repo, ".gitattributes"), "* text=auto\n");
+		const before = crlf(["line1", "line2", "line3"]);
+		writeFileSync(join(repo, "file.txt"), before);
+		commitAll(repo, "init");
+
+		const base = captureTree(repo) as string;
+		writeFileSync(join(repo, "file.txt"), crlf(["line1", "AGENT", "line3"]));
+		expect(revertFile(repo, base, "file.txt")).toBe(true);
+		// The whole file, including its CRLF endings, is restored byte-for-byte.
+		expect(readFileSync(join(repo, "file.txt"), "utf-8")).toBe(before);
+	});
+
+	it("revertHunk reverses one CRLF hunk while leaving another intact", () => {
+		writeFileSync(join(repo, ".gitattributes"), "* text=auto\n");
+		const original = Array.from({ length: 20 }, (_, i) => `line${i + 1}`);
+		writeFileSync(join(repo, "file.txt"), crlf(original));
+		commitAll(repo, "init");
+
+		const base = captureTree(repo) as string;
+		const body = [...original];
+		body[2] = "AGENT3"; // hunk near line 3
+		body[15] = "AGENT16"; // well-separated second hunk
+		writeFileSync(join(repo, "file.txt"), crlf(body));
+
+		expect(revertHunk(repo, base, "file.txt", 0)).toBe(true);
+		const after = readFileSync(join(repo, "file.txt"), "utf-8").split("\r\n");
+		expect(after[2]).toBe("line3"); // first hunk reverted against a CRLF baseline
+		expect(after[15]).toBe("AGENT16"); // second preserved
+		// CRLF endings survive the reverse-patch (no normalization crept in).
+		expect(readFileSync(join(repo, "file.txt"), "utf-8")).toContain("\r\n");
+	});
+});


### PR DESCRIPTION
Closes #57

Fixes the VSCode change-review surface rendering single-line edits as whole-file/newly-created. Root cause: the baseline is snapshotted with `git add -A`, which applies `.gitattributes`/`core.autocrlf` normalization, so the served baseline (normalized) never matches the raw on-disk working file — every line reads as changed. Fix: capture and serve raw working-tree bytes.

Implementation plan posted as a comment below.
