### PR TITLE
Fix VSCode RPC child killed mid-reply by unprojected quadratic message_update stream

### DIFF
--- a/packages/coding-agent/src/core/system-prompt.ts
+++ b/packages/coding-agent/src/core/system-prompt.ts
@@ -133,6 +133,8 @@ const UI_DESCRIPTIONS: Record<string, string> = {
 	telegram:
 		"Telegram (mobile messaging app — the user is on their phone so messages may be shorter or have typos, but this doesn't reflect less thought or intent. The user sees tool names and arguments but not tool output/results, so summarize key findings or changes when relevant)",
 	rpc: "RPC (programmatic interface — another application is consuming your output)",
+	vscode:
+		"VS Code extension (a chat panel inside the VS Code editor — the user is coding alongside you in the same workspace)",
 	cli: "CLI (non-interactive command line — output will be printed and the process exits)",
 	agent: "Subagent (running as a child agent — focus on the task, report results concisely)",
 };

--- a/packages/coding-agent/src/modes/rpc/index.ts
+++ b/packages/coding-agent/src/modes/rpc/index.ts
@@ -7,6 +7,15 @@
 
 export type { ModelInfo, RpcClientOptions, RpcEventListener, RpcExitInfo, RpcExitListener } from "./rpc-client.js";
 export { RpcClient } from "./rpc-client.js";
