### PR TITLE
Crash-recovery UX: notify on rebuild + idle, with cause, and offer Retry

### DIFF
--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -94,6 +94,8 @@ When a turn ends in a **provider error** (unavailable, rate-limited, or another 
 
 The control is offered only on the **most recent** turn and only while it stays errored — a stale error buried above later activity, an in-flight turn, and a **fatal host error** (dead RPC child, which surfaces its own reopen banner) never show it. The eligibility test (`retryableResponseId`) and the controller's `retry()` (which retains the last prompt across an in-place RPC restart) are pure/host-side and unit-tested.
 
+After the extension **auto-recovers** a crashed session in place (restarting from the persisted transcript — see *Reopen always re-activates* below), it appends a one-time **recovery notice** so the crash isn't silent. The notice reflects what was actually in flight at crash time: if a reply was **actively streaming** when the child died, it says the last reply was interrupted and not saved, and offers the same **↻ Retry** (when a last prompt was retained) to resend without retyping; if the crash happened while the session was **idle** (the previous turn had already completed and was persisted, so it's present in the rebuilt transcript), it says only that the session recovered — no misleading "not saved" claim and no Retry that would resend an already-answered prompt. The in-flight signal, message selection, and Retry gating are host-side and unit-tested.
+
 ## Change review
 
 Because the agent runs out-of-process and writes edits straight to disk, the extension can't hold changes in an unsaved overlay. Instead it **snapshots a git baseline before each turn** and reviews the working tree against it (the non-interactive analogue of `git restore -p`):

--- a/packages/vscode/src/host/session-controller.ts
+++ b/packages/vscode/src/host/session-controller.ts
@@ -288,11 +288,15 @@ const RESTART_BACKOFF_MS = 500;
  * a *later* isolated crash still gets a fresh recovery budget. */
 const RESTART_STABLE_MS = 10_000;
 const RECOVERING_NOTICE = "dreb stopped unexpectedly — recovering…";
-/** Shown once after a successful auto-recovery from an unexpected crash: the
- * transcript was rebuilt from disk but the in-flight reply was not saved, so the
- * session is now idle. */
-const RECOVERED_MESSAGE =
+/** Shown once after a successful auto-recovery when a reply was actively
+ * streaming at crash time: that in-flight reply was never persisted, so it is
+ * lost and the session is now idle. */
+const RECOVERED_MESSAGE_INTERRUPTED =
 	"Session recovered after an unexpected exit. The last reply was interrupted and not saved — the session is idle.";
