### PR TITLE
VSCode sidebar: stable creation-order sessions + manual drag-reorder

### DIFF
--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -23,6 +23,7 @@ src/
     session-view-lifecycle.ts sleep-on-inactivity driver — backgrounds a closed session, sleeps it on an idle timer or a no-user-input cap; treats a crashed controller as not-reusable so reopen restarts it (pure, tested)
     session-inventory.ts on-disk session enumeration via @dreb/coding-agent's SessionManager (vscode-free)
     session-flags.ts    pin/archive persistence over globalState, keyed by session path (pure seam, tested)
+    session-order.ts    manual drag-reorder persistence over globalState, keyed by session path (pure seam, tested)
     sessions-view-model.ts sidebar list-building + action routing (pure, vscode-free, tested)
     sessions-view.ts    the `dreb.sessions` WebviewView glue (postMessage transport + HTML shell)
     tag-selection.ts    tag-selection-into-chat orchestration (pure, vscode-free, tested)
@@ -40,7 +41,7 @@ src/
     format.ts           status-header + `/session` display formatters (pure, tested)
     tagged-context.ts   selection + file/folder/symbol context DTOs, chip label, prompt fold + threshold (pure, tested)
     mention.ts          `@`/`@@` composer trigger parsing, glob escaping, and typeahead result ranking (pure, tested)
-    session-list.ts     disk+live session reconciliation, grouping, deterministic ordering, status (pure, tested)
+    session-list.ts     disk+live session reconciliation, grouping, stable creation-order + manual-order sort, status (pure, tested)
     sidebar-protocol.ts host ↔ sessions-sidebar message envelopes (no @dreb import)
   webview/       # SolidJS UI — bundled with Vite → dist/webview (chat) + dist/webview-sidebar (sessions)
     app.tsx             transcript, collapsible activity box, composer, needs-input,
@@ -50,7 +51,8 @@ src/
     code-links.ts       grounded file/symbol linkification of answers (pure, tested)
     composer-resize.ts  clamp helper for the drag-resizable composer height (pure, tested)
     sidebar/app.tsx     the sessions side panel — grouped list, live status, resume,
