### PR TITLE
VSCode extension: fix Q&A (ask_user) prompt rendering — multi-question wizard + narration separation

### DIFF
--- a/packages/vscode/src/shared/projection.ts
+++ b/packages/vscode/src/shared/projection.ts
@@ -35,6 +35,11 @@ export interface ResponseGroup {
 	activity: ActivityItem[];
 	/** Accumulated final-answer markdown (assistant text content). */
 	answer: string;
+	/** Internal: `activity.length` when the last answer text was appended. Used to
+	 * detect a new narration block (activity arrived since the last text) so
+	 * consecutive text blocks in one run are separated instead of concatenated.
+	 * Not rendered. */
+	answerActivityMark?: number;
 	/** True between agent_start and agent_end for this run. */
 	streaming: boolean;
 	/** Activity box collapse state; auto-collapses when the run ends. */
@@ -77,6 +82,22 @@ export interface Checkpoint {
 	canFork: boolean;
 }
 
+/** One question inside an `ask` wizard request, mirroring RpcAskQuestion. */
+export interface AskQuestion {
+	/** The question prompt (rendered as Markdown). */
+	question: string;
+	/** Optional per-question heading. */
+	title?: string;
+	/** Selectable options, if any. */
+	options?: string[];
+	/** Offer a free-text field (defaults true). */
+	allowFreeText?: boolean;
+	/** Render options as checkboxes instead of radios. */
+	multiSelect?: boolean;
+	/** Use a multi-line text area for free text. */
+	multiline?: boolean;
+}
+
 /** A pending, blocking extension-UI request the user must answer. */
 export interface UiRequest {
 	id: string;
@@ -86,14 +107,8 @@ export interface UiRequest {
 	options?: string[];
 	placeholder?: string;
 	prefill?: string;
-	/** ask: the question prompt. */
-	question?: string;
-	/** ask: offer a free-text field (defaults true). */
-	allowFreeText?: boolean;
-	/** ask: render options as checkboxes instead of radios. */
-	multiSelect?: boolean;
-	/** ask: use a multi-line text area for free text. */
-	multiline?: boolean;
+	/** ask: one or more questions asked together as a single wizard. */
+	questions?: AskQuestion[];
 	/** ask: absolute runtime deadline (ms epoch); survives reload. */
 	expiresAt?: number;
 }
@@ -156,6 +171,20 @@ function lastThinking(group: ResponseGroup): ThinkingActivity | undefined {
 	return last?.kind === "thinking" ? last : undefined;
 }
 
+/** Append assistant answer text, inserting a blank-line separator when a new text
+ * block begins after intervening activity (a tool call or thinking) since the last
+ * text was written. This keeps consecutive narration blocks in a single run from
+ * running together into one wall of text. */
+function appendAnswerText(group: ResponseGroup, text: string): void {
+	if (!text) return;
+	const mark = group.answerActivityMark ?? 0;
+	if (group.answer.length > 0 && group.activity.length > mark && !group.answer.endsWith("\n\n")) {
+		group.answer += group.answer.endsWith("\n") ? "\n" : "\n\n";
+	}
+	group.answer += text;
+	group.answerActivityMark = group.activity.length;
+}
+
 function findTool(group: ResponseGroup, toolCallId: string): ToolActivity | undefined {
 	for (let i = group.activity.length - 1; i >= 0; i--) {
 		const item = group.activity[i];
@@ -213,19 +242,33 @@ function uiRequestFromEvent(event: any): UiRequest | undefined {
 		};
 	}
 	if (method === "ask") {
+		const rawQuestions = Array.isArray(event.questions) ? event.questions : undefined;
+		const questions: AskQuestion[] = rawQuestions
+			? rawQuestions.map((q: any) => normalizeAskQuestion(q))
+			: // Defensive fallback for a legacy single flat-question event shape so an
+				// older RPC child still renders one question rather than an empty widget.
+				[normalizeAskQuestion(event)];
 		return {
 			id,
 			method: "ask",
 			title: String(event.title ?? "Question"),
-			question: typeof event.question === "string" ? event.question : "",
-			options,
-			allowFreeText: typeof event.allowFreeText === "boolean" ? event.allowFreeText : undefined,
-			multiSelect: typeof event.multiSelect === "boolean" ? event.multiSelect : undefined,
-			multiline: typeof event.multiline === "boolean" ? event.multiline : undefined,
+			questions,
 			expiresAt: typeof event.expiresAt === "number" ? event.expiresAt : undefined,
 		};
 	}
 	return undefined;
+}
+
+/** Coerce an untrusted RPC ask-question payload into a typed {@link AskQuestion}. */
+function normalizeAskQuestion(q: any): AskQuestion {
+	return {
+		question: typeof q?.question === "string" ? q.question : "",
+		title: typeof q?.title === "string" ? q.title : undefined,
+		options: Array.isArray(q?.options) ? q.options.map((o: unknown) => String(o)) : undefined,
+		allowFreeText: typeof q?.allowFreeText === "boolean" ? q.allowFreeText : undefined,
+		multiSelect: typeof q?.multiSelect === "boolean" ? q.multiSelect : undefined,
+		multiline: typeof q?.multiline === "boolean" ? q.multiline : undefined,
+	};
 }
 
 /** Apply one session event (or synthetic host event) to the transcript state. */
@@ -258,7 +301,7 @@ export function applyEvent(state: TranscriptState, event: any): void {
 			if (!group) break;
 			switch (stream.type) {
 				case "text_delta":
-					group.answer += stream.delta ?? "";
+					appendAnswerText(group, stream.delta ?? "");
 					break;
 				case "text_end":
 					// text_end carries the authoritative block content; if no deltas
@@ -422,7 +465,7 @@ interface RebuildMessage {
  * them). Mirrors the live event projection so a rebuilt run renders identically. */
 function foldAssistantContent(group: ResponseGroup, content: unknown): void {
 	if (typeof content === "string") {
-		group.answer += content;
+		appendAnswerText(group, content);
 		return;
 	}
 	if (!Array.isArray(content)) return;
@@ -436,7 +479,7 @@ function foldAssistantContent(group: ResponseGroup, content: unknown): void {
 			arguments?: unknown;
 		};
 		if (part?.type === "text" && typeof part.text === "string") {
-			group.answer += part.text;
+			appendAnswerText(group, part.text);
 		} else if (part?.type === "thinking" && typeof part.thinking === "string") {
 			group.activity.push({ kind: "thinking", text: part.thinking });
 		} else if (part?.type === "toolCall") {

--- a/packages/vscode/src/shared/protocol.ts
+++ b/packages/vscode/src/shared/protocol.ts
@@ -60,11 +60,23 @@ export interface HostStatus {
 	error?: string;
 }
 
-/** A response to a blocking extension-UI request, mirroring RpcExtensionUIResponse. */
+/** A single answer to one question in an `ask` wizard, mirroring RpcAskAnswer.
+ * One per question, in the same order as the request's `questions[]`. */
+export interface AskUiAnswer {
+	/** Options the user selected (empty when only free text was typed, or skipped). */
+	selected: string[];
+	/** Free-text answer, when provided. */
+	customText?: string;
+	/** True when the user left this question unanswered. */
+	skipped?: boolean;
+}
+
+/** A response to a blocking extension-UI request, mirroring RpcExtensionUIResponse.
+ * The `ask` method answers with one {@link AskUiAnswer} per question. */
 export type UiResponse =
 	| { id: string; value: string }
 	| { id: string; confirmed: boolean }
-	| { id: string; selected: string[]; customText?: string }
+	| { id: string; answers: AskUiAnswer[] }
 	| { id: string; cancelled: true };
 
 /** One file pending change-review, shown in the webview indicator + SCM group. */

--- a/packages/vscode/src/webview/app.tsx
+++ b/packages/vscode/src/webview/app.tsx
@@ -4,6 +4,7 @@ import { type ComposerPrefillMode, mergeComposerPrefill } from "../shared/compos
 import { formatContextUsage, formatCost, formatModel, formatThinking } from "../shared/format.js";
 import { activeMention, isFullPickerTrigger, mentionReference, replaceMention } from "../shared/mention.js";
 import {
+	type AskQuestion,
 	activitySummary,
 	applyEvent,
 	type Checkpoint,
@@ -505,7 +506,7 @@ function ToolCard(props: { tool: ToolActivity }) {
 	);
 }
 
-function UiRequestView(props: { request: UiRequest; onRespond: (response: UiResponse) => void }) {
+export function UiRequestView(props: { request: UiRequest; onRespond: (response: UiResponse) => void }) {
 	const request = props.request;
 	const cancel = () => props.onRespond({ id: request.id, cancelled: true });
 
@@ -556,7 +557,7 @@ function UiRequestView(props: { request: UiRequest; onRespond: (response: UiResp
 			</Show>
 
 			<Show when={request.method === "ask"}>
-				<AskResponse request={request} onRespond={props.onRespond} onCancel={cancel} />
+				<AskWizard request={request} onRespond={props.onRespond} onCancel={cancel} />
 			</Show>
 		</div>
 	);
@@ -602,67 +603,101 @@ function TextResponse(props: {
 	);
 }
 
-function AskResponse(props: { request: UiRequest; onRespond: (response: UiResponse) => void; onCancel: () => void }) {
-	const request = props.request;
-	const [selected, setSelected] = createSignal<string[]>([]);
-	const [customText, setCustomText] = createSignal("");
-	const allowFreeText = request.allowFreeText !== false;
+interface AskDraft {
+	selected: string[];
+	customText: string;
+}
 
-	const toggle = (option: string) => {
-		if (request.multiSelect) {
-			setSelected((prev) => (prev.includes(option) ? prev.filter((o) => o !== option) : [...prev, option]));
-		} else {
-			setSelected([option]);
-		}
+/**
+ * Render an `ask` request's `questions[]` as a multi-question wizard. Each question
+ * shows its (Markdown) prompt, optional per-question title, selectable options
+ * (radio for single-select, checkbox for multi-select), and a free-text field when
+ * the question allows it. Submit sends one {@link AskUiAnswer} per question in order
+ * (unanswered questions marked `skipped`); Cancel cancels the whole request. This
+ * mirrors the Dashboard's `AskWizard` so the RPC multi-question protocol renders
+ * with parity instead of the old single-flat-question widget.
+ */
+function AskWizard(props: { request: UiRequest; onRespond: (response: UiResponse) => void; onCancel: () => void }) {
+	const questions = (): AskQuestion[] => props.request.questions ?? [];
+	const [drafts, setDrafts] = createSignal<AskDraft[]>(questions().map(() => ({ selected: [], customText: "" })));
+
+	const setDraft = (index: number, update: (draft: AskDraft) => AskDraft) => {
+		setDrafts((prev) => prev.map((draft, i) => (i === index ? update(draft) : draft)));
+	};
+
+	const toggle = (index: number, option: string, multiSelect: boolean) => {
+		setDraft(index, (draft) => {
+			if (multiSelect) {
+				const selected = draft.selected.includes(option)
+					? draft.selected.filter((o) => o !== option)
+					: [...draft.selected, option];
+				return { ...draft, selected };
+			}
+			return { ...draft, selected: [option] };
+		});
 	};
 
 	const submit = () => {
-		const text = customText().trim();
-		props.onRespond({
-			id: request.id,
-			selected: selected(),
-			customText: text.length > 0 ? text : undefined,
+		const answers = drafts().map((draft) => {
+			const customText = draft.customText.trim() || undefined;
+			const answered = draft.selected.length > 0 || !!customText;
+			return answered ? { selected: draft.selected, customText } : { selected: [], skipped: true };
 		});
+		props.onRespond({ id: props.request.id, answers });
 	};
 
 	return (
 		<div class="dreb-uireq-actions column">
-			<Show when={request.question}>
-				<div class="dreb-uireq-message">{request.question}</div>
-			</Show>
-			<For each={request.options ?? []}>
-				{(option) => (
-					<label class="dreb-option">
-						<input
-							type={request.multiSelect ? "checkbox" : "radio"}
-							name={`ask-${request.id}`}
-							checked={selected().includes(option)}
-							onChange={() => toggle(option)}
-						/>
-						<span>{option}</span>
-					</label>
-				)}
+			<For each={questions()}>
+				{(question, index) => {
+					const allowFreeText = question.allowFreeText !== false;
+					const options = question.options ?? [];
+					const multiSelect = question.multiSelect === true;
+					return (
+						<div class="dreb-ask-question">
+							<Show when={question.title}>
+								<div class="dreb-ask-question-title">{question.title}</div>
+							</Show>
+							<div class="dreb-ask-question-body dreb-answer" innerHTML={renderMarkdown(question.question)} />
+							<For each={options}>
+								{(option) => (
+									<label class="dreb-option">
+										<input
+											type={multiSelect ? "checkbox" : "radio"}
+											name={`ask-${props.request.id}-${index()}`}
+											checked={drafts()[index()]?.selected.includes(option) ?? false}
+											onChange={() => toggle(index(), option, multiSelect)}
+										/>
+										<span>{option}</span>
+									</label>
+								)}
+							</For>
+							<Show when={allowFreeText}>
+								<Show
+									when={question.multiline}
+									fallback={
+										<input
+											type="text"
+											placeholder="Type your own answer…"
+											value={drafts()[index()]?.customText ?? ""}
+											onInput={(e) =>
+												setDraft(index(), (d) => ({ ...d, customText: e.currentTarget.value }))
+											}
+										/>
+									}
+								>
+									<textarea
+										rows={4}
+										placeholder="Type your own answer…"
+										value={drafts()[index()]?.customText ?? ""}
+										onInput={(e) => setDraft(index(), (d) => ({ ...d, customText: e.currentTarget.value }))}
+									/>
+								</Show>
+							</Show>
+						</div>
+					);
+				}}
 			</For>
-			<Show when={allowFreeText}>
-				<Show
-					when={request.multiline}
-					fallback={
-						<input
-							type="text"
-							placeholder="Type your own answer…"
-							value={customText()}
-							onInput={(e) => setCustomText(e.currentTarget.value)}
-						/>
-					}
-				>
-					<textarea
-						rows={4}
-						placeholder="Type your own answer…"
-						value={customText()}
-						onInput={(e) => setCustomText(e.currentTarget.value)}
-					/>
-				</Show>
-			</Show>
 			<div class="dreb-uireq-actions">
 				<button type="button" onClick={submit}>
 					Send

--- a/packages/vscode/src/webview/styles.css
+++ b/packages/vscode/src/webview/styles.css
@@ -376,6 +376,23 @@ body {
 	align-items: center;
 	gap: 6px;
 }
+/* One question block inside a multi-question ask wizard. */
+.dreb-ask-question {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	padding-bottom: 8px;
+}
+.dreb-ask-question + .dreb-ask-question {
+	border-top: 1px solid var(--vscode-panel-border, rgba(128, 128, 128, 0.35));
+	padding-top: 10px;
+}
+.dreb-ask-question-title {
+	font-weight: 600;
+}
+.dreb-ask-question-body {
+	word-break: break-word;
+}
 
 /* Composer ---------------------------------------------------------------- */
 .dreb-composer {

--- a/packages/vscode/test/ask-wizard.test.tsx
+++ b/packages/vscode/test/ask-wizard.test.tsx
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+/**
+ * The `ask` (Q&A) prompt renders the RPC multi-question wizard. The regression it
+ * guards against (issue 68): the RPC `ask` request carries `questions[]`, but the
+ * extension used to read a flat single-question shape, so the question text and
+ * options never rendered. These tests render the real `UiRequestView` in jsdom and
+ * assert that every question's prompt + options show and that Send builds one
+ * `answers[]` entry per question (skipped when left blank), matching RpcAskAnswer.
+ */
+
+import { render } from "solid-js/web/dist/web.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { UiRequest } from "../src/shared/projection.js";
+import type { UiResponse } from "../src/shared/protocol.js";
+
+vi.mock("../src/webview/vscode-api.js", () => ({
+	onHostMessage: () => () => {},
+	postToHost: () => {},
+}));
+
+import { UiRequestView } from "../src/webview/app.js";
+
+let dispose: (() => void) | undefined;
+const responses: UiResponse[] = [];
+
+afterEach(() => {
+	dispose?.();
+	dispose = undefined;
+	responses.length = 0;
+	document.body.innerHTML = "";
+});
+
+function mount(request: UiRequest): HTMLElement {
+	const host = document.createElement("div");
+	document.body.appendChild(host);
+	dispose = render(() => <UiRequestView request={request} onRespond={(r) => responses.push(r)} />, host);
+	return host;
+}
+
+function askRequest(partial: Partial<UiRequest>): UiRequest {
+	return { id: "u1", method: "ask", title: "Question", questions: [], ...partial };
+}
+
+describe("AskWizard rendering", () => {
+	it("renders the question prompt (as Markdown) and its options", () => {
+		const host = mount(
+			askRequest({
+				questions: [{ question: "Pick **one** please", options: ["alpha", "beta"], allowFreeText: false }],
+			}),
+		);
+		const body = host.querySelector(".dreb-ask-question-body") as HTMLElement;
+		expect(body.textContent).toContain("Pick one please");
+		// Markdown rendered to HTML, not shown as raw asterisks.
+		expect(body.querySelector("strong")?.textContent).toBe("one");
+		expect(host.textContent).toContain("alpha");
+		expect(host.textContent).toContain("beta");
+		// allowFreeText:false hides the free-text field.
+		expect(host.querySelector('input[type="text"], textarea')).toBeNull();
+		// Single-select uses radios.
+		expect(host.querySelectorAll('input[type="radio"]').length).toBe(2);
+	});
+
+	it("renders a per-question title and multi-select checkboxes", () => {
+		const host = mount(
+			askRequest({
+				questions: [{ question: "Pick some", title: "Features", options: ["a", "b"], multiSelect: true }],
+			}),
+		);
+		expect(host.querySelector(".dreb-ask-question-title")?.textContent).toBe("Features");
+		expect(host.querySelectorAll('input[type="checkbox"]').length).toBe(2);
+	});
+
+	it("Send builds one answer per question, marking unanswered ones skipped", () => {
+		const host = mount(
+			askRequest({
+				questions: [
+					{ question: "Q1", options: ["a", "b"], allowFreeText: false },
+					{ question: "Q2", allowFreeText: true },
+				],
+			}),
+		);
+		// Answer only the first question (select option "b"); leave Q2 blank.
+		const radios = host.querySelectorAll<HTMLInputElement>('input[type="radio"]');
+		const optionB = Array.from(radios).find(
+			(r) =>
+				(r.closest("label")?.textContent ?? "").includes("b") &&
+				!(r.closest("label")?.textContent ?? "").includes("a"),
+		);
+		(optionB ?? radios[1]).click();
+
+		const send = Array.from(host.querySelectorAll("button")).find((b) => b.textContent?.trim() === "Send");
+		send?.click();
+
+		expect(responses).toEqual([
+			{
+				id: "u1",
+				answers: [
+					{ selected: ["b"], customText: undefined },
+					{ selected: [], skipped: true },
+				],
+			},
+		]);
+	});
+
+	it("Send captures free-text answers", () => {
+		const host = mount(askRequest({ questions: [{ question: "Anything?", allowFreeText: true }] }));
+		const input = host.querySelector<HTMLInputElement>('input[type="text"]');
+		expect(input).toBeTruthy();
+		if (input) {
+			input.value = "my answer";
+			input.dispatchEvent(new Event("input", { bubbles: true }));
+		}
+		const send = Array.from(host.querySelectorAll("button")).find((b) => b.textContent?.trim() === "Send");
+		send?.click();
+
+		expect(responses).toEqual([{ id: "u1", answers: [{ selected: [], customText: "my answer" }] }]);
+	});
+
+	it("Cancel cancels the whole request", () => {
+		const host = mount(askRequest({ questions: [{ question: "Q", options: ["a"] }] }));
+		const cancel = Array.from(host.querySelectorAll("button")).find((b) => b.textContent?.trim() === "Cancel");
+		cancel?.click();
+		expect(responses).toEqual([{ id: "u1", cancelled: true }]);
+	});
+});

--- a/packages/vscode/test/projection.test.ts
+++ b/packages/vscode/test/projection.test.ts
@@ -57,6 +57,21 @@ describe("projection", () => {
 		});
 	});
 
+	it("separates narration text blocks split by a tool call, but not within one block", () => {
+		const state = run([
+			{ type: "agent_start" },
+			{ type: "message_start", message: { role: "assistant" } },
+			{ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "Let me look. " } },
+			{ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "First the config." } },
+			{ type: "tool_execution_start", toolCallId: "t1", toolName: "read", args: { path: "a.ts" } },
+			{ type: "tool_execution_end", toolCallId: "t1", result: "body", isError: false },
+			{ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "Now the answer." } },
+			{ type: "agent_end" },
+		]);
+		// Deltas within one block stay joined; a new block after the tool gets a blank line.
+		expect(onlyResponse(state).answer).toBe("Let me look. First the config.\n\nNow the answer.");
+	});
+
 	it("marks the run streaming, then collapses activity at agent_end", () => {
 		const state = createTranscriptState();
 		applyEvent(state, { type: "agent_start" });
@@ -88,30 +103,51 @@ describe("projection", () => {
 		expect(onlyResponse(nonStreaming).answer).toBe("whole answer");
 	});
 
-	it("tracks and clears blocking extension-UI requests", () => {
+	it("maps an ask request's questions[] into a structured multi-question wizard", () => {
 		const state = createTranscriptState();
 		applyEvent(state, {
 			type: "extension_ui_request",
 			id: "u1",
 			method: "ask",
-			title: "Pick",
-			question: "Which?",
-			options: ["a", "b"],
-			allowFreeText: false,
-			multiSelect: true,
+			title: "Choices",
+			questions: [
+				{ question: "Which?", title: "Pick one", options: ["a", "b"], allowFreeText: false, multiSelect: true },
+				{ question: "Free thoughts?", allowFreeText: true, multiline: true },
+			],
+			expiresAt: 123456,
 		});
 		expect(state.uiRequests).toHaveLength(1);
 		expect(state.uiRequests[0]).toMatchObject({
 			id: "u1",
 			method: "ask",
-			question: "Which?",
-			options: ["a", "b"],
-			allowFreeText: false,
-			multiSelect: true,
+			title: "Choices",
+			expiresAt: 123456,
+			questions: [
+				{ question: "Which?", title: "Pick one", options: ["a", "b"], allowFreeText: false, multiSelect: true },
+				{ question: "Free thoughts?", allowFreeText: true, multiline: true },
+			],
 		});
 
 		applyEvent(state, { type: "extension_ui_response_handled", id: "u1" });
 		expect(state.uiRequests).toHaveLength(0);
+	});
+
+	it("falls back to a single question for a legacy flat ask event shape", () => {
+		const state = createTranscriptState();
+		applyEvent(state, {
+			type: "extension_ui_request",
+			id: "u2",
+			method: "ask",
+			title: "Legacy",
+			question: "Old shape?",
+			options: ["x", "y"],
+			allowFreeText: false,
+		});
+		expect(state.uiRequests[0]).toMatchObject({
+			id: "u2",
+			method: "ask",
+			questions: [{ question: "Old shape?", options: ["x", "y"], allowFreeText: false }],
+		});
 	});
 
 	it("clears pending UI requests when a new run starts", () => {


### PR DESCRIPTION
Closes #68

Fix the VSCode extension Q&A (`ask_user`) prompt so the question text and options render, matching the multi-question wizard the RPC `ask` request actually emits. Also separate consecutive assistant narration blocks so the transcript no longer runs together.

Implementation plan posted as a comment below.