+/** Shown once after a successful auto-recovery when no turn was in flight at
+ * crash time (the previous turn had already completed and was persisted, so it is
+ * present in the rebuilt transcript): nothing was lost. */
+const RECOVERED_MESSAGE_IDLE = "Session recovered after an unexpected exit. The session is idle.";
 
 function errorText(err: unknown): string {
 	return err instanceof Error ? err.message : String(err);
@@ -1455,6 +1459,11 @@ export class SessionController {
 	private handleExit(info: { code?: number | null; signal?: string | null; error?: Error; stderr?: string }): void {
 		if (this.disposed) return;
 		const message = formatExit(info);
+		// Capture whether a reply was actively streaming when the child died (before
+		// teardown), so the recovery notice can distinguish a genuinely-interrupted
+		// reply (lost) from an idle crash after a completed, persisted turn (nothing
+		// lost — and no misleading Retry of an already-answered prompt).
+		const wasStreaming = this.state.streaming === true;
 		// Surface the child's captured stderr (deliverable B) so a late crash's
 		// trigger is recorded for diagnosis instead of being discarded.
 		const stderr = info.stderr?.trim();
@@ -1466,7 +1475,7 @@ export class SessionController {
 		// Automated in-place recovery (deliverable C): auto-restart from the
 		// persisted transcript, bounded by a crash-loop budget. Carry a concise,
 		// user-facing cause so the post-recovery notice can explain what happened.
-		this.beginRecovery(message, extractCrashCause(info));
+		this.beginRecovery(message, extractCrashCause(info), wasStreaming);
 	}
 
 	/** Tear down the current client's subscriptions and drop the reference. The
@@ -1485,8 +1494,9 @@ export class SessionController {
 	/** Decide whether to auto-restart the crashed child (bounded) or give up with
 	 * a persistent banner. Called on an unexpected exit and on a failed restart.
 	 * `cause` is a concise, user-facing reason (from the child's exit info) carried
-	 * through to the post-recovery notice. */
-	private beginRecovery(reason: string, cause?: string): void {
+	 * through to the post-recovery notice. `interrupted` records whether a reply was
+	 * mid-stream at crash time, so the notice can be worded accurately. */
+	private beginRecovery(reason: string, cause?: string, interrupted = false): void {
 		if (this.disposed) return;
 		if (!this.withinRestartBudget()) {
 			this.giveUpRecovery(reason);
@@ -1501,7 +1511,7 @@ export class SessionController {
 		this.clearRestartTimer();
 		this.restartTimer = setTimeout(() => {
 			this.restartTimer = undefined;
-			void this.restart(reason, cause);
+			void this.restart(reason, cause, interrupted);
 		}, RESTART_BACKOFF_MS);
 		this.restartTimer.unref?.();
 	}
@@ -1509,7 +1519,7 @@ export class SessionController {
 	/** Auto-restart the RPC child in place, resuming from the live session file so
 	 * the persisted transcript is reloaded losslessly. All controller-lifetime
 	 * listeners and the connected webview bridge stay attached. */
-	private async restart(reason: string, cause?: string): Promise<void> {
+	private async restart(reason: string, cause?: string, interrupted = false): Promise<void> {
 		if (this.disposed) return;
 		// Resume from the live session file (falls back to the original resume
 		// path for a session that never wrote an entry before crashing).
@@ -1519,31 +1529,33 @@ export class SessionController {
 		} catch {
 			// start() already surfaced its own failure status; route the failed
 			// attempt back through the bounded policy (retry or give up).
-			this.beginRecovery(reason, cause);
+			this.beginRecovery(reason, cause, interrupted);
 			return;
 		}
-		// Connected again. Tell the user the session was rebuilt from disk but the
-		// in-flight reply was lost and it's now idle (with the cause when known),
-		// and offer a one-click Retry. Emitted here — after start()'s transcript
-		// rebuild (which clears items) — so the notice appends below the restored
-		// conversation. This is strictly the crash path; a clean initial open/reopen
-		// never goes through restart(), so those are unaffected.
-		this.emitRecovery(cause);
+		// Connected again. Tell the user the session was rebuilt from disk (with the
+		// cause when known). Emitted here — after start()'s transcript rebuild (which
+		// clears items) — so the notice appends below the restored conversation. This
+		// is strictly the crash path; a clean initial open/reopen never goes through
+		// restart(), so those are unaffected.
+		this.emitRecovery(cause, interrupted);
 		// Arm a stable-run reset so a child that survives long enough clears the
 		// crash budget and a *later* isolated crash still gets a fresh recovery
 		// allowance.
 		this.armStableRunReset();
 	}
 
-	/** Emit the persistent post-recovery notice. Includes the concise crash cause
-	 * when known and offers Retry only when a last prompt was retained (survives
-	 * the in-place restart), reusing the existing `retry()` path. */
-	private emitRecovery(cause?: string): void {
+	/** Emit the persistent post-recovery notice. When a reply was mid-stream at
+	 * crash time (`interrupted`), it says the last reply was lost and offers Retry
+	 * (only when a last prompt was retained, reusing the existing `retry()` path).
+	 * When the crash was idle (a completed turn already persisted), it says only
+	 * that the session recovered — no false "not saved" claim and no Retry that
+	 * would resend an already-answered prompt. */
+	private emitRecovery(cause?: string, interrupted = false): void {
 		this.handleEvent({
 			type: "host_recovery",
-			message: RECOVERED_MESSAGE,
+			message: interrupted ? RECOVERED_MESSAGE_INTERRUPTED : RECOVERED_MESSAGE_IDLE,
 			cause,
-			canRetry: this.lastPrompt != null,
+			canRetry: interrupted && this.lastPrompt != null,
 		});
 	}
 

--- a/packages/vscode/src/host/session-controller.ts
+++ b/packages/vscode/src/host/session-controller.ts
@@ -230,6 +230,54 @@ function formatExit(info: { code?: number | null; signal?: string | null; error?
 	return `dreb process exited (code ${info?.code ?? "null"}, signal ${info?.signal ?? "null"})`;
 }
 
+/** Max length of the concise crash cause surfaced to the user (keeps the recovery
+ * notice a single readable line, never a stack-trace dump). */
+const CRASH_CAUSE_MAX_LEN = 200;
+
+function truncateCause(text: string): string {
+	const trimmed = text.trim();
+	return trimmed.length > CRASH_CAUSE_MAX_LEN ? `${trimmed.slice(0, CRASH_CAUSE_MAX_LEN - 1)}…` : trimmed;
+}
+
+/**
+ * Derive a concise, human-readable crash cause from the child's exit info for the
+ * post-recovery notice. Prefers a captured spawn error, then known fatal stderr
+ * signatures, then the first meaningful (non-stack-frame) stderr line, then the
+ * exit code/signal. Returns `undefined` when nothing informative is available so
+ * the notice renders cleanly without a cause. Never emits multi-line output or
+ * raw stack traces.
+ */
+export function extractCrashCause(info: {
+	code?: number | null;
+	signal?: string | null;
+	error?: Error;
+	stderr?: string;
+}): string | undefined {
+	if (info.error?.message) return truncateCause(info.error.message);
+
+	const stderr = info.stderr?.trim();
+	if (stderr) {
+		const lines = stderr
+			.split("\n")
+			.map((l) => l.trim())
+			.filter(Boolean);
+		// Known fatal signatures → friendly, actionable phrasing.
+		if (lines.some((l) => l.includes("stdout write queue exceeded"))) {
+			return "output overflow — the reply was too large for the connection buffer";
+		}
+		const uncaught = lines.find((l) => l.includes("Uncaught exception (fatal"));
+		if (uncaught) return truncateCause(uncaught.replace(/^\[rpc\]\s*/, ""));
+		// Otherwise the first line that isn't a stack frame — usually the error message.
+		const meaningful = lines.find((l) => !/^at\s/.test(l));
+		if (meaningful) return truncateCause(meaningful);
+	}
+
+	if (info.code != null || info.signal) {
+		return `process exited (code ${info.code ?? "null"}${info.signal ? `, signal ${info.signal}` : ""})`;
+	}
+	return undefined;
+}
+
 /** Recovery policy tuning (deliverable C, issue 53). Bounded auto-restart so a
  * transient crash self-heals but a crash-loop (dead pipe / deterministic
  * startup failure) degrades to a banner instead of spinning forever. */
@@ -240,6 +288,11 @@ const RESTART_BACKOFF_MS = 500;
  * a *later* isolated crash still gets a fresh recovery budget. */
 const RESTART_STABLE_MS = 10_000;
 const RECOVERING_NOTICE = "dreb stopped unexpectedly — recovering…";
+/** Shown once after a successful auto-recovery from an unexpected crash: the
+ * transcript was rebuilt from disk but the in-flight reply was not saved, so the
+ * session is now idle. */
+const RECOVERED_MESSAGE =
+	"Session recovered after an unexpected exit. The last reply was interrupted and not saved — the session is idle.";
 
 function errorText(err: unknown): string {
 	return err instanceof Error ? err.message : String(err);
@@ -1411,8 +1464,9 @@ export class SessionController {
 		// a leftover handler can't fire against the old process.
 		this.teardownClient();
 		// Automated in-place recovery (deliverable C): auto-restart from the
-		// persisted transcript, bounded by a crash-loop budget.
-		this.beginRecovery(message);
+		// persisted transcript, bounded by a crash-loop budget. Carry a concise,
+		// user-facing cause so the post-recovery notice can explain what happened.
+		this.beginRecovery(message, extractCrashCause(info));
 	}
 
 	/** Tear down the current client's subscriptions and drop the reference. The
@@ -1429,8 +1483,10 @@ export class SessionController {
 	}
 
 	/** Decide whether to auto-restart the crashed child (bounded) or give up with
-	 * a persistent banner. Called on an unexpected exit and on a failed restart. */
-	private beginRecovery(reason: string): void {
+	 * a persistent banner. Called on an unexpected exit and on a failed restart.
+	 * `cause` is a concise, user-facing reason (from the child's exit info) carried
+	 * through to the post-recovery notice. */
+	private beginRecovery(reason: string, cause?: string): void {
 		if (this.disposed) return;
 		if (!this.withinRestartBudget()) {
 			this.giveUpRecovery(reason);
@@ -1445,7 +1501,7 @@ export class SessionController {
 		this.clearRestartTimer();
 		this.restartTimer = setTimeout(() => {
 			this.restartTimer = undefined;
-			void this.restart(reason);
+			void this.restart(reason, cause);
 		}, RESTART_BACKOFF_MS);
 		this.restartTimer.unref?.();
 	}
@@ -1453,7 +1509,7 @@ export class SessionController {
 	/** Auto-restart the RPC child in place, resuming from the live session file so
 	 * the persisted transcript is reloaded losslessly. All controller-lifetime
 	 * listeners and the connected webview bridge stay attached. */
-	private async restart(reason: string): Promise<void> {
+	private async restart(reason: string, cause?: string): Promise<void> {
 		if (this.disposed) return;
 		// Resume from the live session file (falls back to the original resume
 		// path for a session that never wrote an entry before crashing).
@@ -1463,13 +1519,32 @@ export class SessionController {
 		} catch {
 			// start() already surfaced its own failure status; route the failed
 			// attempt back through the bounded policy (retry or give up).
-			this.beginRecovery(reason);
+			this.beginRecovery(reason, cause);
 			return;
 		}
-		// Connected again. Arm a stable-run reset so a child that survives long
-		// enough clears the crash budget and a *later* isolated crash still gets a
-		// fresh recovery allowance.
+		// Connected again. Tell the user the session was rebuilt from disk but the
+		// in-flight reply was lost and it's now idle (with the cause when known),
+		// and offer a one-click Retry. Emitted here — after start()'s transcript
+		// rebuild (which clears items) — so the notice appends below the restored
+		// conversation. This is strictly the crash path; a clean initial open/reopen
+		// never goes through restart(), so those are unaffected.
+		this.emitRecovery(cause);
+		// Arm a stable-run reset so a child that survives long enough clears the
+		// crash budget and a *later* isolated crash still gets a fresh recovery
+		// allowance.
 		this.armStableRunReset();
+	}
+
+	/** Emit the persistent post-recovery notice. Includes the concise crash cause
+	 * when known and offers Retry only when a last prompt was retained (survives
+	 * the in-place restart), reusing the existing `retry()` path. */
+	private emitRecovery(cause?: string): void {
+		this.handleEvent({
+			type: "host_recovery",
+			message: RECOVERED_MESSAGE,
+			cause,
+			canRetry: this.lastPrompt != null,
+		});
 	}
 
 	/** Terminal recovery state: repeated crashes within the window. Surface a

--- a/packages/vscode/src/shared/projection.ts
+++ b/packages/vscode/src/shared/projection.ts
@@ -59,7 +59,17 @@ export interface SystemItem {
 	text: string;
 }
 
-export type TranscriptItem = UserItem | ResponseGroup | SystemItem;
+/** Host-emitted notice shown after the RPC child crashed and was auto-recovered:
+ * the transcript was rebuilt but the in-flight reply was lost, so the session is
+ * idle. `canRetry` is true when the host retained a last prompt that can be
+ * resent via the existing `{ type: "retry" }` path. */
+export interface RecoveryItem {
+	kind: "recovery";
+	text: string;
+	canRetry: boolean;
+}
+
+export type TranscriptItem = UserItem | ResponseGroup | SystemItem | RecoveryItem;
 
 /** The agent's end-of-turn next-step suggestion (`suggest_next` tool). Mirrors
  * the TUI's ghost-text affordance: a single command the user most likely wants
@@ -497,6 +507,18 @@ export function applyEvent(state: TranscriptState, event: any): void {
 			// Synthetic event for host-side output that should persist in the
 			// transcript (e.g. `/session` stats), not a transient status line.
 			state.items.push({ kind: "system", text: String(event.text ?? "") });
+			break;
+		}
+		case "host_recovery": {
+			// Synthetic event emitted by the SessionController after a successful
+			// auto-recovery from an unexpected RPC child crash. Persistent transcript
+			// item: the conversation was rebuilt from disk but the in-flight reply was
+			// never persisted, so it's gone and the session is now idle. `canRetry`
+			// gates the one-click Retry (resends the retained last prompt).
+			const message = String(event.message ?? "");
+			const cause = typeof event.cause === "string" && event.cause.trim() ? event.cause.trim() : undefined;
+			const text = cause ? `${message} Cause: ${cause}.` : message;
+			state.items.push({ kind: "recovery", text, canRetry: event.canRetry === true });
 			break;
 		}
 		default:

--- a/packages/vscode/src/shared/projection.ts
+++ b/packages/vscode/src/shared/projection.ts
@@ -516,8 +516,8 @@ export function applyEvent(state: TranscriptState, event: any): void {
 			// never persisted, so it's gone and the session is now idle. `canRetry`
 			// gates the one-click Retry (resends the retained last prompt).
 			const message = String(event.message ?? "");
-			const cause = typeof event.cause === "string" && event.cause.trim() ? event.cause.trim() : undefined;
-			const text = cause ? `${message} Cause: ${cause}.` : message;
+			const trimmedCause = typeof event.cause === "string" ? event.cause.trim() : "";
+			const text = trimmedCause ? `${message} Cause: ${trimmedCause}.` : message;
 			state.items.push({ kind: "recovery", text, canRetry: event.canRetry === true });
 			break;
 		}

--- a/packages/vscode/src/webview/app.tsx
+++ b/packages/vscode/src/webview/app.tsx
@@ -265,6 +265,20 @@ export function App() {
 								<div class="dreb-user">{item.text}</div>
 							) : item.kind === "system" ? (
 								<pre class="dreb-system">{item.text}</pre>
+							) : item.kind === "recovery" ? (
+								<div class="dreb-banner error">
+									<span class="dreb-banner-text">{item.text}</span>
+									<Show when={item.canRetry}>
+										<button
+											type="button"
+											class="dreb-retry-btn"
+											title="Resend the last message"
+											onClick={() => postToHost({ type: "retry" })}
+										>
+											↻ Retry
+										</button>
+									</Show>
+								</div>
 							) : (
 								<>
 									<ResponseView

--- a/packages/vscode/src/webview/app.tsx
+++ b/packages/vscode/src/webview/app.tsx
@@ -266,19 +266,10 @@ export function App() {
 							) : item.kind === "system" ? (
 								<pre class="dreb-system">{item.text}</pre>
 							) : item.kind === "recovery" ? (
-								<div class="dreb-banner error">
-									<span class="dreb-banner-text">{item.text}</span>
-									<Show when={item.canRetry}>
-										<button
-											type="button"
-											class="dreb-retry-btn"
-											title="Resend the last message"
-											onClick={() => postToHost({ type: "retry" })}
-										>
-											↻ Retry
-										</button>
-									</Show>
-								</div>
+								<RetryBanner
+									text={item.text}
+									onRetry={item.canRetry ? () => postToHost({ type: "retry" }) : undefined}
+								/>
 							) : (
 								<>
 									<ResponseView
@@ -451,19 +442,29 @@ export function ResponseView(props: { group: ResponseGroup; onRetry?: () => void
 				/>
 			</Show>
 			<Show when={props.group.error}>
-				<div class="dreb-banner error">
-					<span class="dreb-banner-text">{props.group.error}</span>
-					<Show when={props.onRetry}>
-						<button
-							type="button"
-							class="dreb-retry-btn"
-							title="Resend the last message"
-							onClick={() => props.onRetry?.()}
-						>
-							↻ Retry
-						</button>
-					</Show>
-				</div>
+				<RetryBanner text={props.group.error ?? ""} onRetry={props.onRetry} />
+			</Show>
+		</div>
+	);
+}
+
+/** Error/notice banner with an optional one-click Retry, reused by the response
+ * error group and the crash-recovery item. Retry is shown only when `onRetry` is
+ * provided; the callback's origin (host retry vs. `postToHost`) is the caller's
+ * concern. */
+export function RetryBanner(props: { text: string; onRetry?: () => void }) {
+	return (
+		<div class="dreb-banner error">
+			<span class="dreb-banner-text">{props.text}</span>
+			<Show when={props.onRetry}>
+				<button
+					type="button"
+					class="dreb-retry-btn"
+					title="Resend the last message"
+					onClick={() => props.onRetry?.()}
+				>
+					↻ Retry
+				</button>
 			</Show>
 		</div>
 	);

--- a/packages/vscode/test/app-retry.test.tsx
+++ b/packages/vscode/test/app-retry.test.tsx
@@ -19,7 +19,7 @@ vi.mock("../src/webview/vscode-api.js", () => ({
 	postToHost: () => {},
 }));
 
-import { ResponseView } from "../src/webview/app.js";
+import { ResponseView, RetryBanner } from "../src/webview/app.js";
 
 const erroredGroup = (): ResponseGroup => ({
 	kind: "response",
@@ -71,6 +71,43 @@ describe("ResponseView retry control", () => {
 		const clean: ResponseGroup = { ...erroredGroup(), error: undefined, answer: "all done" };
 		const host = mount(clean, () => {});
 		expect(host.querySelector(".dreb-banner.error")).toBeNull();
+		expect(host.querySelector("button.dreb-retry-btn")).toBeNull();
+	});
+});
+
+/**
+ * `RetryBanner` is the shared primitive rendered by the crash-recovery transcript
+ * item (`item.kind === "recovery"`) and the response error group. These tests pin
+ * the recovery notice's glue directly: the message text renders, and the Retry
+ * button appears (and fires) only when `onRetry` is supplied — which the app wires
+ * to `item.canRetry`. A wrong `Show` guard, class rename, or missing handler would
+ * fail here, so a broken/missing recovery notice can't ship silently.
+ */
+describe("RetryBanner (crash-recovery notice)", () => {
+	function mountBanner(text: string, onRetry?: () => void): HTMLElement {
+		const host = document.createElement("div");
+		document.body.appendChild(host);
+		dispose = render(() => <RetryBanner text={text} onRetry={onRetry} />, host);
+		return host;
+	}
+
+	it("renders the recovery text and a Retry button when retryable", () => {
+		const host = mountBanner("Session recovered — last reply not saved. Cause: output overflow.", () => {});
+		expect(host.querySelector(".dreb-banner.error")?.textContent).toContain("Session recovered");
+		expect(host.querySelector(".dreb-banner.error")?.textContent).toContain("Cause: output overflow");
+		expect(host.querySelector("button.dreb-retry-btn")).not.toBeNull();
+	});
+
+	it("calls onRetry when the Retry button is clicked", () => {
+		const onRetry = vi.fn();
+		const host = mountBanner("Session recovered.", onRetry);
+		(host.querySelector("button.dreb-retry-btn") as HTMLButtonElement).click();
+		expect(onRetry).toHaveBeenCalledTimes(1);
+	});
+
+	it("renders the text but no Retry button when not retryable", () => {
+		const host = mountBanner("Session recovered after an unexpected exit. The session is idle.");
+		expect(host.querySelector(".dreb-banner.error")?.textContent).toContain("session is idle");
 		expect(host.querySelector("button.dreb-retry-btn")).toBeNull();
 	});
 });

--- a/packages/vscode/test/projection.test.ts
+++ b/packages/vscode/test/projection.test.ts
@@ -190,6 +190,37 @@ describe("projection", () => {
 		expect(system.kind === "system" && system.text).toContain("Session stats");
 	});
 
+	it("appends a host_recovery item with the cause folded into the text", () => {
+		const state = run([
+			{ type: "message_start", message: { role: "user", content: "?" } },
+			{
+				type: "host_recovery",
+				message: "Session recovered after an unexpected exit. The last reply was not saved — the session is idle.",
+				cause: "output overflow — the reply was too large for the connection buffer",
+				canRetry: true,
+			},
+		]);
+		expect(state.items.map((i) => i.kind)).toEqual(["user", "recovery"]);
+		const recovery = state.items[1];
+		expect(recovery.kind).toBe("recovery");
+		if (recovery.kind === "recovery") {
+			expect(recovery.text).toContain("Session recovered");
+			expect(recovery.text).toContain("Cause: output overflow");
+			expect(recovery.canRetry).toBe(true);
+		}
+	});
+
+	it("renders a host_recovery item without a cause and defaults canRetry to false", () => {
+		const state = run([{ type: "host_recovery", message: "Session recovered — the session is idle." }]);
+		const recovery = state.items[0];
+		expect(recovery.kind).toBe("recovery");
+		if (recovery.kind === "recovery") {
+			expect(recovery.text).toBe("Session recovered — the session is idle.");
+			expect(recovery.text).not.toContain("Cause:");
+			expect(recovery.canRetry).toBe(false);
+		}
+	});
+
 	it("groups sequential agent runs into distinct responses", () => {
 		const state = run([
 			{ type: "agent_start" },

--- a/packages/vscode/test/session-controller.test.ts
+++ b/packages/vscode/test/session-controller.test.ts
@@ -2555,6 +2555,8 @@ describe("SessionController — auto-restart on crash", () => {
 		const { controller, clients } = await setup();
 		const recoveries = collectRecoveries(controller);
 
+		// A reply is mid-stream when the child dies.
+		clients[0].emit({ type: "agent_start" });
 		clients[0].emitExit({
 			code: 1,
 			signal: null,
@@ -2566,7 +2568,7 @@ describe("SessionController — auto-restart on crash", () => {
 		expect(recoveries()).toHaveLength(1);
 		const r = recoveries()[0];
 		expect(r.message).toMatch(/recovered/i);
-		expect(r.message).toMatch(/not saved|idle/i);
+		expect(r.message).toMatch(/not saved/i); // interrupted mid-stream
 		expect(r.cause).toContain("Uncaught exception (fatal");
 	});
 
@@ -2582,23 +2584,49 @@ describe("SessionController — auto-restart on crash", () => {
 		expect(recoveries()[0].message).toMatch(/recovered/i);
 	});
 
-	it("offers Retry only when a prompt was retained before the crash", async () => {
+	it("offers Retry and a 'not saved' notice only when a reply was mid-stream at crash time", async () => {
 		const { controller, clients } = await setup();
 		const recoveries = collectRecoveries(controller);
 
-		// No prompt sent yet → canRetry false.
+		// Prompt sent and a reply streaming when the child dies → interrupted:
+		// 'not saved' wording + Retry (the retained prompt was never answered).
+		await controller.submit("hello");
+		clients[0].emit({ type: "agent_start" });
 		clients[0].emitExit({ code: 1, signal: null });
 		await vi.advanceTimersByTimeAsync(600);
-		expect(recoveries()[0].canRetry).toBe(false);
+		expect(recoveries()).toHaveLength(1);
+		expect(recoveries()[0].canRetry).toBe(true);
+		expect(recoveries()[0].message).toMatch(/not saved/i);
+	});
 
-		// Send a prompt on the recovered child (retained as the retry target), reset
-		// the budget with a stable run, then crash again → canRetry true.
+	it("does not claim loss or offer Retry when the crash is idle after a completed turn", async () => {
+		const { controller, clients } = await setup();
+		const recoveries = collectRecoveries(controller);
+
+		// A turn completes and is persisted, then the child dies while idle. The
+		// last reply is in the rebuilt transcript, so the notice must not claim it
+		// was lost, and Retry (which would resend an already-answered prompt) is
+		// suppressed.
 		await controller.submit("hello");
-		clients[1].emit({ type: "agent_end", messages: [] });
-		clients[1].emitExit({ code: 1, signal: null });
+		clients[0].emit({ type: "agent_start" });
+		clients[0].emit({ type: "agent_end", messages: [] });
+		clients[0].emitExit({ code: 1, signal: null });
 		await vi.advanceTimersByTimeAsync(600);
-		expect(recoveries()).toHaveLength(2);
-		expect(recoveries()[1].canRetry).toBe(true);
+		expect(recoveries()).toHaveLength(1);
+		expect(recoveries()[0].canRetry).toBe(false);
+		expect(recoveries()[0].message).not.toMatch(/not saved/i);
+		expect(recoveries()[0].message).toMatch(/recovered/i);
+	});
+
+	it("suppresses Retry when nothing was ever submitted before the crash", async () => {
+		const { controller, clients } = await setup();
+		const recoveries = collectRecoveries(controller);
+
+		clients[0].emit({ type: "agent_start" });
+		clients[0].emitExit({ code: 1, signal: null });
+		await vi.advanceTimersByTimeAsync(600);
+		// Mid-stream (interrupted) but no retained prompt → Retry absent.
+		expect(recoveries()[0].canRetry).toBe(false);
 	});
 
 	it("does not emit a recovery notice on the initial clean start", async () => {

--- a/packages/vscode/test/session-controller.test.ts
+++ b/packages/vscode/test/session-controller.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { HostUi, HostUiPickItem, WorkspaceSearchResult } from "../src/host/host-ui.js";
-import { type ControllerUpdate, type RpcClientLike, SessionController } from "../src/host/session-controller.js";
+import {
+	type ControllerUpdate,
+	extractCrashCause,
+	type RpcClientLike,
+	SessionController,
+} from "../src/host/session-controller.js";
 import type { SourceLinkUi } from "../src/host/source-link-ui.js";
 import type { OpenSourceRef, SessionTreeNodeDto } from "../src/shared/protocol.js";
 
@@ -351,6 +356,23 @@ function collectNotices(controller: SessionController): () => string[] {
 		}
 	});
 	return () => notices;
+}
+
+/** Collect `host_recovery` events (post-crash-recovery notices) from the update
+ * stream. Returns an accessor for the events captured so far. */
+function collectRecoveries(
+	controller: SessionController,
+): () => Array<{ message?: string; cause?: string; canRetry?: boolean }> {
+	const recoveries: Array<{ message?: string; cause?: string; canRetry?: boolean }> = [];
+	controller.onUpdate((u) => {
+		if (u.kind === "event") {
+			const event = u.event as { type?: string; message?: string; cause?: string; canRetry?: boolean };
+			if (event?.type === "host_recovery") {
+				recoveries.push({ message: event.message, cause: event.cause, canRetry: event.canRetry });
+			}
+		}
+	});
+	return () => recoveries;
 }
 
 describe("SessionController", () => {
@@ -2527,5 +2549,138 @@ describe("SessionController — auto-restart on crash", () => {
 
 		// Should eventually give up.
 		expect(controller.hasFailed()).toBe(true);
+	});
+
+	it("emits a recovery notice with the cause after a successful restart", async () => {
+		const { controller, clients } = await setup();
+		const recoveries = collectRecoveries(controller);
+
+		clients[0].emitExit({
+			code: 1,
+			signal: null,
+			stderr: "[rpc] Uncaught exception (fatal — exiting for supervised restart): boom",
+		});
+		await vi.advanceTimersByTimeAsync(600);
+
+		expect(clients).toHaveLength(2);
+		expect(recoveries()).toHaveLength(1);
+		const r = recoveries()[0];
+		expect(r.message).toMatch(/recovered/i);
+		expect(r.message).toMatch(/not saved|idle/i);
+		expect(r.cause).toContain("Uncaught exception (fatal");
+	});
+
+	it("omits the cause when the exit info carries none", async () => {
+		const { controller, clients } = await setup();
+		const recoveries = collectRecoveries(controller);
+
+		clients[0].emitExit({}); // no code/signal/stderr/error
+		await vi.advanceTimersByTimeAsync(600);
+
+		expect(recoveries()).toHaveLength(1);
+		expect(recoveries()[0].cause).toBeUndefined();
+		expect(recoveries()[0].message).toMatch(/recovered/i);
+	});
+
+	it("offers Retry only when a prompt was retained before the crash", async () => {
+		const { controller, clients } = await setup();
+		const recoveries = collectRecoveries(controller);
+
+		// No prompt sent yet → canRetry false.
+		clients[0].emitExit({ code: 1, signal: null });
+		await vi.advanceTimersByTimeAsync(600);
+		expect(recoveries()[0].canRetry).toBe(false);
+
+		// Send a prompt on the recovered child (retained as the retry target), reset
+		// the budget with a stable run, then crash again → canRetry true.
+		await controller.submit("hello");
+		clients[1].emit({ type: "agent_end", messages: [] });
+		clients[1].emitExit({ code: 1, signal: null });
+		await vi.advanceTimersByTimeAsync(600);
+		expect(recoveries()).toHaveLength(2);
+		expect(recoveries()[1].canRetry).toBe(true);
+	});
+
+	it("does not emit a recovery notice on the initial clean start", async () => {
+		const clients: FakeClient[] = [];
+		const factory = () => {
+			const c = new FakeClient();
+			c.state = { sessionFile: "/sessions/live.jsonl" };
+			clients.push(c);
+			return c;
+		};
+		const controller = new SessionController({
+			cwd: "/tmp/project",
+			cliPath: "/cli.js",
+			clientFactory: factory,
+			sessionPath: "/sessions/original.jsonl",
+		});
+		const recoveries = collectRecoveries(controller);
+		await controller.start();
+		expect(recoveries()).toHaveLength(0);
+	});
+
+	it("gives up after budget exhaustion without a recovery notice (fatal banner only)", async () => {
+		const { controller, clients } = await setup();
+		const recoveries = collectRecoveries(controller);
+
+		// 3 successful restarts (each emits a recovery notice)…
+		for (let i = 0; i < 3; i++) {
+			clients[i].emitExit({ code: 1, signal: null });
+			await vi.advanceTimersByTimeAsync(600);
+		}
+		// …then the 4th crash exhausts the budget and gives up (no notice).
+		clients[3].emitExit({ code: 1, signal: null });
+		await vi.advanceTimersByTimeAsync(600);
+
+		expect(controller.hasFailed()).toBe(true);
+		expect(recoveries()).toHaveLength(3);
+		expect(controller.getStatus().error).toMatch(/recovery failed after repeated crashes/i);
+	});
+});
+
+describe("extractCrashCause", () => {
+	it("prefers a captured spawn error message", () => {
+		expect(extractCrashCause({ error: new Error("spawn node ENOENT") })).toBe("spawn node ENOENT");
+	});
+
+	it("maps the stdout-backpressure overflow signature to friendly text", () => {
+		const cause = extractCrashCause({
+			code: 1,
+			stderr: "Fatal: stdout write queue exceeded 16777216 bytes while the stream was backpressured.\n",
+		});
+		expect(cause).toBe("output overflow — the reply was too large for the connection buffer");
+	});
+
+	it("surfaces the uncaught-exception fatal line without the [rpc] prefix or stack", () => {
+		const cause = extractCrashCause({
+			code: 1,
+			stderr: "[rpc] Uncaught exception (fatal — exiting for supervised restart): boom\n    at foo (x.js:1:1)",
+		});
+		expect(cause).toBe("Uncaught exception (fatal — exiting for supervised restart): boom");
+	});
+
+	it("falls back to the first non-stack-frame stderr line", () => {
+		const cause = extractCrashCause({
+			code: 1,
+			stderr: "TypeError: x is not a function\n    at a (b.js:2:3)\n    at c (d.js:4:5)",
+		});
+		expect(cause).toBe("TypeError: x is not a function");
+	});
+
+	it("falls back to code/signal when there is no stderr", () => {
+		expect(extractCrashCause({ code: 1, signal: "SIGTERM" })).toBe("process exited (code 1, signal SIGTERM)");
+	});
+
+	it("returns undefined when nothing informative is available", () => {
+		expect(extractCrashCause({ code: null, signal: null })).toBeUndefined();
+		expect(extractCrashCause({})).toBeUndefined();
+	});
+
+	it("truncates an overlong cause to a single readable line", () => {
+		const cause = extractCrashCause({ error: new Error("E".repeat(500)) });
+		expect(cause).toBeDefined();
+		expect(cause?.length).toBeLessThanOrEqual(200);
+		expect(cause?.endsWith("…")).toBe(true);
 	});
 });


### PR DESCRIPTION
Closes #86

Crash-recovery UX for the VSCode extension: when the RPC child dies unexpectedly and is auto-recovered, tell the user the session was rebuilt but is idle, include the failure cause when known, and offer a one-click Retry (reusing the existing `retry()` path). No automatic retry is added.

Base branch: `vscode` (VSCode extension epic #12).

Implementation plan posted as a comment below.
