### PR TITLE
VSCode extension: lightweight system-prompt pointer that the extension exists

### DIFF
--- a/packages/coding-agent/src/config.ts
+++ b/packages/coding-agent/src/config.ts
@@ -162,6 +162,11 @@ export function getExamplesPath(): string {
 	return resolve(join(getPackageDir(), "examples"));
 }
 
+/** Get path to the VSCode extension's README (sibling `packages/vscode/` package). */
+export function getVscodeReadmePath(): string {
+	return resolve(join(getPackageDir(), "..", "vscode", "README.md"));
+}
+
 // =============================================================================
 // App Config (from package.json drebConfig)
 // =============================================================================

--- a/packages/coding-agent/src/core/system-prompt.ts
+++ b/packages/coding-agent/src/core/system-prompt.ts
@@ -327,7 +327,7 @@ Dreb documentation (read only when the user asks about dreb itself, its SDK, ext
 - Main documentation: ${readmePath}
 - Additional docs: ${docsPath}
 - Examples: ${examplesPath} (extensions, custom tools, SDK)
-- dreb also has a native VSCode extension; read ${vscodeReadmePath} for questions about it
+- dreb also has a native VSCode extension; read ${vscodeReadmePath} for questions about it (this path may not exist in all installations, e.g. when the extension package is not built)
 - When asked about: extensions (docs/extensions.md, examples/extensions/), themes (docs/themes.md), skills (docs/skills.md), prompt templates (docs/prompt-templates.md), TUI components (docs/tui.md), keybindings (docs/keybindings.md), SDK integrations (docs/sdk.md), custom providers (docs/custom-provider.md), adding models (docs/models.md), dreb packages (docs/packages.md)
 - When working on dreb topics, read the docs and examples, and follow .md cross-references before implementing
 - Always read dreb .md files completely and follow links to related docs (e.g., tui.md for TUI API details)`;

--- a/packages/coding-agent/src/core/system-prompt.ts
+++ b/packages/coding-agent/src/core/system-prompt.ts
@@ -2,7 +2,7 @@
  * System prompt construction and project context loading
  */
 
-import { getDocsPath, getExamplesPath, getReadmePath } from "../config.js";
+import { getDocsPath, getExamplesPath, getReadmePath, getVscodeReadmePath } from "../config.js";
 import type { GitRepoState } from "./git-repo-state.js";
 import { getMemoryInstructions } from "./memory-prompt.js";
 import type { MemoryIndexes } from "./resource-loader.js";
@@ -246,6 +246,7 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions = {}): strin
 	const readmePath = getReadmePath();
 	const docsPath = getDocsPath();
 	const examplesPath = getExamplesPath();
+	const vscodeReadmePath = getVscodeReadmePath();
 
 	// Build tools list based on selected tools.
 	// A tool appears in Available tools only when the caller provides a one-line snippet.
@@ -326,6 +327,7 @@ Dreb documentation (read only when the user asks about dreb itself, its SDK, ext
 - Main documentation: ${readmePath}
 - Additional docs: ${docsPath}
 - Examples: ${examplesPath} (extensions, custom tools, SDK)
+- dreb also has a native VSCode extension; read ${vscodeReadmePath} for questions about it
 - When asked about: extensions (docs/extensions.md, examples/extensions/), themes (docs/themes.md), skills (docs/skills.md), prompt templates (docs/prompt-templates.md), TUI components (docs/tui.md), keybindings (docs/keybindings.md), SDK integrations (docs/sdk.md), custom providers (docs/custom-provider.md), adding models (docs/models.md), dreb packages (docs/packages.md)
 - When working on dreb topics, read the docs and examples, and follow .md cross-references before implementing
 - Always read dreb .md files completely and follow links to related docs (e.g., tui.md for TUI API details)`;

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "vitest";
+import { getVscodeReadmePath } from "../src/config.js";
 import type { GitRepoState } from "../src/core/git-repo-state.js";
 import { buildSystemPrompt } from "../src/core/system-prompt.js";
 import { subagentToolDefinition } from "../src/core/tools/subagent.js";
@@ -390,6 +391,46 @@ describe("buildSystemPrompt", () => {
 			expect(dateIdx).toBeGreaterThan(-1);
 			expect(modelIdx).toBeGreaterThan(-1);
 			expect(modelIdx).toBeGreaterThan(dateIdx);
+		});
+	});
+
+	describe("vscode extension pointer", () => {
+		test("default prompt points to the VSCode extension README", () => {
+			const prompt = buildSystemPrompt({
+				selectedTools: [],
+				contextFiles: [],
+				skills: [],
+			});
+
+			expect(prompt).toContain("native VSCode extension");
+			expect(prompt).toContain(getVscodeReadmePath());
+		});
+
+		test("pointer lives inside the Dreb documentation section", () => {
+			const prompt = buildSystemPrompt({
+				selectedTools: [],
+				contextFiles: [],
+				skills: [],
+			});
+
+			const docsIdx = prompt.indexOf("Dreb documentation");
+			const pointerIdx = prompt.indexOf("native VSCode extension");
+			expect(docsIdx).toBeGreaterThan(-1);
+			expect(pointerIdx).toBeGreaterThan(docsIdx);
+		});
+
+		test("pointer stays lightweight — no extension capabilities inlined", () => {
+			const prompt = buildSystemPrompt({
+				selectedTools: [],
+				contextFiles: [],
+				skills: [],
+			});
+
+			// The pointer must not enumerate what the extension does — it only
+			// says the extension exists and where to read about it.
+			for (const capability of ["change review", "accept/reject", "reject hunk", "selection tag", "webview"]) {
+				expect(prompt).not.toContain(capability);
+			}
 		});
 	});
 });

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -404,6 +404,8 @@ describe("buildSystemPrompt", () => {
 
 			expect(prompt).toContain("native VSCode extension");
 			expect(prompt).toContain(getVscodeReadmePath());
+			// The pointer notes the path may be absent (e.g. standalone install / not built).
+			expect(prompt).toContain("may not exist in all installations");
 		});
 
 		test("pointer lives inside the Dreb documentation section", () => {


### PR DESCRIPTION
Closes #63

Adds a lightweight, always-present pointer in the coding-agent system prompt so dreb is aware the native VSCode extension exists and where to read about it (`packages/vscode/README.md`) — without inlining any extension capability details.

Part of epic #12. Implementation plan posted as a comment below.
