### PR TITLE
VSCode extension: name chat tabs by session + highlight active session in sidebar

### DIFF
--- a/packages/vscode/src/host/extension.ts
+++ b/packages/vscode/src/host/extension.ts
@@ -16,7 +16,8 @@ import { randomUUID } from "node:crypto";
 import { homedir } from "node:os";
 import { relative, sep } from "node:path";
 import * as vscode from "vscode";
-import type { LiveSessionInput, SessionRunState } from "../shared/session-list.js";
+import type { LiveSessionInput } from "../shared/session-list.js";
+import { formatTabTitle } from "../shared/tab-title.js";
 import { resolveCliPath } from "./cli-path.js";
 import type { ReviewUi } from "./review-ui.js";
 import { SessionController } from "./session-controller.js";
@@ -113,6 +114,7 @@ export function activate(context: vscode.ExtensionContext): void {
 					state: s.controller.runState,
 				}),
 			),
+		activeKey: () => pool.active?.key,
 		pathForKey: (key) => pool.get(key)?.controller.sessionPath ?? (key.startsWith("new:") ? undefined : key),
 		openSession: (key) => void openSession(context, key),
 		newSession: () => void openNewSession(context),
@@ -351,16 +353,11 @@ function createSession(context: vscode.ExtensionContext, key: string, sessionPat
  * controller — on first creation and again when reopening a backgrounded session
  * whose original panel was closed. */
 function attachView(context: vscode.ExtensionContext, session: ChatSession): void {
-	const panel = vscode.window.createWebviewPanel(
-		"dreb.chat",
-		panelTitle(session.controller.runState),
-		vscode.ViewColumn.Active,
-		{
-			enableScripts: true,
-			retainContextWhenHidden: true,
-			localResourceRoots: [vscode.Uri.joinPath(context.extensionUri, "dist", "webview")],
-		},
-	);
+	const panel = vscode.window.createWebviewPanel("dreb.chat", panelTitle(session), vscode.ViewColumn.Active, {
+		enableScripts: true,
+		retainContextWhenHidden: true,
+		localResourceRoots: [vscode.Uri.joinPath(context.extensionUri, "dist", "webview")],
+	});
 
 	const connection = connectWebview(panel.webview, session.controller);
 	panel.webview.html = getWebviewHtml(panel.webview, context.extensionUri, makeNonce());
@@ -376,10 +373,23 @@ function attachView(context: vscode.ExtensionContext, session: ChatSession): voi
 		// It stays alive while working / awaiting input, and sleeps once idle.
 		detachView(session);
 		session.sleep.onDetach();
+		// If the closed tab was the focused one, no dreb chat is active anymore
+		// (focus may land on a non-dreb editor that emits no view-state event).
+		if (pool.active?.key === session.key) pool.setActive(undefined);
 		scheduleSidebarRefresh();
 	});
 	panel.onDidChangeViewState((e) => {
-		if (e.webviewPanel.active) pool.setActive(session.key);
+		// Track which session's tab is focused so the sidebar can highlight it.
+		// Switching chats fires deactivate(old) + activate(new) in either order;
+		// only clearing when *this* panel is still the recorded active one makes
+		// the net result the newly-activated session regardless of order, and
+		// clears the highlight when focus leaves for a non-dreb editor.
+		if (e.webviewPanel.active) {
+			pool.setActive(session.key);
+		} else if (pool.active?.key === session.key) {
+			pool.setActive(undefined);
+		}
+		scheduleSidebarRefresh();
 	});
 }
 
@@ -407,21 +417,16 @@ function revealSession(session: ChatSession): void {
 	);
 }
 