+// Projection gate + canonical uiType constants, so RPC consumers (e.g. the
+// VSCode host) reference one source of truth for the "vscode" opt-in string
+// rather than re-typing a literal that could silently drift (issue 84).
+export {
+	DASHBOARD_UI_TYPE,
+	PROJECTED_UI_TYPES,
+	shouldProjectRpcEvents,
+	VSCODE_UI_TYPE,
+} from "./rpc-event-projection.js";
 export type {
 	RpcAgentTypeInfo,
 	RpcBackgroundAgentInfo,

--- a/packages/coding-agent/src/modes/rpc/rpc-event-projection.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-event-projection.ts
@@ -1,22 +1,44 @@
 /**
- * Dashboard-mode RPC event projection.
+ * RPC event projection for consumers that don't read the cumulative fields.
  *
  * `message_update` events carry two cumulative copies of the growing assistant
  * message: the top-level `message` field and `assistantMessageEvent.partial`.
  * Serializing both for every token makes the child->parent JSONL pipe quadratic
  * in response length and floods the stdout queue (see issue 448).
  *
- * The dashboard never reads those fields: its browser reducer consumes only
- * the delta fields (`delta`, `content`, `toolCall`, `contentIndex`), and its
- * authoritative transcript comes from `message_end` plus `get_dashboard_snapshot`
- * RPC responses. The dashboard's own EventHub already strips the same fields at
- * the browser SSE boundary (projectDashboardEvent); this module applies the same
- * removal one boundary earlier, before JSONL serialization in runRpcMode.
+ * Consumers that rebuild the transcript from the delta fields (`delta`,
+ * `content`, `toolCall`, `contentIndex`) plus `message_end` never read those
+ * cumulative fields, so stripping them is lossless for them. This currently
+ * covers two consumers:
+ *   - the dashboard, whose browser reducer consumes only deltas and whose
+ *     authoritative transcript comes from `message_end` plus
+ *     `get_dashboard_snapshot` responses (its own EventHub already strips the
+ *     same fields at the browser SSE boundary via projectDashboardEvent);
+ *   - the VSCode extension, whose projection reducer likewise reads only the
+ *     `assistantMessageEvent` delta fields (see packages/vscode
+ *     src/shared/projection.ts). Without this bounding a long reply overruns
+ *     the child's 16 MiB stdout queue and kills it mid-reply before
+ *     `message_end` persists the reply (issue 84).
+ * This module applies the removal one boundary earlier than the dashboard's
+ * EventHub — before JSONL serialization in runRpcMode.
+ *
+ * Generic RPC consumers (`uiType === "rpc"`) may still rely on the cumulative
+ * fields and are left untouched; see `shouldProjectRpcEvents`.
  *
  * Only the quadratic `message_update` fields are removed here. Broader bounding
  * (agent_end messages, tool_execution_update args, retry discardedPartial,
  * images) remains the EventHub's browser-facing concern.
  */
+
+/**
+ * uiTypes whose consumers rebuild the transcript from delta fields + message_end
+ * and therefore never read the cumulative `message`/`partial` fields. Their RPC
+ * event stream is projected (bounded) before serialization. Generic RPC
+ * consumers (`"rpc"`) are intentionally excluded so their protocol is unchanged.
+ */
+export function shouldProjectRpcEvents(uiType: string | undefined): boolean {
+	return uiType === "dashboard" || uiType === "vscode";
+}
 
 function omit(event: Record<string, unknown>, ...keys: string[]): Record<string, unknown> {
 	const copy = { ...event };

--- a/packages/coding-agent/src/modes/rpc/rpc-event-projection.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-event-projection.ts
@@ -31,13 +31,32 @@
  */
 
 /**
+ * The canonical `uiType` string the VSCode extension must pass (`--ui vscode`)
+ * to opt into projection. Exported so the VSCode host and any test can reference
+ * the single source of truth instead of re-typing the literal — a mismatch is
+ * then a caught drift, not a silent revert to the O(n^2) stream (issue 84).
+ */
+export const VSCODE_UI_TYPE = "vscode";
+
+/** The dashboard `uiType` that has always opted into projection (issue 448). */
+export const DASHBOARD_UI_TYPE = "dashboard";
+
+/**
  * uiTypes whose consumers rebuild the transcript from delta fields + message_end
  * and therefore never read the cumulative `message`/`partial` fields. Their RPC
  * event stream is projected (bounded) before serialization. Generic RPC
  * consumers (`"rpc"`) are intentionally excluded so their protocol is unchanged.
  */
+export const PROJECTED_UI_TYPES: ReadonlySet<string> = new Set([DASHBOARD_UI_TYPE, VSCODE_UI_TYPE]);
+
+/**
+ * Whether the given `uiType` consumer should receive the bounded (projected)
+ * event stream. Input is trimmed so a stray surrounding space in a `--ui` value
+ * cannot silently fall through to the unprojected O(n^2) stream and reintroduce
+ * the mid-reply crash (issue 84).
+ */
 export function shouldProjectRpcEvents(uiType: string | undefined): boolean {
-	return uiType === "dashboard" || uiType === "vscode";
+	return uiType !== undefined && PROJECTED_UI_TYPES.has(uiType.trim());
 }
 
 function omit(event: Record<string, unknown>, ...keys: string[]): Record<string, unknown> {
@@ -48,6 +67,44 @@ function omit(event: Record<string, unknown>, ...keys: string[]): Record<string,
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * A projected `message_update` frame carries only delta-sized data, so it should
+ * stay small regardless of reply length. This ceiling is deliberately generous
+ * (far above any legitimate single delta or tool-arg chunk) so it never fires on
+ * normal traffic — it only trips if a future protocol change smuggles a
+ * cumulative, reply-length-scaled field past projection (issue 84).
+ */
+export const PROJECTED_FRAME_WARN_BYTES = 256 * 1024; // 256 KiB
+
+let warnedOversizedFrame = false;
+
+/** Reset the one-shot oversized-frame warning latch (tests only). */
+export function resetProjectedFrameWarning(): void {
+	warnedOversizedFrame = false;
+}
+
+/**
+ * Emit a one-time stderr warning if a projected `message_update` frame is larger
+ * than {@link PROJECTED_FRAME_WARN_BYTES}. Never writes to stdout (that carries
+ * the JSONL protocol). Non-`message_update` events are ignored. See the call
+ * site in `runRpcMode` for why this defense-in-depth guard exists.
+ */
+export function warnIfProjectedFrameOversized(event: Record<string, unknown>): void {
+	if (warnedOversizedFrame || event.type !== "message_update") return;
+	let bytes: number;
+	try {
+		bytes = Buffer.byteLength(JSON.stringify(event), "utf8");
+	} catch {
+		return; // Unserializable frame: leave it to the serializer's own handling.
+	}
+	if (bytes <= PROJECTED_FRAME_WARN_BYTES) return;
+	warnedOversizedFrame = true;
+	console.error(
+		`[rpc-projection] projected message_update frame is ${bytes} bytes (> ${PROJECTED_FRAME_WARN_BYTES}); ` +
+			"a cumulative field may be escaping projection and could reintroduce the quadratic stream (issue 84).",
+	);
 }
 
 /**

--- a/packages/coding-agent/src/modes/rpc/rpc-event-projection.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-event-projection.ts
@@ -86,19 +86,17 @@ export function resetProjectedFrameWarning(): void {
 }
 
 /**
- * Emit a one-time stderr warning if a projected `message_update` frame is larger
- * than {@link PROJECTED_FRAME_WARN_BYTES}. Never writes to stdout (that carries
- * the JSONL protocol). Non-`message_update` events are ignored. See the call
- * site in `runRpcMode` for why this defense-in-depth guard exists.
+ * Emit a one-time stderr warning if a projected `message_update` frame's
+ * already-serialized JSONL line exceeds {@link PROJECTED_FRAME_WARN_BYTES}.
+ * Takes the serialized line (produced once by the caller for the actual write)
+ * so this check adds no extra serialization on the streaming hot path. Never
+ * writes to stdout (that carries the JSONL protocol). Non-`message_update`
+ * events are ignored. See the call site in `runRpcMode` for why this
+ * defense-in-depth guard exists.
  */
-export function warnIfProjectedFrameOversized(event: Record<string, unknown>): void {
+export function warnIfProjectedFrameOversized(event: Record<string, unknown>, serialized: string): void {
 	if (warnedOversizedFrame || event.type !== "message_update") return;
-	let bytes: number;
-	try {
-		bytes = Buffer.byteLength(JSON.stringify(event), "utf8");
-	} catch {
-		return; // Unserializable frame: leave it to the serializer's own handling.
-	}
+	const bytes = Buffer.byteLength(serialized, "utf8");
 	if (bytes <= PROJECTED_FRAME_WARN_BYTES) return;
 	warnedOversizedFrame = true;
 	console.error(

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -59,7 +59,7 @@ import {
 import { type Theme, theme } from "../interactive/theme/theme.js";
 import { attachJsonlLineReader, serializeJsonLine } from "./jsonl.js";
 import { installRpcCrashGuards } from "./rpc-crash-guard.js";
-import { projectDashboardRpcEvent } from "./rpc-event-projection.js";
+import { projectDashboardRpcEvent, shouldProjectRpcEvents } from "./rpc-event-projection.js";
 import type {
 	RpcAgentTypeInfo,
 	RpcBackgroundAgentInfo,
@@ -1831,14 +1831,18 @@ export async function runRpcMode(session: AgentSession, modelFallbackMessage?: s
 				})
 			: undefined;
 
-	// Dashboard-launched runtimes (--ui dashboard) get message_update events
-	// projected before serialization: the cumulative `message` and
-	// `assistantMessageEvent.partial` fields are quadratic in response length on
-	// the JSONL pipe, and no dashboard consumer reads them (deltas, message_end,
-	// and get_dashboard_snapshot responses carry the authoritative data). Generic
-	// RPC consumers keep the full protocol unchanged. Only the event stream is
-	// projected — command responses (output() calls below) always stay complete.
-	const projectEvents = session.uiType === "dashboard";
+	// Runtimes whose consumers rebuild the transcript from delta fields plus
+	// message_end (dashboard via --ui dashboard, VSCode via --ui vscode) get
+	// message_update events projected before serialization: the cumulative
+	// `message` and `assistantMessageEvent.partial` fields are quadratic in
+	// response length on the JSONL pipe, and those consumers never read them
+	// (deltas, message_end, and get_dashboard_snapshot responses carry the
+	// authoritative data). For VSCode this bounding is what stops a long reply
+	// from overrunning the 16 MiB stdout queue and killing the child mid-reply
+	// (issue 84). Generic RPC consumers (uiType "rpc") keep the full protocol
+	// unchanged. Only the event stream is projected — command responses
+	// (output() calls below) always stay complete.
+	const projectEvents = shouldProjectRpcEvents(session.uiType);
 
 	// Output all agent events as JSON
 	session.subscribe((event) => {

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -1863,6 +1863,10 @@ export async function runRpcMode(session: AgentSession, modelFallbackMessage?: s
 		}
 		if (projectEvents) {
 			const projected = projectDashboardRpcEvent(event as unknown as Record<string, unknown>);
+			// Serialize once and reuse the line for both the size check and the
+			// actual write, so the defense-in-depth guard adds no extra
+			// serialization on the streaming hot path.
+			const line = serializeJsonLine(projected);
 			// Defense-in-depth (issue 84): projection strips a hardcoded set of
 			// cumulative fields. If a future protocol change adds a new cumulative
 			// field to message_update, projection would miss it and per-frame size
@@ -1870,8 +1874,8 @@ export async function runRpcMode(session: AgentSession, modelFallbackMessage?: s
 			// the quadratic stream that overruns the 16 MiB stdout queue. A single
 			// stderr warning (never stdout — that would corrupt the JSONL pipe)
 			// makes that regression observable instead of a silent crash.
-			warnIfProjectedFrameOversized(projected);
-			output(projected);
+			warnIfProjectedFrameOversized(projected, line);
+			writeRawStdout(line);
 		} else {
 			output(event);
 		}

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -59,7 +59,11 @@ import {
 import { type Theme, theme } from "../interactive/theme/theme.js";
 import { attachJsonlLineReader, serializeJsonLine } from "./jsonl.js";
 import { installRpcCrashGuards } from "./rpc-crash-guard.js";
-import { projectDashboardRpcEvent, shouldProjectRpcEvents } from "./rpc-event-projection.js";
+import {
+	projectDashboardRpcEvent,
+	shouldProjectRpcEvents,
+	warnIfProjectedFrameOversized,
+} from "./rpc-event-projection.js";
 import type {
 	RpcAgentTypeInfo,
 	RpcBackgroundAgentInfo,
@@ -1857,7 +1861,20 @@ export async function runRpcMode(session: AgentSession, modelFallbackMessage?: s
 				tabTitleGenerator.onMessageEnd(event.message);
 			}
 		}
-		output(projectEvents ? projectDashboardRpcEvent(event as unknown as Record<string, unknown>) : event);
+		if (projectEvents) {
+			const projected = projectDashboardRpcEvent(event as unknown as Record<string, unknown>);
+			// Defense-in-depth (issue 84): projection strips a hardcoded set of
+			// cumulative fields. If a future protocol change adds a new cumulative
+			// field to message_update, projection would miss it and per-frame size
+			// would start growing with reply length again — silently reintroducing
+			// the quadratic stream that overruns the 16 MiB stdout queue. A single
+			// stderr warning (never stdout — that would corrupt the JSONL pipe)
+			// makes that regression observable instead of a silent crash.
+			warnIfProjectedFrameOversized(projected);
+			output(projected);
+		} else {
+			output(event);
+		}
 	});
 
 	// Handle a single command

--- a/packages/coding-agent/test/rpc-event-projection.test.ts
+++ b/packages/coding-agent/test/rpc-event-projection.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { projectDashboardRpcEvent } from "../src/modes/rpc/rpc-event-projection.js";
+import { projectDashboardRpcEvent, shouldProjectRpcEvents } from "../src/modes/rpc/rpc-event-projection.js";
 
 function growingAssistantMessage(textLength: number) {
 	return {
@@ -143,5 +143,22 @@ describe("projectDashboardRpcEvent", () => {
 			const projected = projectDashboardRpcEvent(makeMessageUpdate(size));
 			expect(JSON.stringify(projected).length).toBeLessThan(300);
 		}
+	});
+});
+
+describe("shouldProjectRpcEvents", () => {
+	it("projects for consumers that only read delta fields", () => {
+		// Dashboard (issue 448) and VSCode (issue 84) rebuild the transcript from
+		// delta fields + message_end, so they get the bounded stream.
+		expect(shouldProjectRpcEvents("dashboard")).toBe(true);
+		expect(shouldProjectRpcEvents("vscode")).toBe(true);
+	});
+
+	it("leaves generic and unknown RPC consumers unprojected", () => {
+		// Generic RPC consumers may rely on the cumulative fields — never strip.
+		expect(shouldProjectRpcEvents("rpc")).toBe(false);
+		expect(shouldProjectRpcEvents("tui")).toBe(false);
+		expect(shouldProjectRpcEvents("cli")).toBe(false);
+		expect(shouldProjectRpcEvents(undefined)).toBe(false);
 	});
 });

--- a/packages/coding-agent/test/rpc-event-projection.test.ts
+++ b/packages/coding-agent/test/rpc-event-projection.test.ts
@@ -184,23 +184,57 @@ describe("warnIfProjectedFrameOversized", () => {
 		};
 	}
 
+	/** Serialize an event the way runRpcMode does before calling the guard. */
+	function line(event: Record<string, unknown>): string {
+		return JSON.stringify(event);
+	}
+
 	it("stays silent for normal delta-sized frames", () => {
 		resetProjectedFrameWarning();
 		const spy = vi.spyOn(console, "error").mockImplementation(() => {});
 		try {
-			warnIfProjectedFrameOversized(messageUpdate(100));
+			const event = messageUpdate(100);
+			warnIfProjectedFrameOversized(event, line(event));
 			expect(spy).not.toHaveBeenCalled();
 		} finally {
 			spy.mockRestore();
 		}
 	});
 
-	it("warns once (to stderr) when a projected frame exceeds the ceiling", () => {
+	it("stays silent exactly at the threshold and warns one byte over it", () => {
+		// Land the serialized length exactly on the ceiling, then one byte past it,
+		// to pin the `<=` boundary (guards against an off-by-one operator flip).
+		const base = line(messageUpdate(0)).length;
+		const atLimit = messageUpdate(PROJECTED_FRAME_WARN_BYTES - base);
+		expect(line(atLimit).length).toBe(PROJECTED_FRAME_WARN_BYTES);
+
+		resetProjectedFrameWarning();
+		let spy = vi.spyOn(console, "error").mockImplementation(() => {});
+		try {
+			warnIfProjectedFrameOversized(atLimit, line(atLimit));
+			expect(spy).not.toHaveBeenCalled();
+		} finally {
+			spy.mockRestore();
+		}
+
+		const overLimit = messageUpdate(PROJECTED_FRAME_WARN_BYTES - base + 1);
+		expect(line(overLimit).length).toBe(PROJECTED_FRAME_WARN_BYTES + 1);
+		resetProjectedFrameWarning();
+		spy = vi.spyOn(console, "error").mockImplementation(() => {});
+		try {
+			warnIfProjectedFrameOversized(overLimit, line(overLimit));
+			expect(spy).toHaveBeenCalledTimes(1);
+		} finally {
+			spy.mockRestore();
+		}
+	});
+
+	it("warns once (to stderr) and stays latched across many oversized frames", () => {
 		resetProjectedFrameWarning();
 		const spy = vi.spyOn(console, "error").mockImplementation(() => {});
 		try {
-			warnIfProjectedFrameOversized(messageUpdate(PROJECTED_FRAME_WARN_BYTES + 1_000));
-			warnIfProjectedFrameOversized(messageUpdate(PROJECTED_FRAME_WARN_BYTES + 1_000));
+			const event = messageUpdate(PROJECTED_FRAME_WARN_BYTES + 1_000);
+			for (let i = 0; i < 6; i++) warnIfProjectedFrameOversized(event, line(event));
 			expect(spy).toHaveBeenCalledTimes(1);
 			expect(String(spy.mock.calls[0]?.[0])).toContain("issue 84");
 		} finally {
@@ -212,10 +246,11 @@ describe("warnIfProjectedFrameOversized", () => {
 		resetProjectedFrameWarning();
 		const spy = vi.spyOn(console, "error").mockImplementation(() => {});
 		try {
-			warnIfProjectedFrameOversized({
+			const event = {
 				type: "message_end",
 				message: { text: "x".repeat(PROJECTED_FRAME_WARN_BYTES + 1_000) },
-			});
+			};
+			warnIfProjectedFrameOversized(event, line(event));
 			expect(spy).not.toHaveBeenCalled();
 		} finally {
 			spy.mockRestore();

--- a/packages/coding-agent/test/rpc-event-projection.test.ts
+++ b/packages/coding-agent/test/rpc-event-projection.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, it } from "vitest";
-import { projectDashboardRpcEvent, shouldProjectRpcEvents } from "../src/modes/rpc/rpc-event-projection.js";
+import { describe, expect, it, vi } from "vitest";
+import {
+	PROJECTED_FRAME_WARN_BYTES,
+	projectDashboardRpcEvent,
+	resetProjectedFrameWarning,
+	shouldProjectRpcEvents,
+	warnIfProjectedFrameOversized,
+} from "../src/modes/rpc/rpc-event-projection.js";
 
 function growingAssistantMessage(textLength: number) {
 	return {
@@ -160,5 +166,59 @@ describe("shouldProjectRpcEvents", () => {
 		expect(shouldProjectRpcEvents("tui")).toBe(false);
 		expect(shouldProjectRpcEvents("cli")).toBe(false);
 		expect(shouldProjectRpcEvents(undefined)).toBe(false);
+	});
+
+	it("tolerates surrounding whitespace so a stray-space --ui value still projects", () => {
+		// A trailing space in a --ui value must not silently fall through to the
+		// unprojected O(n^2) stream (issue 84).
+		expect(shouldProjectRpcEvents(" vscode ")).toBe(true);
+		expect(shouldProjectRpcEvents("dashboard ")).toBe(true);
+	});
+});
+
+describe("warnIfProjectedFrameOversized", () => {
+	function messageUpdate(textLength: number): Record<string, unknown> {
+		return {
+			type: "message_update",
+			assistantMessageEvent: { type: "text_delta", delta: "x".repeat(textLength) },
+		};
+	}
+
+	it("stays silent for normal delta-sized frames", () => {
+		resetProjectedFrameWarning();
+		const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+		try {
+			warnIfProjectedFrameOversized(messageUpdate(100));
+			expect(spy).not.toHaveBeenCalled();
+		} finally {
+			spy.mockRestore();
+		}
+	});
+
+	it("warns once (to stderr) when a projected frame exceeds the ceiling", () => {
+		resetProjectedFrameWarning();
+		const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+		try {
+			warnIfProjectedFrameOversized(messageUpdate(PROJECTED_FRAME_WARN_BYTES + 1_000));
+			warnIfProjectedFrameOversized(messageUpdate(PROJECTED_FRAME_WARN_BYTES + 1_000));
+			expect(spy).toHaveBeenCalledTimes(1);
+			expect(String(spy.mock.calls[0]?.[0])).toContain("issue 84");
+		} finally {
+			spy.mockRestore();
+		}
+	});
+
+	it("ignores non-message_update events", () => {
+		resetProjectedFrameWarning();
+		const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+		try {
+			warnIfProjectedFrameOversized({
+				type: "message_end",
+				message: { text: "x".repeat(PROJECTED_FRAME_WARN_BYTES + 1_000) },
+			});
+			expect(spy).not.toHaveBeenCalled();
+		} finally {
+			spy.mockRestore();
+		}
 	});
 });

--- a/packages/coding-agent/test/rpc-mode-dashboard-projection.test.ts
+++ b/packages/coding-agent/test/rpc-mode-dashboard-projection.test.ts
@@ -10,6 +10,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import * as outputGuard from "../src/core/output-guard.js";
 import * as jsonl from "../src/modes/rpc/jsonl.js";
+import * as projection from "../src/modes/rpc/rpc-event-projection.js";
 import { runRpcMode } from "../src/modes/rpc/rpc-mode.js";
 import { createHarness, type Harness } from "./test-harness.js";
 
@@ -245,6 +246,49 @@ describe("runRpcMode dashboard event projection (issue 448)", () => {
 			const endMessage = messageEnd?.message as { content?: Array<{ text?: string }> };
 			expect(endMessage.content?.[0]?.text).toHaveLength(8_000);
 		} finally {
+			capture.detach();
+			harness.cleanup();
+		}
+	});
+
+	// Issue 84 hardening: the oversized-frame guard is the canary that would make
+	// a FUTURE quadratic-growth regression observable. Prove runRpcMode actually
+	// runs it on the live projected path (on the projected frame + its serialized
+	// line), and never on the generic-rpc path — a wiring mistake here would
+	// silently disable that safety net.
+	it("runs warnIfProjectedFrameOversized on the projected frame for a projected consumer", async () => {
+		const spy = vi.spyOn(projection, "warnIfProjectedFrameOversized");
+		const { capture, harness } = await streamTextOfSize(4_000, "vscode");
+		try {
+			const updates = messageUpdateFrames(capture);
+			// Called once per emitted message_update frame.
+			const guardedUpdates = spy.mock.calls.filter(
+				([event]) => (event as Record<string, unknown>).type === "message_update",
+			);
+			expect(guardedUpdates.length).toBe(updates.length);
+			for (const [event, serialized] of guardedUpdates) {
+				// It sees the PROJECTED frame (cumulative field stripped)...
+				expect((event as Record<string, unknown>).message).toBeUndefined();
+				// ...and the serialized line matches what is actually written, so the
+				// size check reflects the real wire bytes with no re-serialization.
+				expect(serialized).toBe(jsonl.serializeJsonLine(event));
+			}
+		} finally {
+			spy.mockRestore();
+			capture.detach();
+			harness.cleanup();
+		}
+	});
+
+	it("does not run warnIfProjectedFrameOversized for a generic RPC consumer", async () => {
+		const spy = vi.spyOn(projection, "warnIfProjectedFrameOversized");
+		const harness = createHarness({ responses: ["x".repeat(4_000)], uiType: "rpc" });
+		const capture = await startRpcMode(harness);
+		try {
+			await harness.session.prompt("hi");
+			expect(spy).not.toHaveBeenCalled();
+		} finally {
+			spy.mockRestore();
 			capture.detach();
 			harness.cleanup();
 		}

--- a/packages/coding-agent/test/rpc-mode-dashboard-projection.test.ts
+++ b/packages/coding-agent/test/rpc-mode-dashboard-projection.test.ts
@@ -75,8 +75,11 @@ function serializedMessageUpdateBytes(capture: RpcCapture): number {
 }
 
 /** Run one streaming turn of the given text size and return the capture. */
-async function streamTextOfSize(size: number): Promise<{ capture: RpcCapture; harness: Harness }> {
-	const harness = createHarness({ responses: ["x".repeat(size)], uiType: "dashboard" });
+async function streamTextOfSize(
+	size: number,
+	uiType = "dashboard",
+): Promise<{ capture: RpcCapture; harness: Harness }> {
+	const harness = createHarness({ responses: ["x".repeat(size)], uiType });
 	const capture = await startRpcMode(harness);
 	await harness.session.prompt("hi");
 	return { capture, harness };
@@ -184,8 +187,8 @@ describe("runRpcMode dashboard event projection (issue 448)", () => {
 		}
 	});
 
-	it("leaves the generic RPC protocol untouched when uiType is not dashboard", async () => {
-		const harness = createHarness({ responses: ["x".repeat(4_000)] });
+	it("leaves the generic RPC protocol untouched when uiType is not a projected consumer", async () => {
+		const harness = createHarness({ responses: ["x".repeat(4_000)], uiType: "rpc" });
 		const capture = await startRpcMode(harness);
 		try {
 			await harness.session.prompt("hi");
@@ -198,6 +201,49 @@ describe("runRpcMode dashboard event projection (issue 448)", () => {
 				const streamEvent = frame.assistantMessageEvent as Record<string, unknown>;
 				expect(streamEvent.partial).toBeDefined();
 			}
+		} finally {
+			capture.detach();
+			harness.cleanup();
+		}
+	});
+
+	// Issue 84: the VSCode extension launches --mode rpc --ui vscode. Its reducer
+	// reads only the assistantMessageEvent delta fields, so it must receive the
+	// same bounded stream as the dashboard; otherwise a long reply overruns the
+	// child's 16 MiB stdout queue and kills it mid-reply before message_end.
+	it("projects cumulative fields out of message_update frames for uiType vscode (issue 84)", async () => {
+		const { capture, harness } = await streamTextOfSize(8_000, "vscode");
+		try {
+			const updates = messageUpdateFrames(capture);
+			expect(updates.length).toBeGreaterThan(1_500);
+
+			for (const frame of updates) {
+				expect(frame.message).toBeUndefined();
+				const streamEvent = frame.assistantMessageEvent as Record<string, unknown>;
+				expect(streamEvent.partial).toBeUndefined();
+			}
+
+			// Deltas survive and reconstruct the full text.
+			const reconstructed = updates
+				.map((f) => f.assistantMessageEvent as Record<string, unknown>)
+				.filter((e) => e.type === "text_delta")
+				.map((e) => e.delta as string)
+				.join("");
+			expect(reconstructed).toHaveLength(8_000);
+
+			// Every delta frame stays small and bounded — no growth with position.
+			const deltaLines = capture.lines.filter((l) => l.includes('"message_update"') && l.includes('"text_delta"'));
+			for (const line of deltaLines) {
+				expect(line.length).toBeLessThan(512);
+			}
+
+			// The authoritative final message still arrives complete on message_end.
+			const messageEnd = capture.frames.find(
+				(f) => f.type === "message_end" && (f.message as { role?: string })?.role === "assistant",
+			);
+			expect(messageEnd).toBeDefined();
+			const endMessage = messageEnd?.message as { content?: Array<{ text?: string }> };
+			expect(endMessage.content?.[0]?.text).toHaveLength(8_000);
 		} finally {
 			capture.detach();
 			harness.cleanup();

--- a/packages/vscode/src/host/build-args.ts
+++ b/packages/vscode/src/host/build-args.ts
@@ -1,0 +1,34 @@
+/**
+ * CLI argument construction for the RPC child the extension spawns.
+ *
+ * Kept vscode-free (structural {@link ConfigReader} instead of
+ * `vscode.WorkspaceConfiguration`) so it is directly unit-testable in the node
+ * test environment without a VS Code API mock — the `--ui vscode` wiring is the
+ * actual fix for issue 84 and must be regression-tested.
+ */
+
+/** Minimal structural view of `vscode.WorkspaceConfiguration` used here. */
+export interface ConfigReader {
+	get<T>(section: string): T | undefined;
+}
+
+/**
+ * Build the CLI args for the RPC child.
+ *
+ * Always emits `--ui vscode` first so the child projects (bounds) the
+ * `message_update` event stream. Without it the child receives the full
+ * O(n^2) cumulative stream and a long reply overruns the 16 MiB stdout queue,
+ * killing the child mid-reply before the reply is persisted (issue 84). The
+ * `"vscode"` literal must match `shouldProjectRpcEvents`'s accepted set in
+ * `@dreb/coding-agent/rpc`; the build-args test cross-checks that agreement so
+ * a drift on either side fails CI instead of silently reverting the fix.
+ */
+export function buildArgs(config: ConfigReader): string[] {
+	const args: string[] = [];
+	args.push("--ui", "vscode");
+	const provider = config.get<string>("provider")?.trim();
+	const model = config.get<string>("model")?.trim();
+	if (provider) args.push("--provider", provider);
+	if (model) args.push("--model", model);
+	return args;
+}

--- a/packages/vscode/src/host/extension.ts
+++ b/packages/vscode/src/host/extension.ts
@@ -539,6 +539,11 @@ function workspaceCwd(): string {
 
 function buildArgs(config: vscode.WorkspaceConfiguration): string[] {
 	const args: string[] = [];
+	// Identify this consumer as the VSCode extension so the RPC child projects
+	// (bounds) the message_update event stream. Without it the child receives the
+	// full O(n^2) cumulative stream and a long reply overruns the 16 MiB stdout
+	// queue, killing the child mid-reply before the reply is persisted (issue 84).
+	args.push("--ui", "vscode");
 	const provider = config.get<string>("provider")?.trim();
 	const model = config.get<string>("model")?.trim();
 	if (provider) args.push("--provider", provider);

--- a/packages/vscode/src/host/extension.ts
+++ b/packages/vscode/src/host/extension.ts
@@ -18,6 +18,7 @@ import { relative, sep } from "node:path";
 import * as vscode from "vscode";
 import type { LiveSessionInput } from "../shared/session-list.js";
 import { formatTabTitle } from "../shared/tab-title.js";
+import { buildArgs } from "./build-args.js";
 import { resolveCliPath } from "./cli-path.js";
 import type { ReviewUi } from "./review-ui.js";
 import { SessionController } from "./session-controller.js";
@@ -535,20 +536,6 @@ async function deleteSession(key: string): Promise<void> {
 
 function workspaceCwd(): string {
 	return vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? homedir();
-}
-
-function buildArgs(config: vscode.WorkspaceConfiguration): string[] {
-	const args: string[] = [];
-	// Identify this consumer as the VSCode extension so the RPC child projects
-	// (bounds) the message_update event stream. Without it the child receives the
-	// full O(n^2) cumulative stream and a long reply overruns the 16 MiB stdout
-	// queue, killing the child mid-reply before the reply is persisted (issue 84).
-	args.push("--ui", "vscode");
-	const provider = config.get<string>("provider")?.trim();
-	const model = config.get<string>("model")?.trim();
-	if (provider) args.push("--provider", provider);
-	if (model) args.push("--model", model);
-	return args;
 }
 
 function makeNonce(): string {

--- a/packages/vscode/test/build-args.test.ts
+++ b/packages/vscode/test/build-args.test.ts
@@ -1,0 +1,44 @@
+import { shouldProjectRpcEvents } from "@dreb/coding-agent/rpc";
+import { describe, expect, it } from "vitest";
+import { buildArgs, type ConfigReader } from "../src/host/build-args.js";
+
+/** A {@link ConfigReader} backed by a plain record. */
+function config(values: Record<string, string> = {}): ConfigReader {
+	return {
+		get<T>(section: string): T | undefined {
+			return values[section] as T | undefined;
+		},
+	};
+}
+
+/** Return the value passed to the `--ui` flag, or undefined if absent. */
+function uiFlag(args: string[]): string | undefined {
+	const i = args.indexOf("--ui");
+	return i >= 0 ? args[i + 1] : undefined;
+}
+
+describe("buildArgs (issue 84 wiring)", () => {
+	it("always emits --ui vscode so the RPC child bounds the message_update stream", () => {
+		const args = buildArgs(config());
+		expect(uiFlag(args)).toBe("vscode");
+	});
+
+	it("emits --ui before provider/model", () => {
+		const args = buildArgs(config({ provider: "openai", model: "gpt-x" }));
+		expect(args.slice(0, 2)).toEqual(["--ui", "vscode"]);
+		expect(args).toEqual(["--ui", "vscode", "--provider", "openai", "--model", "gpt-x"]);
+	});
+
+	it("omits provider/model when unset or blank", () => {
+		expect(buildArgs(config({ provider: "  ", model: "" }))).toEqual(["--ui", "vscode"]);
+	});
+
+	// Cross-package drift guard: the `--ui` value buildArgs emits MUST be one the
+	// coding-agent RPC layer projects. If either side is renamed/typo'd, this
+	// fails CI instead of silently reverting VSCode to the O(n^2) crash (issue 84).
+	it("emits a --ui value the RPC layer actually projects", () => {
+		const ui = uiFlag(buildArgs(config()));
+		expect(ui).toBeDefined();
+		expect(shouldProjectRpcEvents(ui)).toBe(true);
+	});
+});


### PR DESCRIPTION
Closes #84

VSCode RPC child is killed mid-reply because the quadratic `message_update` stream (cumulative `message` + `assistantMessageEvent.partial` on every token) is only bounded for `uiType === "dashboard"`. This gives VSCode its own `uiType === "vscode"` and widens the projection gate so its stream is bounded — leaving generic RPC consumers untouched.

Implementation plan posted as a comment below.