-                        inline rename, pin / archive / delete
+                        inline rename, pin / archive / delete, drag-to-reorder
+    sidebar/reorder.ts  pure move-math for drag-to-reorder — new key order from a drop (DOM-free, tested)
 ```
 
 - The host keeps the authoritative `TranscriptState`. On (re)load the webview announces `ready` and receives a full snapshot, so recreating the webview never loses the conversation.

--- a/packages/vscode/src/host/extension.ts
+++ b/packages/vscode/src/host/extension.ts
@@ -22,6 +22,7 @@ import type { ReviewUi } from "./review-ui.js";
 import { SessionController } from "./session-controller.js";
 import { SessionFlagsStore } from "./session-flags.js";
 import { createSessionInventory, deletePersistedSession, type SessionInventory } from "./session-inventory.js";
+import { SessionOrderStore } from "./session-order.js";
 import { SessionPool } from "./session-registry.js";
 import {
 	readSleepSetting,
@@ -81,6 +82,7 @@ const pool = new SessionPool<ChatSession>({
 let sessionsView: SessionsViewProvider | undefined;
 let inventory: SessionInventory;
 let flags: SessionFlagsStore;
+let order: SessionOrderStore;
 /** The activation context, kept so `reveal` can rebuild a panel for a
  * backgrounded session that outlived its original panel. */
 let extensionContext: vscode.ExtensionContext | undefined;
@@ -100,9 +102,11 @@ export function activate(context: vscode.ExtensionContext): void {
 	extensionContext = context;
 	inventory = createSessionInventory();
 	flags = new SessionFlagsStore(context.globalState);
+	order = new SessionOrderStore(context.globalState);
 	sessionsView = new SessionsViewProvider(context.extensionUri, {
 		inventory,
 		flags,
+		order,
 		currentCwd: workspaceCwd,
 		liveSessions: () =>
 			pool.list().map(
@@ -507,9 +511,16 @@ async function deleteSession(key: string): Promise<void> {
 		// Delete the transcript and drop its flags only on success. `activeSessionPath`
 		// is read *after* disposing the target above, so the guard only fires for a
 		// genuinely different session that is still active.
-		await deletePersistedSession(inventory, flags, path, pool.active?.controller.sessionPath, (message) =>
-			vscode.window.showErrorMessage(message),
+		const result = await deletePersistedSession(
+			inventory,
+			flags,
+			path,
+			pool.active?.controller.sessionPath,
+			(message) => vscode.window.showErrorMessage(message),
 		);
+		// Drop any persisted manual order rank too, so a re-created session at the
+		// same path doesn't inherit a stale position.
+		if (result.ok) await order.clear(path);
 	}
 	scheduleSidebarRefresh();
 }

--- a/packages/vscode/src/host/session-order.ts
+++ b/packages/vscode/src/host/session-order.ts
@@ -1,0 +1,80 @@
+/**
+ * Vscode-free, unit-testable store for the sidebar's manual session order.
+ *
+ * By default the sessions side panel orders sessions by creation time (newest
+ * first) — a stable order that never shifts with activity. Users can override
+ * that within a group by dragging rows; this module persists that manual order
+ * so it survives refreshes and extension restarts.
+ *
+ * Like {@link SessionFlagsStore}, the order is UI state (not part of the session
+ * `.jsonl` transcript), so it lives in the extension's `globalState`. This module
+ * holds the pure, vscode-independent core: `extension.ts` injects the real
+ * {@link https://code.visualstudio.com/api | vscode} `Memento` (globalState),
+ * while tests inject an in-memory fake.
+ *
+ * Ranks are keyed by the session's `.jsonl` file path. Within a dragged group the
+ * first row gets the largest rank so a **descending** rank sort reproduces the
+ * displayed order. Ranks are small positive integers (`1..N`) that deliberately
+ * sit below creation-time epoch values, so a session created *after* a manual
+ * reorder still surfaces at the top by newest-created while the dragged block
+ * keeps its relative order beneath it.
+ */
+
+/** Minimal subset of vscode.Memento the store needs (globalState). */
+export interface OrderMemento {
+	get<T>(key: string): T | undefined;
+	update(key: string, value: unknown): Thenable<void> | Promise<void>;
+}
+
+/** globalState key under which the whole order record is stored. */
+const STORAGE_KEY = "dreb.sessionOrder";
+
+/** Persisted shape: session path -> its manual rank (higher sorts first). */
+type OrderRecord = Record<string, number>;
+
+/**
+ * Persists a per-session manual order rank keyed by session `.jsonl` file path in
+ * a single globalState record. Sessions with no stored rank fall back to the
+ * default creation-time ordering.
+ */
+export class SessionOrderStore {
+	constructor(private readonly memento: OrderMemento) {}
+
+	/** Read the whole persisted record, defaulting to an empty object. */
+	private read(): OrderRecord {
+		return this.memento.get<OrderRecord>(STORAGE_KEY) ?? {};
+	}
+
+	/** Manual rank for a session path, or undefined when none is stored (or the
+	 * path is undefined — a brand-new not-yet-persisted session). */
+	get(path: string | undefined): number | undefined {
+		if (path === undefined) return undefined;
+		const rec = this.read();
+		return rec[path];
+	}
+
+	/**
+	 * Persist an explicit manual order for a group of sessions. `orderedPaths` is
+	 * the group's rows in the exact top-to-bottom order the user arranged them;
+	 * each path is assigned a descending rank so the default rank-DESC sort
+	 * reproduces that order. Ranks for paths outside `orderedPaths` are untouched.
+	 */
+	async setGroupOrder(orderedPaths: string[]): Promise<void> {
+		const rec = this.read();
+		const n = orderedPaths.length;
+		orderedPaths.forEach((path, index) => {
+			// First row -> largest rank (n), last row -> 1, so rank-DESC = displayed order.
+			rec[path] = n - index;
+		});
+		await this.memento.update(STORAGE_KEY, rec);
+	}
+
+	/** Remove a path's stored rank entirely (call on delete). */
+	async clear(path: string): Promise<void> {
+		const rec = this.read();
+		if (path in rec) {
+			delete rec[path];
+			await this.memento.update(STORAGE_KEY, rec);
+		}
+	}
+}

--- a/packages/vscode/src/host/sessions-view-model.ts
+++ b/packages/vscode/src/host/sessions-view-model.ts
@@ -14,11 +14,14 @@ import { buildSessionList, type LiveSessionInput, type SessionListDto } from "..
 import type { HostToSidebar, SidebarToHost } from "../shared/sidebar-protocol.js";
 import type { SessionFlagsStore } from "./session-flags.js";
 import type { SessionInventory } from "./session-inventory.js";
+import type { SessionOrderStore } from "./session-order.js";
 
 /** Ports the view-model needs; all vscode/pool specifics live behind these. */
 export interface SessionsViewDeps {
 	inventory: SessionInventory;
 	flags: SessionFlagsStore;
+	/** Persisted manual drag order for sessions (keyed by path). */
+	order: SessionOrderStore;
 	/** The workspace cwd whose sessions sort first. */
 	currentCwd: () => string;
 	/** Snapshot of the currently-live sessions in the host's pool. */
@@ -88,6 +91,18 @@ export class SessionsViewModel {
 				await this.deps.deleteSession(msg.key);
 				await this.refresh();
 				return;
+			case "reorder": {
+				// Resolve the dragged row keys to session paths, dropping any
+				// not-yet-persisted (`new:`) rows that have no path to key an order by.
+				const paths = msg.orderedKeys
+					.map((key) => this.deps.pathForKey(key))
+					.filter((p): p is string => p !== undefined);
+				if (paths.length > 0) {
+					await this.deps.order.setGroupOrder(paths);
+					await this.refresh();
+				}
+				return;
+			}
 			case "stop":
 				// Stopping tears the controller down; the host refreshes the list as a
 				// side effect of the pool change. Refresh anyway so a slept/aborted row
@@ -127,6 +142,7 @@ export class SessionsViewModel {
 			disk,
 			live,
 			flags: (path) => this.deps.flags.get(path),
+			order: (path) => this.deps.order.get(path),
 		});
 	}
 }

--- a/packages/vscode/src/shared/session-list.ts
+++ b/packages/vscode/src/shared/session-list.ts
@@ -9,10 +9,12 @@
  * that row (so opening it round-trips through the pool key) rather than showing
  * twice; a live session without a path is a brand-new not-yet-persisted one.
  *
- * Ordering is deliberately **deterministic** — pinned-first, then modified
- * DESC, then title, then key — and live run-state never affects placement, so
- * rows don't jump around as sessions stream (see AGENTS.md "Determinism Over
- * Recency").
+ * Ordering is deliberately **deterministic** and stable — pinned-first, then a
+ * per-session manual order (when the user has dragged rows) else creation time
+ * DESC (newest-created first), then title, then key. Neither live run-state nor
+ * the mutable `modified` timestamp affects placement, so rows keep a fixed
+ * position and don't jump around as sessions become active or stream (see
+ * AGENTS.md "Determinism Over Recency").
  *
  * Like `shared/tagged-context.ts`, this module is intentionally free of
  * `vscode` AND of any `node:` builtins so it can be bundled into the webview,
@@ -46,6 +48,9 @@ export interface SessionSummaryDto {
 	title: string;
 	/** ISO timestamp. */
 	modified: string;
+	/** ISO timestamp of session creation. Stable — drives default ordering
+	 * (newest-created first) and, unlike `modified`, never changes with activity. */
+	created: string;
 	messageCount: number;
 	/** `"idle"` for disk-only rows. */
 	state: SessionRunState;
@@ -81,6 +86,8 @@ export interface DiskSessionInput {
 	name?: string;
 	firstMessage: string;
 	modified: string;
+	/** ISO timestamp of session creation (stable; drives default ordering). */
+	created: string;
 	messageCount: number;
 }
 
@@ -92,6 +99,9 @@ export interface LiveSessionInput {
 	state: SessionRunState;
 	title?: string;
 	modified?: string;
+	/** ISO timestamp of session creation, when known. A brand-new not-yet-persisted
+	 * session has none; ordering then falls back to `modified` or now. */
+	created?: string;
 	messageCount?: number;
 }
 
@@ -101,6 +111,11 @@ export interface BuildSessionListInput {
 	disk: DiskSessionInput[];
 	live: LiveSessionInput[];
 	flags: (path: string | undefined) => SessionFlags;
+	/** Optional per-session manual order rank (keyed by session path). Present
+	 * only for sessions the user has dragged to reorder; a defined rank overrides
+	 * the default creation-time ordering within a group. Undefined -> use
+	 * creation time. */
+	order?: (path: string | undefined) => number | undefined;
 }
 
 /** Last path segment of a slash/back-slash separated path (falls back to the
@@ -120,7 +135,8 @@ function basename(cwd: string): string {
  * grouped list. See the module doc for the merge/ordering rules.
  */
 export function buildSessionList(input: BuildSessionListInput): SessionListDto {
-	const { currentCwd, disk, live, flags } = input;
+	const { currentCwd, disk, live, flags, order } = input;
+	const orderOf = (path: string | undefined): number | undefined => (order ? order(path) : undefined);
 
 	// 1. Map disk sessions to rows, indexed by path for live merging.
 	const rows: SessionSummaryDto[] = [];
@@ -133,6 +149,7 @@ export function buildSessionList(input: BuildSessionListInput): SessionListDto {
 			cwd: d.cwd,
 			title: d.name?.trim() || d.firstMessage?.trim() || "(untitled session)",
 			modified: d.modified,
+			created: d.created,
 			messageCount: d.messageCount,
 			state: "idle",
 			live: false,
@@ -162,6 +179,7 @@ export function buildSessionList(input: BuildSessionListInput): SessionListDto {
 			cwd: l.cwd,
 			title: l.title?.trim() || "New session",
 			modified: l.modified ?? new Date().toISOString(),
+			created: l.created ?? l.modified ?? new Date().toISOString(),
 			messageCount: l.messageCount ?? 0,
 			state: l.state,
 			live: true,
@@ -188,12 +206,28 @@ export function buildSessionList(input: BuildSessionListInput): SessionListDto {
 		}
 	}
 
-	// 4. Deterministic ordering — pinned first, then modified DESC, then title
-	//    ascending, then key ascending. Live run-state never affects ordering.
+	// 4. Deterministic, stable ordering — pinned first, then by an effective rank
+	//    (a persisted manual drag order when present, else creation time), highest
+	//    rank first, then title ascending, then key ascending. Neither live
+	//    run-state nor the mutable `modified` timestamp affects ordering, so rows
+	//    keep a fixed position (see AGENTS.md "Determinism Over Recency").
+	//
+	//    Manual ranks are small integers (see SessionOrderStore), which sit below
+	//    creation-time epoch values, so a session created *after* a manual reorder
+	//    still surfaces at the top by newest-created while the dragged block keeps
+	//    its relative order beneath it.
+	const rankOf = (row: SessionSummaryDto): number => {
+		const manual = orderOf(row.path);
+		if (manual !== undefined) return manual;
+		const t = Date.parse(row.created);
+		return Number.isNaN(t) ? 0 : t;
+	};
 	const sortRows = (list: SessionSummaryDto[]): SessionSummaryDto[] =>
 		list.slice().sort((a, b) => {
 			if (a.pinned !== b.pinned) return a.pinned ? -1 : 1;
-			if (a.modified !== b.modified) return a.modified < b.modified ? 1 : -1;
+			const ra = rankOf(a);
+			const rb = rankOf(b);
+			if (ra !== rb) return ra < rb ? 1 : -1;
 			if (a.title !== b.title) return a.title < b.title ? -1 : 1;
 			return a.key < b.key ? -1 : a.key > b.key ? 1 : 0;
 		});

--- a/packages/vscode/src/shared/sidebar-protocol.ts
+++ b/packages/vscode/src/shared/sidebar-protocol.ts
@@ -22,6 +22,9 @@ export type SidebarToHost =
 	| { type: "pin"; key: string; pinned: boolean }
 	| { type: "archive"; key: string; archived: boolean }
 	| { type: "delete"; key: string }
+	/** Persist a manual drag order for one group. `orderedKeys` is the group's
+	 * rows in the exact top-to-bottom order the user arranged them. */
+	| { type: "reorder"; groupKey: string; orderedKeys: string[] }
 	/** Abort the session's current turn and end it (release its RPC child). The
 	 * only way to deliberately interrupt a working agent — closing a tab never
 	 * does. */

--- a/packages/vscode/src/webview/sidebar/app.tsx
+++ b/packages/vscode/src/webview/sidebar/app.tsx
@@ -1,6 +1,7 @@
 import { createSignal, For, onCleanup, onMount, Show } from "solid-js";
 import { createStore, reconcile } from "solid-js/store";
 import type { SessionGroupDto, SessionListDto, SessionSummaryDto } from "../../shared/session-list.js";
+import { computeReorder } from "./reorder.js";
 import { onHostMessage, postToHost } from "./vscode-api.js";
 
 export function SidebarApp() {
@@ -65,6 +66,21 @@ export function SidebarApp() {
 
 function GroupView(props: { group: SessionGroupDto }) {
 	const group = props.group;
+	// Local drag state for reordering rows within this group. The dragged row's
+	// key is held while a drag is in flight; on drop we compute the new key order
+	// and hand it to the host, which persists it and pushes back a rebuilt list.
+	const [draggingKey, setDraggingKey] = createSignal<string | null>(null);
+
+	const keys = () => props.group.sessions.map((s) => s.key);
+
+	const drop = (targetKey: string, placeAfter: boolean) => {
+		const dragged = draggingKey();
+		setDraggingKey(null);
+		if (!dragged || dragged === targetKey) return;
+		const next = computeReorder(keys(), dragged, targetKey, placeAfter);
+		postToHost({ type: "reorder", groupKey: props.group.key, orderedKeys: next });
+	};
+
 	return (
 		<details class="dreb-side-group" open={group.kind === "current"}>
 			<summary class="dreb-side-group-head">
@@ -72,15 +88,37 @@ function GroupView(props: { group: SessionGroupDto }) {
 				<span class="dreb-side-group-count">{group.sessions.length}</span>
 			</summary>
 			<div class="dreb-side-group-body">
-				<For each={group.sessions}>{(session) => <SessionRow session={session} groupKind={group.kind} />}</For>
+				<For each={group.sessions}>
+					{(session) => (
+						<SessionRow
+							session={session}
+							groupKind={group.kind}
+							dragging={() => draggingKey() === session.key}
+							onDragStart={() => setDraggingKey(session.key)}
+							onDragEnd={() => setDraggingKey(null)}
+							onDrop={(placeAfter) => drop(session.key, placeAfter)}
+						/>
+					)}
+				</For>
 			</div>
 		</details>
 	);
 }
 
-function SessionRow(props: { session: SessionSummaryDto; groupKind: SessionGroupDto["kind"] }) {
+function SessionRow(props: {
+	session: SessionSummaryDto;
+	groupKind: SessionGroupDto["kind"];
+	dragging: () => boolean;
+	onDragStart: () => void;
+	onDragEnd: () => void;
+	onDrop: (placeAfter: boolean) => void;
+}) {
 	const [editing, setEditing] = createSignal(false);
 	const [draft, setDraft] = createSignal("");
+	// Highlights the row as a drop target while another row is dragged over it,
+	// and remembers which half (top/bottom) the pointer is in so the drop lands
+	// before or after this row.
+	const [dropHint, setDropHint] = createSignal<"none" | "before" | "after">("none");
 
 	const session = () => props.session;
 
@@ -122,8 +160,61 @@ function SessionRow(props: { session: SessionSummaryDto; groupKind: SessionGroup
 		return parts.join(" · ");
 	};
 
+	// --- Drag-to-reorder wiring -------------------------------------------------
+	const onHandleDragStart = (event: DragEvent) => {
+		props.onDragStart();
+		if (event.dataTransfer) {
+			event.dataTransfer.effectAllowed = "move";
+			// Firefox requires data to be set for a drag to start.
+			event.dataTransfer.setData("text/plain", session().key);
+		}
+	};
+
+	const onRowDragOver = (event: DragEvent) => {
+		if (props.dragging()) return; // don't hint over the row being dragged
+		event.preventDefault(); // allow the drop
+		if (event.dataTransfer) event.dataTransfer.dropEffect = "move";
+		const rect = (event.currentTarget as HTMLElement).getBoundingClientRect();
+		setDropHint(event.clientY - rect.top < rect.height / 2 ? "before" : "after");
+	};
+
+	const onRowDragLeave = () => setDropHint("none");
+
+	const onRowDrop = (event: DragEvent) => {
+		event.preventDefault();
+		const placeAfter = dropHint() === "after";
+		setDropHint("none");
+		props.onDrop(placeAfter);
+	};
+
 	return (
-		<div class="dreb-side-row" classList={{ "dreb-side-row-live": session().live }}>
+		// biome-ignore lint/a11y/noStaticElementInteractions: drop target for drag-to-reorder; the draggable handle is the interactive control and the row's open/rename actions are real buttons
+		<div
+			class="dreb-side-row"
+			classList={{
+				"dreb-side-row-live": session().live,
+				"dreb-side-row-dragging": props.dragging(),
+				"dreb-side-drop-before": dropHint() === "before",
+				"dreb-side-drop-after": dropHint() === "after",
+			}}
+			onDragOver={onRowDragOver}
+			onDragLeave={onRowDragLeave}
+			onDrop={onRowDrop}
+		>
+			<span
+				class="dreb-side-drag"
+				aria-hidden="true"
+				draggable={true}
+				title="Drag to reorder"
+				onDragStart={onHandleDragStart}
+				onDragEnd={() => {
+					setDropHint("none");
+					props.onDragEnd();
+				}}
+			>
+				⠿
+			</span>
+
 			<Show
 				when={editing()}
 				fallback={

--- a/packages/vscode/src/webview/sidebar/reorder.ts
+++ b/packages/vscode/src/webview/sidebar/reorder.ts
@@ -1,0 +1,25 @@
+/**
+ * Pure helper for the sidebar's drag-to-reorder: given a group's current row
+ * order and a drag from one row onto another, produce the new top-to-bottom key
+ * order. Kept `vscode`- and DOM-free so it is unit-testable in plain node.
+ */
+
+/**
+ * Move `draggingKey` to sit immediately before (or after, when `placeAfter`) the
+ * `targetKey` within `keys`, returning the new order. Returns the input order
+ * unchanged when the drag is a no-op (same key, or either key missing).
+ */
+export function computeReorder(
+	keys: readonly string[],
+	draggingKey: string,
+	targetKey: string,
+	placeAfter: boolean,
+): string[] {
+	if (draggingKey === targetKey) return keys.slice();
+	if (!keys.includes(draggingKey) || !keys.includes(targetKey)) return keys.slice();
+	const without = keys.filter((k) => k !== draggingKey);
+	const targetIndex = without.indexOf(targetKey);
+	const insertAt = placeAfter ? targetIndex + 1 : targetIndex;
+	without.splice(insertAt, 0, draggingKey);
+	return without;
+}

--- a/packages/vscode/src/webview/sidebar/styles.css
+++ b/packages/vscode/src/webview/sidebar/styles.css
@@ -138,6 +138,36 @@ body {
 	border-left-color: var(--vscode-charts-green, #2a2);
 }
 
+/* Drag-to-reorder: grab handle, revealed on hover like the action buttons. */
+.dreb-side-drag {
+	flex: 0 0 auto;
+	display: flex;
+	align-items: center;
+	padding: 0 2px;
+	cursor: grab;
+	opacity: 0;
+	color: var(--vscode-descriptionForeground, #888);
+	user-select: none;
+}
+.dreb-side-row:hover .dreb-side-drag,
+.dreb-side-row:focus-within .dreb-side-drag {
+	opacity: 0.7;
+}
+.dreb-side-drag:active {
+	cursor: grabbing;
+}
+/* The row currently being dragged. */
+.dreb-side-row-dragging {
+	opacity: 0.5;
+}
+/* Drop-target indicators: a line above/below the hovered row. */
+.dreb-side-drop-before {
+	box-shadow: inset 0 2px 0 0 var(--vscode-focusBorder, #07d);
+}
+.dreb-side-drop-after {
+	box-shadow: inset 0 -2px 0 0 var(--vscode-focusBorder, #07d);
+}
+
 .dreb-side-row-main {
 	flex: 1;
 	min-width: 0;

--- a/packages/vscode/test/session-list.test.ts
+++ b/packages/vscode/test/session-list.test.ts
@@ -19,6 +19,7 @@ function disk(overrides: Partial<DiskSessionInput> & { path: string }): DiskSess
 		cwd: "/proj",
 		firstMessage: "hello",
 		modified: "2026-01-01T00:00:00.000Z",
+		created: "2026-01-01T00:00:00.000Z",
 		messageCount: 1,
 		...overrides,
 	};
@@ -127,21 +128,86 @@ describe("buildSessionList", () => {
 		expect(fresh?.state).toBe("running");
 	});
 
-	it("(d) sorts pinned rows before unpinned, then by modified desc", () => {
+	it("(d) sorts pinned rows before unpinned, then by created desc (newest first)", () => {
 		const list = buildSessionList({
 			currentCwd: "/proj",
 			disk: [
-				disk({ path: "/proj/old.jsonl", name: "Old", modified: "2026-01-01T00:00:00.000Z" }),
-				disk({ path: "/proj/new.jsonl", name: "New", modified: "2026-06-01T00:00:00.000Z" }),
-				disk({ path: "/proj/pinned.jsonl", name: "Pinned", modified: "2020-01-01T00:00:00.000Z" }),
+				disk({ path: "/proj/old.jsonl", name: "Old", created: "2026-01-01T00:00:00.000Z" }),
+				disk({ path: "/proj/new.jsonl", name: "New", created: "2026-06-01T00:00:00.000Z" }),
+				disk({ path: "/proj/pinned.jsonl", name: "Pinned", created: "2020-01-01T00:00:00.000Z" }),
 			],
 			live: [],
 			flags: flagsFrom({ "/proj/pinned.jsonl": { pinned: true, archived: false } }),
 		});
 
 		const titles = list.groups[0].sessions.map((s) => s.title);
-		// Pinned first despite being oldest; then modified DESC among unpinned.
+		// Pinned first despite being oldest; then created DESC among unpinned.
 		expect(titles).toEqual(["Pinned", "New", "Old"]);
+	});
+
+	it("(d2) a newer `modified` does not reorder rows — only `created` orders them", () => {
+		const list = buildSessionList({
+			currentCwd: "/proj",
+			disk: [
+				// "Old" was created first but touched most recently; it must still sort
+				// last, proving activity (`modified`) no longer promotes a row.
+				disk({
+					path: "/proj/old.jsonl",
+					name: "Old",
+					created: "2026-01-01T00:00:00.000Z",
+					modified: "2026-12-31T00:00:00.000Z",
+				}),
+				disk({
+					path: "/proj/new.jsonl",
+					name: "New",
+					created: "2026-06-01T00:00:00.000Z",
+					modified: "2026-06-01T00:00:00.000Z",
+				}),
+			],
+			live: [],
+			flags: noFlags,
+		});
+		expect(list.groups[0].sessions.map((s) => s.title)).toEqual(["New", "Old"]);
+	});
+
+	it("(d3) a manual order rank overrides the default created ordering", () => {
+		const input = {
+			currentCwd: "/proj",
+			disk: [
+				disk({ path: "/proj/a.jsonl", name: "A", created: "2026-06-01T00:00:00.000Z" }),
+				disk({ path: "/proj/b.jsonl", name: "B", created: "2026-05-01T00:00:00.000Z" }),
+				disk({ path: "/proj/c.jsonl", name: "C", created: "2026-04-01T00:00:00.000Z" }),
+			],
+			live: [],
+			flags: noFlags,
+		};
+
+		// Default: newest-created first -> A, B, C.
+		expect(buildSessionList(input).groups[0].sessions.map((s) => s.title)).toEqual(["A", "B", "C"]);
+
+		// Manual ranks (higher sorts first) place C, A, B — overriding created order.
+		const ranks: Record<string, number> = { "/proj/c.jsonl": 3, "/proj/a.jsonl": 2, "/proj/b.jsonl": 1 };
+		const reordered = buildSessionList({ ...input, order: (p) => (p ? ranks[p] : undefined) });
+		expect(reordered.groups[0].sessions.map((s) => s.title)).toEqual(["C", "A", "B"]);
+	});
+
+	it("(d4) a session created after a manual reorder still surfaces at the top", () => {
+		// Manually-ordered rows carry small integer ranks; a freshly-created row has
+		// no rank and falls back to its creation epoch, which sits above them.
+		const ranks: Record<string, number> = { "/proj/a.jsonl": 2, "/proj/b.jsonl": 1 };
+		const list = buildSessionList({
+			currentCwd: "/proj",
+			disk: [
+				disk({ path: "/proj/a.jsonl", name: "A", created: "2026-01-01T00:00:00.000Z" }),
+				disk({ path: "/proj/b.jsonl", name: "B", created: "2026-01-02T00:00:00.000Z" }),
+				disk({ path: "/proj/fresh.jsonl", name: "Fresh", created: "2026-08-01T00:00:00.000Z" }),
+			],
+			live: [],
+			flags: noFlags,
+			order: (p) => (p ? ranks[p] : undefined),
+		});
+		// Fresh (unranked, newest) on top; the manually-ordered block A,B beneath.
+		expect(list.groups[0].sessions.map((s) => s.title)).toEqual(["Fresh", "A", "B"]);
 	});
 
 	it("(e) moves archived rows to the Archived group regardless of cwd", () => {
@@ -192,8 +258,8 @@ describe("buildSessionList", () => {
 		const base = {
 			currentCwd: "/proj",
 			disk: [
-				disk({ path: "/proj/a.jsonl", name: "A", modified: "2026-01-02T00:00:00.000Z" }),
-				disk({ path: "/proj/b.jsonl", name: "B", modified: "2026-01-01T00:00:00.000Z" }),
+				disk({ path: "/proj/a.jsonl", name: "A", created: "2026-01-02T00:00:00.000Z" }),
+				disk({ path: "/proj/b.jsonl", name: "B", created: "2026-01-01T00:00:00.000Z" }),
 			],
 			flags: noFlags,
 		};
@@ -209,6 +275,26 @@ describe("buildSessionList", () => {
 		expect(order(idle)).toEqual(["A", "B"]);
 		expect(order(running)).toEqual(["A", "B"]);
 		expect(running.groups[0].sessions[1].state).toBe("running");
+	});
+
+	it("(g2) a pathless live session falls back its `created` to `modified` then now", () => {
+		const list = buildSessionList({
+			currentCwd: "/proj",
+			disk: [],
+			live: [live({ key: "pool-new", state: "running", modified: "2026-03-03T00:00:00.000Z" })],
+			flags: noFlags,
+		});
+		expect(list.groups[0].sessions[0].created).toBe("2026-03-03T00:00:00.000Z");
+
+		const noModified = buildSessionList({
+			currentCwd: "/proj",
+			disk: [],
+			live: [live({ key: "pool-new", state: "running" })],
+			flags: noFlags,
+		});
+		// No modified either -> a valid ISO "now" fallback (non-empty, parseable).
+		const created = noModified.groups[0].sessions[0].created;
+		expect(Number.isNaN(Date.parse(created))).toBe(false);
 	});
 
 	it("(h) each group carries a stable, unique key (for webview reconcile)", () => {

--- a/packages/vscode/test/session-order.test.ts
+++ b/packages/vscode/test/session-order.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { type OrderMemento, SessionOrderStore } from "../src/host/session-order.js";
+
+/** In-memory {@link OrderMemento} backed by a Map, exposing raw storage for asserts. */
+class FakeMemento implements OrderMemento {
+	readonly store = new Map<string, unknown>();
+
+	get<T>(key: string): T | undefined {
+		return this.store.get(key) as T | undefined;
+	}
+
+	async update(key: string, value: unknown): Promise<void> {
+		this.store.set(key, value);
+	}
+
+	/** Convenience: the persisted order record (or undefined if never written). */
+	record(): Record<string, number> | undefined {
+		return this.store.get("dreb.sessionOrder") as Record<string, number> | undefined;
+	}
+}
+
+describe("SessionOrderStore", () => {
+	let memento: FakeMemento;
+	let store: SessionOrderStore;
+
+	beforeEach(() => {
+		memento = new FakeMemento();
+		store = new SessionOrderStore(memento);
+	});
+
+	it("returns undefined for an unranked or undefined path", () => {
+		expect(store.get("/s/a.jsonl")).toBeUndefined();
+		expect(store.get(undefined)).toBeUndefined();
+	});
+
+	it("setGroupOrder assigns descending ranks so first row sorts first", async () => {
+		await store.setGroupOrder(["/s/a.jsonl", "/s/b.jsonl", "/s/c.jsonl"]);
+		// First -> largest rank (n), last -> 1.
+		expect(store.get("/s/a.jsonl")).toBe(3);
+		expect(store.get("/s/b.jsonl")).toBe(2);
+		expect(store.get("/s/c.jsonl")).toBe(1);
+		expect(memento.record()).toEqual({ "/s/a.jsonl": 3, "/s/b.jsonl": 2, "/s/c.jsonl": 1 });
+	});
+
+	it("ranks are small integers that stay below creation-epoch values", async () => {
+		await store.setGroupOrder(["/s/a.jsonl", "/s/b.jsonl"]);
+		const epochNow = Date.now();
+		expect(store.get("/s/a.jsonl")).toBeLessThan(epochNow);
+		expect(store.get("/s/b.jsonl")).toBeLessThan(epochNow);
+	});
+
+	it("setGroupOrder leaves ranks for paths outside the group untouched", async () => {
+		await store.setGroupOrder(["/s/x.jsonl", "/s/y.jsonl"]);
+		await store.setGroupOrder(["/s/a.jsonl", "/s/b.jsonl"]);
+		expect(memento.record()).toEqual({
+			"/s/x.jsonl": 2,
+			"/s/y.jsonl": 1,
+			"/s/a.jsonl": 2,
+			"/s/b.jsonl": 1,
+		});
+	});
+
+	it("re-ordering the same group overwrites its ranks", async () => {
+		await store.setGroupOrder(["/s/a.jsonl", "/s/b.jsonl"]);
+		await store.setGroupOrder(["/s/b.jsonl", "/s/a.jsonl"]);
+		expect(store.get("/s/b.jsonl")).toBe(2);
+		expect(store.get("/s/a.jsonl")).toBe(1);
+	});
+
+	it("clear removes a path's stored rank and no-ops when absent", async () => {
+		await store.setGroupOrder(["/s/a.jsonl", "/s/b.jsonl"]);
+		await store.clear("/s/a.jsonl");
+		expect(store.get("/s/a.jsonl")).toBeUndefined();
+		expect(store.get("/s/b.jsonl")).toBe(1);
+		// Clearing an unranked path is a harmless no-op.
+		await store.clear("/s/missing.jsonl");
+		expect(memento.record()).toEqual({ "/s/b.jsonl": 1 });
+	});
+});

--- a/packages/vscode/test/sessions-view-model.test.ts
+++ b/packages/vscode/test/sessions-view-model.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
 import { type FlagMemento, SessionFlagsStore } from "../src/host/session-flags.js";
 import type { DiskSession, SessionInventory } from "../src/host/session-inventory.js";
+import { SessionOrderStore } from "../src/host/session-order.js";
 import { type SessionsViewDeps, SessionsViewModel } from "../src/host/sessions-view-model.js";
 import type { LiveSessionInput } from "../src/shared/session-list.js";
 import type { HostToSidebar } from "../src/shared/sidebar-protocol.js";
 
-/** In-memory Memento for the flags store. */
+/** In-memory Memento for the flags and order stores. */
 class FakeMemento implements FlagMemento {
 	private readonly map = new Map<string, unknown>();
 	get<T>(key: string): T | undefined {
@@ -38,10 +39,12 @@ function makeModel(over: Partial<SessionsViewDeps> = {}) {
 		deleteSession: async () => ({ ok: true, method: "trash" }),
 	};
 	const flags = new SessionFlagsStore(new FakeMemento());
+	const order = new SessionOrderStore(new FakeMemento());
 	let live: LiveSessionInput[] = [];
 	const deps: SessionsViewDeps = {
 		inventory,
 		flags,
+		order,
 		currentCwd: () => "/p",
 		liveSessions: () => live,
 		pathForKey: (key) => (key.startsWith("new:") ? undefined : key),
@@ -59,6 +62,7 @@ function makeModel(over: Partial<SessionsViewDeps> = {}) {
 		deps,
 		posted,
 		flags,
+		order,
 		setLive: (l: LiveSessionInput[]) => {
 			live = l;
 		},
@@ -145,6 +149,31 @@ describe("SessionsViewModel", () => {
 		await model.handle({ type: "stop", key: "/p/a.jsonl" });
 		expect(deps.stopSession).toHaveBeenCalledWith("/p/a.jsonl");
 		expect(posted.some((m) => m.type === "list")).toBe(true);
+	});
+
+	it("reorder persists the group's order (keys->paths) via the order store and refreshes", async () => {
+		const { model, order, posted } = makeModel();
+		const spy = vi.spyOn(order, "setGroupOrder");
+		await model.handle({ type: "reorder", groupKey: "current:/p", orderedKeys: ["/p/b.jsonl", "/p/a.jsonl"] });
+		expect(spy).toHaveBeenCalledWith(["/p/b.jsonl", "/p/a.jsonl"]);
+		expect(order.get("/p/b.jsonl")).toBe(2);
+		expect(order.get("/p/a.jsonl")).toBe(1);
+		expect(posted.some((m) => m.type === "list")).toBe(true);
+	});
+
+	it("reorder drops not-yet-persisted (new:) keys but persists the rest", async () => {
+		const { model, order } = makeModel();
+		await model.handle({ type: "reorder", groupKey: "current:/p", orderedKeys: ["new:abc", "/p/a.jsonl"] });
+		// Only the persisted path is ranked; the transient new: key is skipped.
+		expect(order.get("/p/a.jsonl")).toBe(1);
+	});
+
+	it("reorder with only not-yet-persisted keys is a no-op (no persist, no refresh)", async () => {
+		const { model, order, posted } = makeModel();
+		const spy = vi.spyOn(order, "setGroupOrder");
+		await model.handle({ type: "reorder", groupKey: "current:/p", orderedKeys: ["new:abc"] });
+		expect(spy).not.toHaveBeenCalled();
+		expect(posted.some((m) => m.type === "list")).toBe(false);
 	});
 
 	it("swallows inventory errors without throwing", async () => {

--- a/packages/vscode/test/sidebar-app.test.tsx
+++ b/packages/vscode/test/sidebar-app.test.tsx
@@ -45,6 +45,7 @@ function row(key: string, title: string, state: SessionSummaryDto["state"] = "id
 		cwd: "/proj",
 		title,
 		modified: "2026-01-01T00:00:00.000Z",
+		created: "2026-01-01T00:00:00.000Z",
 		messageCount: 3,
 		state,
 		live: false,
@@ -165,6 +166,47 @@ describe("SidebarApp reconcile identity preservation (F2)", () => {
 		const detailsAfter = container.querySelectorAll<HTMLDetailsElement>(".dreb-side-group");
 		expect(detailsAfter[1]).toBe(projectDetails);
 		expect(detailsAfter[1].open).toBe(true);
+	});
+});
+
+describe("SidebarApp drag-to-reorder (issue 78)", () => {
+	it("renders a drag handle on each row", () => {
+		mountSidebar();
+		emit({
+			currentCwd: "/proj",
+			groups: [
+				group("current", "/proj", "This workspace", [row("/proj/a.jsonl", "Alpha"), row("/proj/b.jsonl", "Beta")]),
+			],
+		});
+		expect(container.querySelectorAll(".dreb-side-drag").length).toBe(2);
+	});
+
+	it("posts a reorder message with the new key order after a drag+drop", () => {
+		mountSidebar();
+		emit({
+			currentCwd: "/proj",
+			groups: [
+				group("current", "/proj", "This workspace", [row("/proj/a.jsonl", "Alpha"), row("/proj/b.jsonl", "Beta")]),
+			],
+		});
+
+		const rows = container.querySelectorAll<HTMLElement>(".dreb-side-row");
+		const handleA = rows[0].querySelector<HTMLElement>(".dreb-side-drag");
+		expect(handleA).not.toBeNull();
+
+		// Drag row A's handle, hover over row B, and drop. (jsdom lacks a real
+		// DragEvent/dataTransfer; the handlers guard for that, and a zero-size
+		// bounding box resolves the drop to "after" — moving A below B.)
+		handleA!.dispatchEvent(new Event("dragstart", { bubbles: true }));
+		rows[1].dispatchEvent(new Event("dragover", { bubbles: true }));
+		rows[1].dispatchEvent(new Event("drop", { bubbles: true }));
+
+		const reorder = hoisted.posted.find((m) => (m as { type?: string }).type === "reorder");
+		expect(reorder).toEqual({
+			type: "reorder",
+			groupKey: "current:/proj",
+			orderedKeys: ["/proj/b.jsonl", "/proj/a.jsonl"],
+		});
 	});
 });
 

--- a/packages/vscode/test/sidebar-reorder.test.ts
+++ b/packages/vscode/test/sidebar-reorder.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { computeReorder } from "../src/webview/sidebar/reorder.js";
+
+describe("computeReorder", () => {
+	const keys = ["a", "b", "c", "d"];
+
+	it("moves a row before the target", () => {
+		expect(computeReorder(keys, "d", "b", false)).toEqual(["a", "d", "b", "c"]);
+	});
+
+	it("moves a row after the target", () => {
+		expect(computeReorder(keys, "d", "b", true)).toEqual(["a", "b", "d", "c"]);
+	});
+
+	it("moves an earlier row later", () => {
+		expect(computeReorder(keys, "a", "c", true)).toEqual(["b", "c", "a", "d"]);
+	});
+
+	it("moving before the first row puts it at the top", () => {
+		expect(computeReorder(keys, "c", "a", false)).toEqual(["c", "a", "b", "d"]);
+	});
+
+	it("is a no-op when dragging onto itself", () => {
+		expect(computeReorder(keys, "b", "b", false)).toEqual(keys);
+	});
+
+	it("is a no-op when either key is missing", () => {
+		expect(computeReorder(keys, "z", "b", false)).toEqual(keys);
+		expect(computeReorder(keys, "b", "z", true)).toEqual(keys);
+	});
+});


### PR DESCRIPTION
Closes #78

Make the sessions sidebar hold a stable order (creation order, newest-created
first) instead of re-sorting by last activity, and let the user manually
reorder sessions within a group by dragging. Pinned-first is preserved.

Implementation plan posted as a comment below.