-/** The chat tab title reflecting run-state, so a backgrounded / unfocused
- * session's running or needs-input status is visible in the editor tab strip. */
-function panelTitle(state: SessionRunState): string {
-	switch (state) {
-		case "running":
-			return "dreb ● running";
-		case "needs-input":
-			return "dreb ⚠ needs input";
-		default:
-			return "dreb";
-	}
+/** The chat tab title: `D: <session name>` (shortened) plus a compact run-state
+ * marker, so multiple open chats are distinguishable in the tab strip, map back
+ * to their sidebar row, and a backgrounded / unfocused session's running or
+ * needs-input status stays visible. */
+function panelTitle(session: ChatSession): string {
+	return formatTabTitle(session.controller.title, session.controller.runState);
 }
 
 function updateTabTitle(session: ChatSession): void {
-	if (session.panel) session.panel.title = panelTitle(session.controller.runState);
+	if (session.panel) session.panel.title = panelTitle(session);
 }
 
 /** Put a session to sleep: release its controller / RPC child (via the pool

--- a/packages/vscode/src/host/extension.ts
+++ b/packages/vscode/src/host/extension.ts
@@ -23,7 +23,7 @@ import type { ReviewUi } from "./review-ui.js";
 import { SessionController } from "./session-controller.js";
 import { SessionFlagsStore } from "./session-flags.js";
 import { createSessionInventory, deletePersistedSession, type SessionInventory } from "./session-inventory.js";
-import { SessionPool } from "./session-registry.js";
+import { nextActiveKey, SessionPool } from "./session-registry.js";
 import {
 	readSleepSetting,
 	revealOrReattach,
@@ -111,6 +111,11 @@ export function activate(context: vscode.ExtensionContext): void {
 					key: s.key,
 					cwd: s.controller.cwd,
 					path: s.controller.sessionPath,
+					// Source the sidebar row's title from the same `controller.title` the
+					// chat tab uses, so a session's tab (`D: <shortened>`) is always a
+					// shortened form of the exact name its sidebar row shows — they can
+					// never diverge (a live rename reflects in both immediately).
+					title: s.controller.title,
 					state: s.controller.runState,
 				}),
 			),
@@ -375,20 +380,14 @@ function attachView(context: vscode.ExtensionContext, session: ChatSession): voi
 		session.sleep.onDetach();
 		// If the closed tab was the focused one, no dreb chat is active anymore
 		// (focus may land on a non-dreb editor that emits no view-state event).
-		if (pool.active?.key === session.key) pool.setActive(undefined);
+		pool.setActive(nextActiveKey(pool.active?.key, session.key, false));
 		scheduleSidebarRefresh();
 	});
 	panel.onDidChangeViewState((e) => {
 		// Track which session's tab is focused so the sidebar can highlight it.
-		// Switching chats fires deactivate(old) + activate(new) in either order;
-		// only clearing when *this* panel is still the recorded active one makes
-		// the net result the newly-activated session regardless of order, and
-		// clears the highlight when focus leaves for a non-dreb editor.
-		if (e.webviewPanel.active) {
-			pool.setActive(session.key);
-		} else if (pool.active?.key === session.key) {
-			pool.setActive(undefined);
-		}
+		// The decision is order-independent (deactivate(old) + activate(new) fire
+		// in either order) — see `nextActiveKey`.
+		pool.setActive(nextActiveKey(pool.active?.key, session.key, e.webviewPanel.active));
 		scheduleSidebarRefresh();
 	});
 }

--- a/packages/vscode/src/host/session-controller.ts
+++ b/packages/vscode/src/host/session-controller.ts
@@ -332,6 +332,10 @@ export class SessionController {
 	private readonly options: SessionControllerOptions;
 	private client: RpcClientLike | undefined;
 	private sessionFile: string | undefined;
+	/** Explicit session name set via rename / `/name`, cached locally so the
+	 * editor tab title reflects it immediately (the RPC state read does not echo
+	 * the name back). Falls back to the first user message when unset. */
+	private sessionName: string | undefined;
 	private commands: SlashCommandDto[] = [...BUILTIN_COMMANDS];
 	private status: HostStatus;
 	private unsubEvent: (() => void) | undefined;
@@ -396,8 +400,25 @@ export class SessionController {
 		return deriveSessionStatus(this.state);
 	}
 
+	/** The session's display title for the editor tab: an explicit name set via
+	 * rename / `/name`, else the first user message, else `undefined` for a
+	 * brand-new session with no messages yet. Mirrors the sidebar's
+	 * `name || firstMessage` title resolution so tab and sidebar labels agree. */
+	get title(): string | undefined {
+		const name = this.sessionName?.trim();
+		if (name) return name;
+		for (const item of this.state.items) {
+			if (item.kind === "user") {
+				const text = item.text.trim();
+				if (text) return text;
+			}
+		}
+		return undefined;
+	}
+
 	/** Rename the live session (persisted via the set_session_name RPC). */
 	async rename(name: string): Promise<void> {
+		this.sessionName = name.trim();
 		await this.client?.setSessionName(name);
 	}
 
@@ -716,6 +737,7 @@ export class SessionController {
 			case "name": {
 				const name = arg ?? (await this.ui.inputBox({ prompt: "Session name", placeholder: "My session" }));
 				if (!name || name.trim().length === 0) return;
+				this.sessionName = name.trim();
 				await client.setSessionName(name.trim());
 				await this.refreshStatus(false);
 				this.emitNotice(`Renamed session to "${name.trim()}".`);

--- a/packages/vscode/src/host/session-controller.ts
+++ b/packages/vscode/src/host/session-controller.ts
@@ -736,11 +736,12 @@ export class SessionController {
 			}
 			case "name": {
 				const name = arg ?? (await this.ui.inputBox({ prompt: "Session name", placeholder: "My session" }));
-				if (!name || name.trim().length === 0) return;
-				this.sessionName = name.trim();
-				await client.setSessionName(name.trim());
+				const trimmed = name?.trim();
+				if (!trimmed) return;
+				this.sessionName = trimmed;
+				await client.setSessionName(trimmed);
 				await this.refreshStatus(false);
-				this.emitNotice(`Renamed session to "${name.trim()}".`);
+				this.emitNotice(`Renamed session to "${trimmed}".`);
 				return;
 			}
 			case "export": {

--- a/packages/vscode/src/host/session-registry.ts
+++ b/packages/vscode/src/host/session-registry.ts
@@ -154,3 +154,27 @@ export class SessionPool<S extends object> {
 		this.activeKey = undefined;
 	}
 }
+
+/**
+ * Pure decision for which session key should be "active" (its sidebar row
+ * highlighted) after a chat panel's focus state changes.
+ *
+ * VS Code fires panel view-state events as deactivate(old) + activate(new) in
+ * either order, so the logic must be order-independent:
+ * - the panel just became focused → it is now the active session;
+ * - the panel just lost focus and *was* the recorded active one → clear (focus
+ *   left for a non-dreb editor, or another chat's activate hasn't fired yet);
+ * - otherwise (another chat is active) → leave the active key unchanged.
+ *
+ * Also used on panel dispose (a closed tab counts as "not active"): if the
+ * closed tab was active the highlight clears, else it is untouched.
+ */
+export function nextActiveKey(
+	currentActive: string | undefined,
+	thisKey: string,
+	isActive: boolean,
+): string | undefined {
+	if (isActive) return thisKey;
+	if (currentActive === thisKey) return undefined;
+	return currentActive;
+}

--- a/packages/vscode/src/host/sessions-view-model.ts
+++ b/packages/vscode/src/host/sessions-view-model.ts
@@ -23,6 +23,9 @@ export interface SessionsViewDeps {
 	currentCwd: () => string;
 	/** Snapshot of the currently-live sessions in the host's pool. */
 	liveSessions: () => LiveSessionInput[];
+	/** Row `key` of the session whose chat tab is currently focused (for the
+	 * active-row highlight), or `undefined` when no dreb chat tab is focused. */
+	activeKey?: () => string | undefined;
 	/** Resolve a row key to its session `.jsonl` path (for pin/archive/delete),
 	 * or undefined for a brand-new not-yet-persisted session. */
 	pathForKey: (key: string) => string | undefined;
@@ -127,6 +130,7 @@ export class SessionsViewModel {
 			disk,
 			live,
 			flags: (path) => this.deps.flags.get(path),
+			activeKey: this.deps.activeKey?.(),
 		});
 	}
 }

--- a/packages/vscode/src/shared/session-list.ts
+++ b/packages/vscode/src/shared/session-list.ts
@@ -72,6 +72,11 @@ export interface SessionGroupDto {
 export interface SessionListDto {
 	currentCwd: string;
 	groups: SessionGroupDto[];
+	/** Row `key` of the session whose chat tab is currently focused, so the
+	 * sidebar can highlight "the session you're looking at". `undefined` when no
+	 * dreb chat tab is focused. Never affects row ordering (see the module doc's
+	 * determinism note). */
+	activeKey?: string;
 }
 
 /** A persisted session discovered on disk. */
@@ -101,6 +106,9 @@ export interface BuildSessionListInput {
 	disk: DiskSessionInput[];
 	live: LiveSessionInput[];
 	flags: (path: string | undefined) => SessionFlags;
+	/** Row `key` of the currently-focused chat tab, passed straight through to
+	 * {@link SessionListDto.activeKey}. Does not influence ordering or grouping. */
+	activeKey?: string;
 }
 
 /** Last path segment of a slash/back-slash separated path (falls back to the
@@ -220,5 +228,5 @@ export function buildSessionList(input: BuildSessionListInput): SessionListDto {
 		groups.push({ key: "archived:", kind: "archived", cwd: "", label: "Archived", sessions: sortRows(archived) });
 	}
 
-	return { currentCwd, groups };
+	return { currentCwd, groups, activeKey: input.activeKey };
 }

--- a/packages/vscode/src/shared/tab-title.ts
+++ b/packages/vscode/src/shared/tab-title.ts
@@ -26,12 +26,11 @@ const UNTITLED = "New session";
  * even a wide tab strip readable and predictable. */
 const DEFAULT_MAX_LEN = 20;
 
-/** Collapse internal whitespace/newlines (a first user message may be
- * multi-line) and trim, then truncate to `maxLen` with an ellipsis. */
+/** Truncate to `maxLen` with a trailing ellipsis. `text` is expected to be
+ * already whitespace-collapsed and trimmed by the caller ({@link formatTabTitle}). */
 function shorten(text: string, maxLen: number): string {
-	const clean = text.replace(/\s+/g, " ").trim();
-	if (clean.length <= maxLen) return clean;
-	return `${clean.slice(0, Math.max(1, maxLen - 1)).trimEnd()}…`;
+	if (text.length <= maxLen) return text;
+	return `${text.slice(0, Math.max(1, maxLen - 1)).trimEnd()}…`;
 }
 
 /** Compact run-state marker appended after the name (empty for idle). */

--- a/packages/vscode/src/shared/tab-title.ts
+++ b/packages/vscode/src/shared/tab-title.ts
@@ -1,0 +1,62 @@
+/**
+ * Pure formatter for a chat editor tab's title.
+ *
+ * Every dreb chat opens as its own editor tab. Titling them all `dreb` makes
+ * multiple open sessions indistinguishable in the tab strip and impossible to
+ * map back to their row in the Sessions sidebar. {@link formatTabTitle} names
+ * each tab after its session (`D: <shortened title>`), keeping a compact
+ * run-state marker so a backgrounded / unfocused session's running or
+ * needs-input status stays visible in the tab strip — the markers mirror the
+ * sidebar's `StatusIndicator`.
+ *
+ * Like `session-list.ts`, this module is free of `vscode` and of any `node:`
+ * builtins so it can be imported by the host and unit tested in plain node.
+ */
+
+import type { SessionRunState } from "./session-list.js";
+
+/** Prefix that marks a tab as a dreb chat and keeps its name short in the strip. */
+const TAB_PREFIX = "D: ";
+
+/** Shown when a session has no name and no messages yet (matches the sidebar's
+ * brand-new-live-session fallback). */
+const UNTITLED = "New session";
+
+/** Default cap on the name portion; VS Code elides further, but a hard cap keeps
+ * even a wide tab strip readable and predictable. */
+const DEFAULT_MAX_LEN = 20;
+
+/** Collapse internal whitespace/newlines (a first user message may be
+ * multi-line) and trim, then truncate to `maxLen` with an ellipsis. */
+function shorten(text: string, maxLen: number): string {
+	const clean = text.replace(/\s+/g, " ").trim();
+	if (clean.length <= maxLen) return clean;
+	return `${clean.slice(0, Math.max(1, maxLen - 1)).trimEnd()}…`;
+}
+
+/** Compact run-state marker appended after the name (empty for idle). */
+function stateMarker(state: SessionRunState): string {
+	switch (state) {
+		case "running":
+			return " ●";
+		case "needs-input":
+			return " ⚠";
+		default:
+			return "";
+	}
+}
+
+/**
+ * Build a chat tab title from a session's display title and run-state:
+ * `D: <shortened title>` plus a compact `●` (running) / `⚠` (needs input)
+ * marker. An empty/undefined title falls back to `D: New session`.
+ */
+export function formatTabTitle(
+	title: string | undefined,
+	state: SessionRunState,
+	maxLen: number = DEFAULT_MAX_LEN,
+): string {
+	const base = (title ?? "").replace(/\s+/g, " ").trim();
+	const name = base.length === 0 ? UNTITLED : shorten(base, maxLen);
+	return `${TAB_PREFIX}${name}${stateMarker(state)}`;
+}

--- a/packages/vscode/src/webview/sidebar/app.tsx
+++ b/packages/vscode/src/webview/sidebar/app.tsx
@@ -56,14 +56,14 @@ export function SidebarApp() {
 				}
 			>
 				<div class="dreb-side-list">
-					<For each={list.groups}>{(group) => <GroupView group={group} />}</For>
+					<For each={list.groups}>{(group) => <GroupView group={group} activeKey={list.activeKey} />}</For>
 				</div>
 			</Show>
 		</div>
 	);
 }
 
-function GroupView(props: { group: SessionGroupDto }) {
+function GroupView(props: { group: SessionGroupDto; activeKey?: string }) {
 	const group = props.group;
 	return (
 		<details class="dreb-side-group" open={group.kind === "current"}>
@@ -72,13 +72,17 @@ function GroupView(props: { group: SessionGroupDto }) {
 				<span class="dreb-side-group-count">{group.sessions.length}</span>
 			</summary>
 			<div class="dreb-side-group-body">
-				<For each={group.sessions}>{(session) => <SessionRow session={session} groupKind={group.kind} />}</For>
+				<For each={group.sessions}>
+					{(session) => (
+						<SessionRow session={session} groupKind={group.kind} active={props.activeKey === session.key} />
+					)}
+				</For>
 			</div>
 		</details>
 	);
 }
 
-function SessionRow(props: { session: SessionSummaryDto; groupKind: SessionGroupDto["kind"] }) {
+function SessionRow(props: { session: SessionSummaryDto; groupKind: SessionGroupDto["kind"]; active?: boolean }) {
 	const [editing, setEditing] = createSignal(false);
 	const [draft, setDraft] = createSignal("");
 
@@ -123,7 +127,10 @@ function SessionRow(props: { session: SessionSummaryDto; groupKind: SessionGroup
 	};
 
 	return (
-		<div class="dreb-side-row" classList={{ "dreb-side-row-live": session().live }}>
+		<div
+			class="dreb-side-row"
+			classList={{ "dreb-side-row-live": session().live, "dreb-side-row-active": props.active }}
+		>
 			<Show
 				when={editing()}
 				fallback={

--- a/packages/vscode/src/webview/sidebar/styles.css
+++ b/packages/vscode/src/webview/sidebar/styles.css
@@ -137,6 +137,16 @@ body {
 .dreb-side-row-live {
 	border-left-color: var(--vscode-charts-green, #2a2);
 }
+/* The session whose chat tab is currently focused — mirrors the editor tab so
+ * the user can map "the tab I'm on" to its sidebar row. */
+.dreb-side-row-active {
+	background: var(--vscode-list-activeSelectionBackground, rgba(128, 128, 128, 0.24));
+	color: var(--vscode-list-activeSelectionForeground, inherit);
+}
+.dreb-side-row-active:hover,
+.dreb-side-row-active:focus-within {
+	background: var(--vscode-list-activeSelectionBackground, rgba(128, 128, 128, 0.24));
+}
 
 .dreb-side-row-main {
 	flex: 1;

--- a/packages/vscode/test/session-controller.test.ts
+++ b/packages/vscode/test/session-controller.test.ts
@@ -1480,6 +1480,62 @@ describe("SessionController", () => {
 		expect(fake.names).toEqual(["My name"]);
 	});
 
+	describe("title (chat-tab / sidebar display name)", () => {
+		it("returns the explicit name (trimmed) after rename()", async () => {
+			const fake = new FakeClient();
+			const controller = makeController(fake);
+			await controller.start();
+
+			await controller.rename("  Fix auth  ");
+			expect(controller.title).toBe("Fix auth");
+		});
+
+		it("returns the explicit name after the /name command", async () => {
+			const fake = new FakeClient();
+			const controller = makeController(fake);
+			await controller.start();
+
+			await controller.submit("/name My Session");
+			expect(controller.title).toBe("My Session");
+		});
+
+		it("falls back to the first user message (trimmed) when unnamed", async () => {
+			const fake = new FakeClient();
+			const controller = makeController(fake);
+			await controller.start();
+
+			fake.emit({ type: "message_start", message: { role: "user", content: "  first thing  " } });
+			expect(controller.title).toBe("first thing");
+		});
+
+		it("prefers an explicit name over an existing first user message", async () => {
+			const fake = new FakeClient();
+			const controller = makeController(fake);
+			await controller.start();
+
+			fake.emit({ type: "message_start", message: { role: "user", content: "first thing" } });
+			await controller.rename("Named");
+			expect(controller.title).toBe("Named");
+		});
+
+		it("is undefined for a brand-new session with no name and no messages", async () => {
+			const fake = new FakeClient();
+			const controller = makeController(fake);
+			await controller.start();
+
+			expect(controller.title).toBeUndefined();
+		});
+
+		it("skips a whitespace-only first user message", async () => {
+			const fake = new FakeClient();
+			const controller = makeController(fake);
+			await controller.start();
+
+			fake.emit({ type: "message_start", message: { role: "user", content: "   " } });
+			expect(controller.title).toBeUndefined();
+		});
+	});
+
 	it("runState reflects the projected transcript (idle → running → needs-input)", async () => {
 		const fake = new FakeClient();
 		const controller = makeController(fake);

--- a/packages/vscode/test/session-list.test.ts
+++ b/packages/vscode/test/session-list.test.ts
@@ -243,4 +243,41 @@ describe("buildSessionList", () => {
 		});
 		expect(rebuilt.groups.map((g) => g.key)).toEqual(keys);
 	});
+
+	it("(g) passes activeKey straight through to the DTO", () => {
+		const list = buildSessionList({
+			currentCwd: "/proj",
+			disk: [disk({ path: "/proj/a.jsonl", name: "Alpha" })],
+			live: [],
+			flags: noFlags,
+			activeKey: "/proj/a.jsonl",
+		});
+		expect(list.activeKey).toBe("/proj/a.jsonl");
+	});
+
+	it("(h) leaves activeKey undefined when not supplied", () => {
+		const list = buildSessionList({
+			currentCwd: "/proj",
+			disk: [disk({ path: "/proj/a.jsonl", name: "Alpha" })],
+			live: [],
+			flags: noFlags,
+		});
+		expect(list.activeKey).toBeUndefined();
+	});
+
+	it("(i) activeKey never affects row ordering or grouping", () => {
+		const base = {
+			currentCwd: "/proj",
+			disk: [
+				disk({ path: "/proj/a.jsonl", name: "A", modified: "2026-01-02T00:00:00.000Z" }),
+				disk({ path: "/proj/b.jsonl", name: "B", modified: "2026-01-01T00:00:00.000Z" }),
+			],
+			live: [],
+			flags: noFlags,
+		};
+		const without = buildSessionList(base);
+		const withActive = buildSessionList({ ...base, activeKey: "/proj/b.jsonl" });
+		const order = (l: ReturnType<typeof buildSessionList>) => l.groups.flatMap((g) => g.sessions.map((s) => s.key));
+		expect(order(withActive)).toEqual(order(without));
+	});
 });

--- a/packages/vscode/test/session-list.test.ts
+++ b/packages/vscode/test/session-list.test.ts
@@ -109,6 +109,19 @@ describe("buildSessionList", () => {
 		expect(row.messageCount).toBe(5);
 	});
 
+	it("(b2) a live session's title (from controller.title) overrides the disk name", () => {
+		// The host feeds `controller.title` as the live title so the sidebar row
+		// and the chat tab (`D: <shortened title>`) always share one source and
+		// can't diverge — e.g. a live rename shows in the sidebar immediately.
+		const list = buildSessionList({
+			currentCwd: "/proj",
+			disk: [disk({ path: "/proj/a.jsonl", name: "Old disk name" })],
+			live: [live({ key: "pool-1", path: "/proj/a.jsonl", title: "Live renamed" })],
+			flags: noFlags,
+		});
+		expect(list.groups[0].sessions[0].title).toBe("Live renamed");
+	});
+
 	it("(c) appends a pathless live session as a New session in the current group", () => {
 		const list = buildSessionList({
 			currentCwd: "/proj",

--- a/packages/vscode/test/session-registry.test.ts
+++ b/packages/vscode/test/session-registry.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { type SessionOps, SessionPool } from "../src/host/session-registry.js";
+import { nextActiveKey, type SessionOps, SessionPool } from "../src/host/session-registry.js";
 
 /** A fake session with controllable disposed-state and an observable teardown
  * whose completion a test can gate to simulate slow/racing `/quit` reopen. */
@@ -264,5 +264,42 @@ describe("SessionPool", () => {
 		expect(pool.size).toBe(0);
 		expect(pool.list()).toEqual([]);
 		expect(pool.active).toBeUndefined();
+	});
+});
+
+describe("nextActiveKey (view-state focus decision)", () => {
+	it("makes a newly-focused panel the active session", () => {
+		expect(nextActiveKey(undefined, "b", true)).toBe("b");
+		// Even if another session was active, focusing this one takes over.
+		expect(nextActiveKey("a", "b", true)).toBe("b");
+	});
+
+	it("clears when the recorded-active panel loses focus (blur to non-dreb)", () => {
+		expect(nextActiveKey("a", "a", false)).toBeUndefined();
+	});
+
+	it("leaves the active key unchanged when a non-active panel blurs", () => {
+		// deactivate(old) can fire AFTER activate(new): old blurring must not
+		// wipe the newly-active session.
+		expect(nextActiveKey("b", "a", false)).toBe("b");
+	});
+
+	it("is order-independent for a switch from a to b", () => {
+		// activate(b) then deactivate(a):
+		let active: string | undefined = "a";
+		active = nextActiveKey(active, "b", true); // activate(b)
+		active = nextActiveKey(active, "a", false); // deactivate(a)
+		expect(active).toBe("b");
+
+		// deactivate(a) then activate(b):
+		active = "a";
+		active = nextActiveKey(active, "a", false); // deactivate(a)
+		active = nextActiveKey(active, "b", true); // activate(b)
+		expect(active).toBe("b");
+	});
+
+	it("on dispose (not active), clears only if the closed tab was active", () => {
+		expect(nextActiveKey("a", "a", false)).toBeUndefined(); // closed active tab
+		expect(nextActiveKey("a", "b", false)).toBe("a"); // closed a background tab
 	});
 });

--- a/packages/vscode/test/sessions-view-model.test.ts
+++ b/packages/vscode/test/sessions-view-model.test.ts
@@ -161,4 +161,16 @@ describe("SessionsViewModel", () => {
 		expect(posted.some((m) => m.type === "list")).toBe(false);
 		expect(logs.some((l) => l.includes("disk boom"))).toBe(true);
 	});
+
+	it("threads activeKey from the dep into the posted list", async () => {
+		let active: string | undefined = "/p/a.jsonl";
+		const { model, posted } = makeModel({ activeKey: () => active });
+		await model.handle({ type: "ready" });
+		expect(lastList(posted).activeKey).toBe("/p/a.jsonl");
+
+		// Reflects a change when focus moves to a different (or no) session.
+		active = undefined;
+		await model.handle({ type: "refresh" });
+		expect(lastList(posted).activeKey).toBeUndefined();
+	});
 });

--- a/packages/vscode/test/sidebar-app.test.tsx
+++ b/packages/vscode/test/sidebar-app.test.tsx
@@ -213,3 +213,47 @@ describe("SidebarApp stop action (Phase 7)", () => {
 		expect(container.querySelector('[aria-label="Stop session"]')).toBeNull();
 	});
 });
+
+describe("SidebarApp active-session highlight (issue 76)", () => {
+	const twoRows = (activeKey?: string): SessionListDto => ({
+		currentCwd: "/proj",
+		groups: [
+			group("current", "/proj", "This workspace", [row("/proj/a.jsonl", "Alpha"), row("/proj/b.jsonl", "Beta")]),
+		],
+		activeKey,
+	});
+
+	const activeKeys = () =>
+		[...container.querySelectorAll(".dreb-side-row-active")].map((el) =>
+			el.querySelector(".dreb-side-row-title")?.textContent?.trim(),
+		);
+
+	it("marks only the row whose key matches activeKey", () => {
+		mountSidebar();
+		emit(twoRows("/proj/b.jsonl"));
+		expect(container.querySelectorAll(".dreb-side-row-active").length).toBe(1);
+		expect(activeKeys()).toEqual(["Beta"]);
+	});
+
+	it("marks no row when activeKey is undefined", () => {
+		mountSidebar();
+		emit(twoRows(undefined));
+		expect(container.querySelectorAll(".dreb-side-row-active").length).toBe(0);
+	});
+
+	it("moves the highlight when the active session changes", () => {
+		mountSidebar();
+		emit(twoRows("/proj/a.jsonl"));
+		expect(activeKeys()).toEqual(["Alpha"]);
+		emit(twoRows("/proj/b.jsonl"));
+		expect(activeKeys()).toEqual(["Beta"]);
+	});
+
+	it("clears the highlight when focus leaves all dreb chat tabs", () => {
+		mountSidebar();
+		emit(twoRows("/proj/a.jsonl"));
+		expect(container.querySelectorAll(".dreb-side-row-active").length).toBe(1);
+		emit(twoRows(undefined));
+		expect(container.querySelectorAll(".dreb-side-row-active").length).toBe(0);
+	});
+});

--- a/packages/vscode/test/tab-title.test.ts
+++ b/packages/vscode/test/tab-title.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { formatTabTitle } from "../src/shared/tab-title.js";
+
+describe("formatTabTitle", () => {
+	it("prefixes the session name with `D: `", () => {
+		expect(formatTabTitle("Fix auth", "idle")).toBe("D: Fix auth");
+	});
+
+	it("falls back to `New session` for an empty/undefined title", () => {
+		expect(formatTabTitle(undefined, "idle")).toBe("D: New session");
+		expect(formatTabTitle("", "idle")).toBe("D: New session");
+		expect(formatTabTitle("   ", "idle")).toBe("D: New session");
+	});
+
+	it("appends a compact marker for each non-idle run state", () => {
+		expect(formatTabTitle("Task", "running")).toBe("D: Task ●");
+		expect(formatTabTitle("Task", "needs-input")).toBe("D: Task ⚠");
+		expect(formatTabTitle("Task", "idle")).toBe("D: Task");
+	});
+
+	it("collapses internal whitespace/newlines from a multi-line first message", () => {
+		expect(formatTabTitle("hello\n  world\ttab", "idle")).toBe("D: hello world tab");
+	});
+
+	it("truncates a long name to maxLen with an ellipsis", () => {
+		// maxLen 5 → keep 4 chars + ellipsis.
+		expect(formatTabTitle("abcdefghij", "idle", 5)).toBe("D: abcd…");
+	});
+
+	it("does not truncate a name at exactly maxLen", () => {
+		expect(formatTabTitle("abcde", "idle", 5)).toBe("D: abcde");
+	});
+
+	it("trims trailing space before the ellipsis when the cut lands after a space", () => {
+		// maxLen 4 → slice(0, 3) = "ab " → trimmed to "ab" before the ellipsis.
+		expect(formatTabTitle("ab cdefgh", "idle", 4)).toBe("D: ab…");
+	});
+
+	it("keeps the run-state marker even when the name is truncated", () => {
+		expect(formatTabTitle("abcdefghij", "running", 5)).toBe("D: abcd… ●");
+	});
+});


### PR DESCRIPTION
Closes #76

Name chat editor tabs after their session (`D: <shortened name>`) and highlight the currently-active session's row in the Sessions sidebar, so users can map "the tab I'm on" ↔ "its sidebar entry."

Part of the VSCode extension epic #12.

Implementation plan posted as a comment below.
