### PR TITLE
Persist in-flight assistant reply on RPC child exit so it survives restart

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1607,6 +1607,53 @@ export class AgentSession {
 		return this.agent.state.messages;
 	}
 
+	/**
+	 * Re-persist an assistant reply that was streamed to a host (e.g. the VSCode
+	 * extension) but never persisted because the previous RPC child died before
+	 * `message_end` (crash, SIGKILL, backpressure exit). Called on the freshly
+	 * restarted child with the text the host retained.
+	 *
+	 * The reply is appended through the normal session-manager path (so the child
+	 * owns id/parentId/leaf bookkeeping and the `.jsonl` format) and marked
+	 * `aborted` since the turn was interrupted. The in-memory agent context is
+	 * then re-synced from the session so `get messages` (and thus the host's
+	 * transcript rebuild) reflects the recovered reply immediately, and a
+	 * subsequent user turn threads from it.
+	 *
+	 * Returns whether an entry was actually appended. Empty/whitespace-only text
+	 * (a genuinely empty interrupted turn) is a no-op so no blank/ghost reply is
+	 * created; a recovery attempted while a turn is streaming is also skipped so a
+	 * live reply can't be shadowed by a stale one.
+	 */
+	recoverInflightReply(text: string): boolean {
+		if (this.isStreaming) return false;
+		if (!text || text.trim().length === 0) return false;
+
+		const model = this.model;
+		const message: AssistantMessage = {
+			role: "assistant",
+			content: [{ type: "text", text }],
+			api: model?.api ?? "unknown",
+			provider: model?.provider ?? "unknown",
+			model: model?.id ?? "unknown",
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "aborted",
+			timestamp: Date.now(),
+		};
+		this.sessionManager.appendMessage(message);
+		// Re-sync in-memory context from the session so the recovered reply is
+		// visible to get_messages / the host rebuild and threads the next turn.
+		this.agent.replaceMessages(this.sessionManager.buildSessionContext().messages);
+		return true;
+	}
+
 	/** Current steering mode */
 	get steeringMode(): "all" | "one-at-a-time" {
 		return this.agent.getSteeringMode();

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1631,10 +1631,10 @@ export class AgentSession {
 
 		const model = this.model;
 		// Real usage is unknowable — the process that generated the reply died before
-		// reporting it. Estimate output tokens from the text length so context-size and
-		// compaction accounting (which read the last assistant message's usage) stay
-		// roughly correct instead of treating the recovered reply as free. Cost stays
-		// zero rather than fabricating a dollar figure.
+		// reporting it. Estimate output tokens from the text length so the pre-send
+		// compaction check (which includes aborted messages) doesn't treat the
+		// recovered reply as free. Cost stays zero rather than fabricating a dollar
+		// figure, and session/context stats exclude aborted turns entirely.
 		const estimatedOutputTokens = Math.ceil(text.length / 4);
 		const message: AssistantMessage = {
 			role: "assistant",
@@ -4305,6 +4305,11 @@ export class AgentSession {
 		for (const message of state.messages) {
 			if (message.role === "assistant") {
 				const assistantMsg = message as AssistantMessage;
+				// Skip aborted turns (matching getContextUsage / the performance
+				// tracker). Their usage is either unreported or, for a crash-recovered
+				// reply, a best-effort estimate with zero cost — counting it would
+				// inflate the reported token total against an unchanged cost.
+				if (assistantMsg.stopReason === "aborted") continue;
 				toolCalls += assistantMsg.content.filter((c) => c.type === "toolCall").length;
 				totalInput += assistantMsg.usage.input;
 				totalOutput += assistantMsg.usage.output;

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1630,6 +1630,12 @@ export class AgentSession {
 		if (!text || text.trim().length === 0) return false;
 
 		const model = this.model;
+		// Real usage is unknowable — the process that generated the reply died before
+		// reporting it. Estimate output tokens from the text length so context-size and
+		// compaction accounting (which read the last assistant message's usage) stay
+		// roughly correct instead of treating the recovered reply as free. Cost stays
+		// zero rather than fabricating a dollar figure.
+		const estimatedOutputTokens = Math.ceil(text.length / 4);
 		const message: AssistantMessage = {
 			role: "assistant",
 			content: [{ type: "text", text }],
@@ -1638,10 +1644,10 @@ export class AgentSession {
 			model: model?.id ?? "unknown",
 			usage: {
 				input: 0,
-				output: 0,
+				output: estimatedOutputTokens,
 				cacheRead: 0,
 				cacheWrite: 0,
-				totalTokens: 0,
+				totalTokens: estimatedOutputTokens,
 				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 			},
 			stopReason: "aborted",

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -698,6 +698,17 @@ export class RpcClient {
 	}
 
 	/**
+	 * Re-persist an assistant reply that a previous (crashed) child streamed to
+	 * the host but died before persisting. The fresh child appends it via the
+	 * normal session-manager path, marked interrupted/aborted. Returns whether an
+	 * entry was actually appended (empty/whitespace text is a no-op).
+	 */
+	async recoverInflightReply(text: string): Promise<boolean> {
+		const response = await this.send({ type: "recover_inflight_reply", text });
+		return this.getData<{ recovered: boolean }>(response).recovered;
+	}
+
+	/**
 	 * Get discoverable commands, including built-ins that require client-side handling.
 	 */
 	async getCommands(): Promise<RpcSlashCommand[]> {

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -1314,6 +1314,19 @@ export function getTreeForRpc(sessionManager: Pick<SessionManager, "getTree" | "
 	return { roots: toRpcTreeNodes(sessionManager.getTree()), leafId: sessionManager.getLeafId() };
 }
 
+/**
+ * Persist an assistant reply that a previous RPC child streamed to the host but
+ * died before it could reach `message_end` (crash, SIGKILL, backpressure exit).
+ *
+ * The host retains every streamed delta and, after auto-restart, hands the text
+ * back here so the fresh child re-persists it and re-syncs its context (see
+ * {@link AgentSession.recoverInflightReply}). Returns whether an entry was
+ * actually appended (empty/whitespace text is a no-op).
+ */
+export function recoverInflightReplyForRpc(session: Pick<AgentSession, "recoverInflightReply">, text: string): boolean {
+	return session.recoverInflightReply(text);
+}
+
 /** Navigate the active session tree, returning only the stable RPC result fields. */
 export async function navigateTreeForRpc(
 	session: Pick<AgentSession, "navigateTree">,
@@ -2227,6 +2240,11 @@ export async function runRpcMode(session: AgentSession, modelFallbackMessage?: s
 
 			case "get_messages": {
 				return success(id, "get_messages", { messages: session.messages });
+			}
+
+			case "recover_inflight_reply": {
+				const recovered = recoverInflightReplyForRpc(session, command.text);
+				return success(id, "recover_inflight_reply", { recovered });
 			}
 
 			// =================================================================

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -104,6 +104,8 @@ export type RpcCommand =
 
 	// Messages
 	| { id?: string; type: "get_messages" }
+	// Recover a host-buffered assistant reply that a crashed child never persisted
+	| { id?: string; type: "recover_inflight_reply"; text: string }
 
 	// Command discovery (resource commands plus client-handled built-ins)
 	| { id?: string; type: "get_commands" }
@@ -413,6 +415,13 @@ export type RpcResponse =
 
 	// Messages
 	| { id?: string; type: "response"; command: "get_messages"; success: true; data: { messages: AgentMessage[] } }
+	| {
+			id?: string;
+			type: "response";
+			command: "recover_inflight_reply";
+			success: true;
+			data: { recovered: boolean };
+	  }
 
 	// Commands
 	| {

--- a/packages/coding-agent/test/agent-session-stats.test.ts
+++ b/packages/coding-agent/test/agent-session-stats.test.ts
@@ -140,4 +140,48 @@ describe("AgentSession.getSessionStats", () => {
 			session.dispose();
 		}
 	});
+
+	it("excludes aborted turns from token and cost totals even when they carry usage", () => {
+		// getSessionStats intentionally skips stopReason "aborted" messages (matching
+		// getContextUsage and the performance tracker). A crash-recovered reply is
+		// stored as aborted with an estimated, zero-cost usage; counting it would
+		// inflate token totals against an unchanged cost. This pins that exclusion so
+		// a future change can't start leaking aborted usage into /session totals.
+		const { session, sessionManager } = createSession();
+
+		try {
+			sessionManager.appendMessage(createUserMessage("hello", 1));
+			sessionManager.appendMessage(createAssistantMessage("counted reply", 200, 2));
+			// An aborted turn carrying real, non-zero usage AND cost.
+			const abortedUsage: Usage = {
+				input: 500,
+				output: 100,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 600,
+				cost: { input: 0.4, output: 0.2, cacheRead: 0, cacheWrite: 0, total: 0.6 },
+			};
+			sessionManager.appendMessage({
+				role: "assistant",
+				content: [{ type: "text", text: "interrupted reply" }],
+				api: model.api,
+				provider: model.provider,
+				model: model.id,
+				usage: abortedUsage,
+				stopReason: "aborted",
+				timestamp: 3,
+			});
+			syncAgentMessages(session, sessionManager);
+
+			const stats = session.getSessionStats();
+			// Only the completed turn's 200 input tokens count; the aborted turn's
+			// 600 tokens and $0.6 cost are excluded.
+			expect(stats.tokens.input).toBe(200);
+			expect(stats.tokens.output).toBe(0);
+			expect(stats.tokens.total).toBe(200);
+			expect(stats.cost).toBe(0);
+		} finally {
+			session.dispose();
+		}
+	});
 });

--- a/packages/coding-agent/test/rpc-recover-inflight.test.ts
+++ b/packages/coding-agent/test/rpc-recover-inflight.test.ts
@@ -87,16 +87,28 @@ describe("recoverInflightReplyForRpc / AgentSession.recoverInflightReply", () =>
 		const msg = persistedAssistants(sessionManager)[0] as unknown as {
 			provider?: string;
 			model?: string;
-			usage?: { output: number; totalTokens: number; cost: { total: number } };
+			usage?: { input: number; output: number; totalTokens: number; cost: { total: number } };
 		};
 		// The session's configured model, not "unknown" — so downstream same-model
 		// logic (e.g. compaction checks) treats the recovered reply correctly.
 		expect(msg.provider).toBe(session.model?.provider);
 		expect(msg.model).toBe(session.model?.id);
-		// Usage is estimated from text length so context/compaction accounting doesn't
-		// treat the recovered reply as free; cost is not fabricated.
-		expect(msg.usage?.output).toBeGreaterThan(0);
-		expect(msg.usage?.totalTokens).toBe(msg.usage?.output);
+		// Usage is estimated from text length (ceil(length / 4)) so the pre-send
+		// compaction check doesn't treat the recovered reply as free; input is zero
+		// and cost is not fabricated. Pin the exact formula so a divisor/rounding
+		// regression is caught, not just any positive number.
+		const expectedOutput = Math.ceil(text.length / 4);
+		expect(msg.usage?.output).toBe(expectedOutput);
+		expect(msg.usage?.totalTokens).toBe(expectedOutput);
+		expect(msg.usage?.input).toBe(0);
 		expect(msg.usage?.cost.total).toBe(0);
+
+		// The estimate must NOT leak into session token totals (it has zero cost, so
+		// counting it would inflate tokens against an unchanged cost). getSessionStats
+		// excludes aborted turns entirely.
+		const stats = session.getSessionStats();
+		expect(stats.tokens.output).toBe(0);
+		expect(stats.tokens.total).toBe(0);
+		expect(stats.cost).toBe(0);
 	});
 });

--- a/packages/coding-agent/test/rpc-recover-inflight.test.ts
+++ b/packages/coding-agent/test/rpc-recover-inflight.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { recoverInflightReplyForRpc } from "../src/modes/rpc/rpc-mode.js";
+import { createTestSession } from "./utilities.js";
+
+const contexts: Array<{ cleanup: () => void }> = [];
+
+afterEach(() => {
+	while (contexts.length > 0) contexts.pop()!.cleanup();
+});
+
+function newSession() {
+	const ctx = createTestSession();
+	contexts.push(ctx);
+	return ctx;
+}
+
+function persistedAssistants(sessionManager: {
+	buildSessionContext(): { messages: Array<{ role: string }> };
+}): Array<{ role: string; content: unknown; stopReason?: string }> {
+	return sessionManager.buildSessionContext().messages.filter((m) => m.role === "assistant") as Array<{
+		role: string;
+		content: unknown;
+		stopReason?: string;
+	}>;
+}
+
+describe("recoverInflightReplyForRpc / AgentSession.recoverInflightReply", () => {
+	it("persists a recovered reply as an interrupted assistant message", () => {
+		const { session, sessionManager } = newSession();
+		const before = sessionManager.getLeafId();
+
+		const recovered = recoverInflightReplyForRpc(session, "half a reply");
+
+		expect(recovered).toBe(true);
+		const assistants = persistedAssistants(sessionManager);
+		expect(assistants).toHaveLength(1);
+		expect(assistants[0].stopReason).toBe("aborted");
+		expect(assistants[0].content).toEqual([{ type: "text", text: "half a reply" }]);
+		// Advances the leaf so the next user turn threads from the recovered reply.
+		expect(sessionManager.getLeafId()).not.toBe(before);
+	});
+
+	it("re-syncs the in-memory agent context so get_messages reflects it", () => {
+		const { session } = newSession();
+
+		recoverInflightReplyForRpc(session, "recovered text");
+
+		// session.messages is what the RPC get_messages / host rebuild reads; it
+		// must include the recovered reply immediately (not only after a reload).
+		const assistant = session.messages.find((m) => m.role === "assistant") as { content: unknown } | undefined;
+		expect(assistant?.content).toEqual([{ type: "text", text: "recovered text" }]);
+	});
+
+	it("is a no-op for empty or whitespace-only text (no ghost reply)", () => {
+		const { session, sessionManager } = newSession();
+		const before = sessionManager.getLeafId();
+
+		expect(recoverInflightReplyForRpc(session, "")).toBe(false);
+		expect(recoverInflightReplyForRpc(session, "   \n\t ")).toBe(false);
+
+		expect(persistedAssistants(sessionManager)).toHaveLength(0);
+		expect(sessionManager.getLeafId()).toBe(before);
+	});
+
+	it("does not append while a turn is streaming", () => {
+		const { session, sessionManager } = newSession();
+		Object.defineProperty(session, "isStreaming", { get: () => true, configurable: true });
+
+		expect(recoverInflightReplyForRpc(session, "should not persist")).toBe(false);
+		expect(persistedAssistants(sessionManager)).toHaveLength(0);
+	});
+
+	it("preserves the exact streamed text including internal whitespace", () => {
+		const { session, sessionManager } = newSession();
+		const text = "line one\n\nline two with trailing spaces   ";
+
+		expect(recoverInflightReplyForRpc(session, text)).toBe(true);
+		expect(persistedAssistants(sessionManager)[0].content).toEqual([{ type: "text", text }]);
+	});
+});

--- a/packages/coding-agent/test/rpc-recover-inflight.test.ts
+++ b/packages/coding-agent/test/rpc-recover-inflight.test.ts
@@ -77,4 +77,26 @@ describe("recoverInflightReplyForRpc / AgentSession.recoverInflightReply", () =>
 		expect(recoverInflightReplyForRpc(session, text)).toBe(true);
 		expect(persistedAssistants(sessionManager)[0].content).toEqual([{ type: "text", text }]);
 	});
+
+	it("records the session's model and a best-effort usage estimate on the recovered message", () => {
+		const { session, sessionManager } = newSession();
+		const text = "a recovered reply of some length";
+
+		expect(recoverInflightReplyForRpc(session, text)).toBe(true);
+
+		const msg = persistedAssistants(sessionManager)[0] as unknown as {
+			provider?: string;
+			model?: string;
+			usage?: { output: number; totalTokens: number; cost: { total: number } };
+		};
+		// The session's configured model, not "unknown" — so downstream same-model
+		// logic (e.g. compaction checks) treats the recovered reply correctly.
+		expect(msg.provider).toBe(session.model?.provider);
+		expect(msg.model).toBe(session.model?.id);
+		// Usage is estimated from text length so context/compaction accounting doesn't
+		// treat the recovered reply as free; cost is not fabricated.
+		expect(msg.usage?.output).toBeGreaterThan(0);
+		expect(msg.usage?.totalTokens).toBe(msg.usage?.output);
+		expect(msg.usage?.cost.total).toBe(0);
+	});
 });

--- a/packages/vscode/src/host/session-controller.ts
+++ b/packages/vscode/src/host/session-controller.ts
@@ -21,6 +21,7 @@ import {
 	type Checkpoint,
 	createTranscriptState,
 	foldMessagesIntoState,
+	type ResponseGroup,
 	type TranscriptState,
 } from "../shared/projection.js";
 import type {
@@ -162,9 +163,12 @@ export interface RpcClientLike {
 	 * complete content — answers, thinking, and tool calls — rather than previews. */
 	getMessages(): Promise<unknown[]>;
 	/** Re-persist an assistant reply the previous (crashed) child streamed but
-	 * never persisted. Returns whether an entry was appended. Optional so fakes
-	 * and older clients without the method degrade gracefully (no recovery). */
-	recoverInFlightReply?(text: string): Promise<boolean>;
+	 * never persisted. Returns whether an entry was appended. Required — when
+	 * this was optional with a casing that drifted from the real `RpcClient`
+	 * (`recoverInFlightReply` vs `recoverInflightReply`), structural typing
+	 * stayed silent and recovery was a silent no-op in production while every
+	 * fake passed. A required member makes that drift a compile error. */
+	recoverInflightReply(text: string): Promise<boolean>;
 }
 
 export type RpcClientFactory = (options: {
@@ -364,16 +368,18 @@ function toImageContent(images?: readonly ImageAttachmentDto[]): ImageContentPar
 
 export class SessionController {
 	private readonly state: TranscriptState = createTranscriptState();
-	/** Text of the assistant reply currently streaming, accumulated from the live
-	 * event deltas. Reset when an assistant turn starts, and cleared on
-	 * `message_end` (the child has persisted it by then). If the child dies while
-	 * this is non-empty, the reply was streamed to the host but never persisted —
-	 * `handleExit` snapshots it into {@link pendingRecovery} for re-persistence. */
-	private inFlightReply = "";
+	/** In-flight reply recovery bookkeeping: which response group was active and how
+	 * much of its answer the child had persisted as of the last assistant
+	 * `message_end`. The recoverable text is *derived* from the live projection's
+	 * active answer — exactly what the user saw, separators included — as everything
+	 * past this mark, so recovery can never drift from the rendered transcript. */
+	private inFlightPersisted: { groupId: number; len: number } | undefined;
 	/** Snapshot of an in-flight reply captured at an unexpected child exit, to be
 	 * re-persisted through the restarted child. `undefined` when there is nothing
-	 * to recover (a clean turn, or an empty interrupted turn). */
-	private pendingRecovery: string | undefined;
+	 * to recover (a clean turn, or an empty interrupted turn). `retried` bounds
+	 * recovery to a single retry so a failed re-persist can't loop forever and a
+	 * stale snapshot can't resurface many restarts later. */
+	private pendingRecovery: { text: string; retried: boolean } | undefined;
 	private readonly listeners = new Set<(update: ControllerUpdate) => void>();
 	/** User-input listeners (Phase 9): fired whenever the user actively drives
 	 * the session (a composer submit or an answer to a blocking UI request), so
@@ -1078,6 +1084,10 @@ export class SessionController {
 		this.state.statusText = undefined;
 		this.state.hostError = undefined;
 		this.state.nextResponseId = 1;
+		// Group ids restart from 1 after a reset, so a stale persisted-mark keyed to
+		// an old id could falsely match a new group — drop it (an empty transcript
+		// has nothing recoverable anyway).
+		this.inFlightPersisted = undefined;
 		// A prior session's end-of-turn suggestion must not survive into a
 		// new/imported/forked session (it is otherwise only cleared at the next
 		// turn's agent_start); drop it so it can't leak across the resync.
@@ -1314,6 +1324,11 @@ export class SessionController {
 		const messages = await this.client.getMessages();
 		const tree = await this.client.getTree();
 		foldMessagesIntoState(this.state, messages);
+		// Everything just folded came from the persisted session file, so mark the
+		// final group as fully persisted — a crash before the next message_end must
+		// recover nothing (otherwise the last turn would be duplicated).
+		const folded = this.activeResponseGroup();
+		this.inFlightPersisted = folded ? { groupId: folded.id, len: folded.answer.length } : undefined;
 		const branch = currentBranch(tree.roots, tree.leafId);
 		this.checkpoints = alignCheckpoints(this.state, branch.runTerminalEntryIds, await this.forkableEntryIds());
 		await this.refreshStatus(true);
@@ -1444,7 +1459,7 @@ export class SessionController {
 
 	private handleEvent(event: unknown): void {
 		applyEvent(this.state, event);
-		this.trackInFlightReply(event);
+		this.markPersistedReply(event);
 		this.emit({ kind: "event", event });
 		const type = (event as { type?: unknown })?.type;
 		// Snapshot a baseline before the first turn of a review cycle (changes
@@ -1471,53 +1486,54 @@ export class SessionController {
 		}
 	}
 
-	/** Accumulate the streaming assistant reply from the live event stream so it
-	 * can be recovered if the child dies before persisting it. Mirrors the subset
-	 * of the projection's `message_update` handling that produces answer text.
-	 *
-	 * - assistant `message_start` opens a fresh turn -> reset the buffer.
-	 * - `text_delta` / `text_end` accumulate the answer text.
-	 * - assistant `message_end` means the child persisted the reply -> clear the
-	 *   buffer so a completed turn has nothing to recover (no duplicate persist). */
-	private trackInFlightReply(event: unknown): void {
-		const e = event as {
-			type?: string;
-			message?: { role?: string };
-			assistantMessageEvent?: { type?: string; delta?: string; content?: string };
-		};
-		switch (e?.type) {
-			case "message_start":
-				if (e.message?.role === "assistant") this.inFlightReply = "";
-				break;
-			case "message_update": {
-				const stream = e.assistantMessageEvent;
-				if (!stream) break;
-				if (stream.type === "text_delta") {
-					this.inFlightReply += stream.delta ?? "";
-				} else if (stream.type === "text_end") {
-					// A non-streaming provider emits only text_end with the full block.
-					if (this.inFlightReply.length === 0 && typeof stream.content === "string") {
-						this.inFlightReply = stream.content;
-					}
-				}
-				break;
-			}
-			case "message_end":
-				if (e.message?.role === "assistant") this.inFlightReply = "";
-				break;
-			default:
-				break;
-		}
+	/** The live projection's active (last) response group — what the user currently
+	 * sees — or undefined when the transcript has no response yet. */
+	private activeResponseGroup(): ResponseGroup | undefined {
+		const last = this.state.items[this.state.items.length - 1];
+		return last && last.kind === "response" ? last : undefined;
+	}
+
+	/** Mark how much of the active response's answer the child has persisted. The
+	 * child persists on assistant `message_end`, so the answer text up to this point
+	 * is on disk and only text streamed after it is recoverable. Keyed to the
+	 * response-group id so a mark from an earlier run can't clip a fresh group
+	 * (a run with no `message_end` yet recovers its whole answer). */
+	private markPersistedReply(event: unknown): void {
+		const e = event as { type?: string; message?: { role?: string } };
+		if (e?.type !== "message_end" || e.message?.role !== "assistant") return;
+		const group = this.activeResponseGroup();
+		if (group) this.inFlightPersisted = { groupId: group.id, len: group.answer.length };
+	}
+
+	/** The streamed-but-unpersisted suffix of the active answer: everything past the
+	 * last persisted mark, or the whole answer when this group never reached
+	 * `message_end`. Empty when the last turn completed (fully persisted). */
+	private unpersistedAnswerSuffix(): string {
+		const group = this.activeResponseGroup();
+		if (!group) return "";
+		const mark = this.inFlightPersisted;
+		if (mark?.groupId === group.id) return group.answer.slice(Math.min(mark.len, group.answer.length));
+		return group.answer;
 	}
 
 	private handleExit(info: { code?: number | null; signal?: string | null; error?: Error; stderr?: string }): void {
 		if (this.disposed) return;
 		// Snapshot any streamed-but-unpersisted reply before recovery so the child's
-		// death doesn't lose the reply the user already saw. A clean turn (cleared
-		// on message_end) or an empty interrupted turn leaves nothing to recover.
-		const inFlight = this.inFlightReply.trim();
-		this.pendingRecovery = inFlight.length > 0 ? this.inFlightReply : undefined;
-		this.inFlightReply = "";
+		// death doesn't lose the reply the user already saw. A clean turn (fully
+		// marked on message_end) or an empty interrupted turn leaves nothing to recover.
+		// When a recovery retry is still pending from a previous crash, keep it and
+		// append any newly streamed text (the pending text is already covered by the
+		// persisted mark, so the suffix holds only the new part) — both are recovered
+		// together, in display order.
+		const suffix = this.unpersistedAnswerSuffix();
+		const existing = this.pendingRecovery;
+		if (existing) {
+			if (suffix.trim().length > 0)
+				this.pendingRecovery = { text: existing.text + suffix, retried: existing.retried };
+		} else {
+			const text = suffix.replace(/^\n+/, "");
+			this.pendingRecovery = text.trim().length > 0 ? { text, retried: false } : undefined;
+		}
 		const message = formatExit(info);
 		// Capture whether a reply was actively streaming when the child died (before
 		// teardown), so the recovery notice can distinguish a genuinely-interrupted
@@ -1596,10 +1612,10 @@ export class SessionController {
 		// transcript — but a reply that the previous child streamed yet never
 		// persisted is absent. Re-persist it through the live child (which owns the
 		// session-file format/leaf bookkeeping), then rebuild so it renders in
-		// place. Guarded so it only runs on the crash path and only once per lost
-		// reply (cleared below regardless of outcome, so a later crash can't
-		// double-append it). Runs before the recovery notice so the notice appends
-		// below the restored (and re-persisted) conversation.
+		// place. Guarded so it only runs on the crash path; the snapshot is cleared
+		// on a definitive answer and retried at most once on failure (see below).
+		// Runs before the recovery notice so the notice appends below the restored
+		// (and re-persisted) conversation.
 		await this.recoverPendingReply();
 		// Connected again. Tell the user the session was rebuilt from disk (with the
 		// cause when known). Emitted here — after start()'s transcript rebuild (which
@@ -1630,21 +1646,44 @@ export class SessionController {
 
 	/** Re-persist a reply the crashed child streamed but never saved, through the
 	 * freshly restarted child, then rebuild the transcript so it renders in place.
-	 * Best-effort: any failure is logged and swallowed (the reply is already gone
-	 * from disk; a failed recovery must not abort the restart). The snapshot is
-	 * always cleared so a subsequent crash cannot append the same reply twice. */
+	 * Best-effort: a failure is logged and swallowed (the reply is already gone from
+	 * disk; a failed recovery must not abort the restart). The snapshot is cleared on
+	 * any definitive child answer (appended or refused). On failure it is re-armed
+	 * exactly once, so a crash inside the recovery round-trip itself doesn't
+	 * permanently drop the reply — bounded so a response lost *after* the child
+	 * appended can't double-append more than once, and a stale snapshot can't
+	 * resurface many restarts later. */
 	private async recoverPendingReply(): Promise<void> {
-		const text = this.pendingRecovery;
-		this.pendingRecovery = undefined;
-		if (text === undefined) return;
+		const pending = this.pendingRecovery;
+		if (!pending) return;
 		const client = this.client;
-		if (!client?.recoverInFlightReply) return;
+		if (!client || typeof client.recoverInflightReply !== "function") {
+			// Loud, never silent: a client without the recovery method must not drop
+			// the reply without a trace. (Regression guard — a casing drift between
+			// this name and the real client's method once made recovery a silent
+			// no-op in production while every fake passed.)
+			this.logger("in-flight reply recovery unavailable: client does not implement recoverInflightReply");
+			this.rearmPendingRecovery(pending);
+			return;
+		}
 		try {
-			const recovered = await client.recoverInFlightReply(text);
+			const recovered = await client.recoverInflightReply(pending.text);
+			this.pendingRecovery = undefined;
 			if (recovered) await this.rebuildTranscript();
 		} catch (err) {
 			this.logger(`in-flight reply recovery failed: ${errorText(err)}`);
+			this.rearmPendingRecovery(pending);
 		}
+	}
+
+	/** Re-arm a failed recovery snapshot for one retry on the next restart, and mark
+	 * the displayed answer as covered by it — a later crash then snapshots only text
+	 * streamed after this point and can never re-append the covered prefix. After
+	 * the retry's own failure the snapshot is dropped (bounded losslessness). */
+	private rearmPendingRecovery(pending: { text: string; retried: boolean }): void {
+		this.pendingRecovery = pending.retried ? undefined : { ...pending, retried: true };
+		const group = this.activeResponseGroup();
+		if (group) this.inFlightPersisted = { groupId: group.id, len: group.answer.length };
 	}
 
 	/** Terminal recovery state: repeated crashes within the window. Surface a

--- a/packages/vscode/src/host/session-controller.ts
+++ b/packages/vscode/src/host/session-controller.ts
@@ -305,6 +305,12 @@ const RECOVERED_MESSAGE_INTERRUPTED =
  * crash time (the previous turn had already completed and was persisted, so it is
  * present in the rebuilt transcript): nothing was lost. */
 const RECOVERED_MESSAGE_IDLE = "Session recovered after an unexpected exit. The session is idle.";
+/** Shown once after a successful auto-recovery when a reply was mid-stream at
+ * crash time and was re-persisted (issue 85): the interrupted reply is back in
+ * the transcript, so there is no loss to report and no Retry to offer (that would
+ * resend an already-answered prompt). */
+const RECOVERED_MESSAGE_RESTORED =
+	"Session recovered after an unexpected exit. The interrupted reply was restored — the session is idle.";
 
 function errorText(err: unknown): string {
 	return err instanceof Error ? err.message : String(err);
@@ -1615,14 +1621,15 @@ export class SessionController {
 		// place. Guarded so it only runs on the crash path; the snapshot is cleared
 		// on a definitive answer and retried at most once on failure (see below).
 		// Runs before the recovery notice so the notice appends below the restored
-		// (and re-persisted) conversation.
-		await this.recoverPendingReply();
+		// (and re-persisted) conversation. The result decides whether the notice
+		// reports a restored reply (no "not saved", no Retry) or a lost one.
+		const recovered = await this.recoverPendingReply();
 		// Connected again. Tell the user the session was rebuilt from disk (with the
 		// cause when known). Emitted here — after start()'s transcript rebuild (which
 		// clears items) and the in-flight recovery above — so the notice appends
 		// below the restored conversation. This is strictly the crash path; a clean
 		// initial open/reopen never goes through restart(), so those are unaffected.
-		this.emitRecovery(cause, interrupted);
+		this.emitRecovery(cause, interrupted, recovered);
 		// Arm a stable-run reset so a child that survives long enough clears the
 		// crash budget and a *later* isolated crash still gets a fresh recovery
 		// allowance.
@@ -1630,17 +1637,24 @@ export class SessionController {
 	}
 
 	/** Emit the persistent post-recovery notice. When a reply was mid-stream at
-	 * crash time (`interrupted`), it says the last reply was lost and offers Retry
-	 * (only when a last prompt was retained, reusing the existing `retry()` path).
-	 * When the crash was idle (a completed turn already persisted), it says only
-	 * that the session recovered — no false "not saved" claim and no Retry that
-	 * would resend an already-answered prompt. */
-	private emitRecovery(cause?: string, interrupted = false): void {
+	 * crash time (`interrupted`) but was re-persisted (`recovered`), it says the
+	 * interrupted reply was restored — no false "not saved" claim and no Retry (the
+	 * prompt was already answered and the reply is back). When it was mid-stream but
+	 * NOT recovered, it says the last reply was lost and offers Retry (only when a
+	 * last prompt was retained, reusing the existing `retry()` path). When the crash
+	 * was idle (a completed turn already persisted), it says only that the session
+	 * recovered. */
+	private emitRecovery(cause?: string, interrupted = false, recovered = false): void {
+		const message = recovered
+			? RECOVERED_MESSAGE_RESTORED
+			: interrupted
+				? RECOVERED_MESSAGE_INTERRUPTED
+				: RECOVERED_MESSAGE_IDLE;
 		this.handleEvent({
 			type: "host_recovery",
-			message: interrupted ? RECOVERED_MESSAGE_INTERRUPTED : RECOVERED_MESSAGE_IDLE,
+			message,
 			cause,
-			canRetry: interrupted && this.lastPrompt != null,
+			canRetry: interrupted && !recovered && this.lastPrompt != null,
 		});
 	}
 
@@ -1653,9 +1667,9 @@ export class SessionController {
 	 * permanently drop the reply — bounded so a response lost *after* the child
 	 * appended can't double-append more than once, and a stale snapshot can't
 	 * resurface many restarts later. */
-	private async recoverPendingReply(): Promise<void> {
+	private async recoverPendingReply(): Promise<boolean> {
 		const pending = this.pendingRecovery;
-		if (!pending) return;
+		if (!pending) return false;
 		const client = this.client;
 		if (!client || typeof client.recoverInflightReply !== "function") {
 			// Loud, never silent: a client without the recovery method must not drop
@@ -1664,7 +1678,7 @@ export class SessionController {
 			// no-op in production while every fake passed.)
 			this.logger("in-flight reply recovery unavailable: client does not implement recoverInflightReply");
 			this.rearmPendingRecovery(pending);
-			return;
+			return false;
 		}
 		let recovered: boolean;
 		try {
@@ -1674,7 +1688,7 @@ export class SessionController {
 			// for one bounded retry on the next restart.
 			this.logger(`in-flight reply recovery failed: ${errorText(err)}`);
 			this.rearmPendingRecovery(pending);
-			return;
+			return false;
 		}
 		// The append succeeded (or was a no-op): the reply is now durably on disk, so
 		// the snapshot must be cleared and never re-armed. A failure in the *following*
@@ -1690,6 +1704,7 @@ export class SessionController {
 				this.logger(`transcript rebuild after in-flight recovery failed: ${errorText(err)}`);
 			}
 		}
+		return recovered;
 	}
 
 	/** Re-arm a failed recovery snapshot for one retry on the next restart, and mark

--- a/packages/vscode/src/host/session-controller.ts
+++ b/packages/vscode/src/host/session-controller.ts
@@ -1666,13 +1666,29 @@ export class SessionController {
 			this.rearmPendingRecovery(pending);
 			return;
 		}
+		let recovered: boolean;
 		try {
-			const recovered = await client.recoverInflightReply(pending.text);
-			this.pendingRecovery = undefined;
-			if (recovered) await this.rebuildTranscript();
+			recovered = await client.recoverInflightReply(pending.text);
 		} catch (err) {
+			// The append itself failed — the reply is not durably persisted, so re-arm
+			// for one bounded retry on the next restart.
 			this.logger(`in-flight reply recovery failed: ${errorText(err)}`);
 			this.rearmPendingRecovery(pending);
+			return;
+		}
+		// The append succeeded (or was a no-op): the reply is now durably on disk, so
+		// the snapshot must be cleared and never re-armed. A failure in the *following*
+		// transcript rebuild must NOT re-arm — doing so would re-append the same reply
+		// on the next restart, a double-persist that violates "no double-recovery
+		// across repeated crashes". The recovered reply will render on the next
+		// natural reconnect/rebuild regardless.
+		this.pendingRecovery = undefined;
+		if (recovered) {
+			try {
+				await this.rebuildTranscript();
+			} catch (err) {
+				this.logger(`transcript rebuild after in-flight recovery failed: ${errorText(err)}`);
+			}
 		}
 	}
 

--- a/packages/vscode/src/host/session-controller.ts
+++ b/packages/vscode/src/host/session-controller.ts
@@ -161,6 +161,10 @@ export interface RpcClientLike {
 	 * navigate/fork, and populated on resume). Used to rebuild the transcript with
 	 * complete content — answers, thinking, and tool calls — rather than previews. */
 	getMessages(): Promise<unknown[]>;
+	/** Re-persist an assistant reply the previous (crashed) child streamed but
+	 * never persisted. Returns whether an entry was appended. Optional so fakes
+	 * and older clients without the method degrade gracefully (no recovery). */
+	recoverInFlightReply?(text: string): Promise<boolean>;
 }
 
 export type RpcClientFactory = (options: {
@@ -360,6 +364,16 @@ function toImageContent(images?: readonly ImageAttachmentDto[]): ImageContentPar
 
 export class SessionController {
 	private readonly state: TranscriptState = createTranscriptState();
+	/** Text of the assistant reply currently streaming, accumulated from the live
+	 * event deltas. Reset when an assistant turn starts, and cleared on
+	 * `message_end` (the child has persisted it by then). If the child dies while
+	 * this is non-empty, the reply was streamed to the host but never persisted —
+	 * `handleExit` snapshots it into {@link pendingRecovery} for re-persistence. */
+	private inFlightReply = "";
+	/** Snapshot of an in-flight reply captured at an unexpected child exit, to be
+	 * re-persisted through the restarted child. `undefined` when there is nothing
+	 * to recover (a clean turn, or an empty interrupted turn). */
+	private pendingRecovery: string | undefined;
 	private readonly listeners = new Set<(update: ControllerUpdate) => void>();
 	/** User-input listeners (Phase 9): fired whenever the user actively drives
 	 * the session (a composer submit or an answer to a blocking UI request), so
@@ -1430,6 +1444,7 @@ export class SessionController {
 
 	private handleEvent(event: unknown): void {
 		applyEvent(this.state, event);
+		this.trackInFlightReply(event);
 		this.emit({ kind: "event", event });
 		const type = (event as { type?: unknown })?.type;
 		// Snapshot a baseline before the first turn of a review cycle (changes
@@ -1456,8 +1471,53 @@ export class SessionController {
 		}
 	}
 
+	/** Accumulate the streaming assistant reply from the live event stream so it
+	 * can be recovered if the child dies before persisting it. Mirrors the subset
+	 * of the projection's `message_update` handling that produces answer text.
+	 *
+	 * - assistant `message_start` opens a fresh turn -> reset the buffer.
+	 * - `text_delta` / `text_end` accumulate the answer text.
+	 * - assistant `message_end` means the child persisted the reply -> clear the
+	 *   buffer so a completed turn has nothing to recover (no duplicate persist). */
+	private trackInFlightReply(event: unknown): void {
+		const e = event as {
+			type?: string;
+			message?: { role?: string };
+			assistantMessageEvent?: { type?: string; delta?: string; content?: string };
+		};
+		switch (e?.type) {
+			case "message_start":
+				if (e.message?.role === "assistant") this.inFlightReply = "";
+				break;
+			case "message_update": {
+				const stream = e.assistantMessageEvent;
+				if (!stream) break;
+				if (stream.type === "text_delta") {
+					this.inFlightReply += stream.delta ?? "";
+				} else if (stream.type === "text_end") {
+					// A non-streaming provider emits only text_end with the full block.
+					if (this.inFlightReply.length === 0 && typeof stream.content === "string") {
+						this.inFlightReply = stream.content;
+					}
+				}
+				break;
+			}
+			case "message_end":
+				if (e.message?.role === "assistant") this.inFlightReply = "";
+				break;
+			default:
+				break;
+		}
+	}
+
 	private handleExit(info: { code?: number | null; signal?: string | null; error?: Error; stderr?: string }): void {
 		if (this.disposed) return;
+		// Snapshot any streamed-but-unpersisted reply before recovery so the child's
+		// death doesn't lose the reply the user already saw. A clean turn (cleared
+		// on message_end) or an empty interrupted turn leaves nothing to recover.
+		const inFlight = this.inFlightReply.trim();
+		this.pendingRecovery = inFlight.length > 0 ? this.inFlightReply : undefined;
+		this.inFlightReply = "";
 		const message = formatExit(info);
 		// Capture whether a reply was actively streaming when the child died (before
 		// teardown), so the recovery notice can distinguish a genuinely-interrupted
@@ -1532,11 +1592,20 @@ export class SessionController {
 			this.beginRecovery(reason, cause, interrupted);
 			return;
 		}
+		// The fresh child has loaded the persisted session and rendered the
+		// transcript — but a reply that the previous child streamed yet never
+		// persisted is absent. Re-persist it through the live child (which owns the
+		// session-file format/leaf bookkeeping), then rebuild so it renders in
+		// place. Guarded so it only runs on the crash path and only once per lost
+		// reply (cleared below regardless of outcome, so a later crash can't
+		// double-append it). Runs before the recovery notice so the notice appends
+		// below the restored (and re-persisted) conversation.
+		await this.recoverPendingReply();
 		// Connected again. Tell the user the session was rebuilt from disk (with the
 		// cause when known). Emitted here — after start()'s transcript rebuild (which
-		// clears items) — so the notice appends below the restored conversation. This
-		// is strictly the crash path; a clean initial open/reopen never goes through
-		// restart(), so those are unaffected.
+		// clears items) and the in-flight recovery above — so the notice appends
+		// below the restored conversation. This is strictly the crash path; a clean
+		// initial open/reopen never goes through restart(), so those are unaffected.
 		this.emitRecovery(cause, interrupted);
 		// Arm a stable-run reset so a child that survives long enough clears the
 		// crash budget and a *later* isolated crash still gets a fresh recovery
@@ -1557,6 +1626,25 @@ export class SessionController {
 			cause,
 			canRetry: interrupted && this.lastPrompt != null,
 		});
+	}
+
+	/** Re-persist a reply the crashed child streamed but never saved, through the
+	 * freshly restarted child, then rebuild the transcript so it renders in place.
+	 * Best-effort: any failure is logged and swallowed (the reply is already gone
+	 * from disk; a failed recovery must not abort the restart). The snapshot is
+	 * always cleared so a subsequent crash cannot append the same reply twice. */
+	private async recoverPendingReply(): Promise<void> {
+		const text = this.pendingRecovery;
+		this.pendingRecovery = undefined;
+		if (text === undefined) return;
+		const client = this.client;
+		if (!client?.recoverInFlightReply) return;
+		try {
+			const recovered = await client.recoverInFlightReply(text);
+			if (recovered) await this.rebuildTranscript();
+		} catch (err) {
+			this.logger(`in-flight reply recovery failed: ${errorText(err)}`);
+		}
 	}
 
 	/** Terminal recovery state: repeated crashes within the window. Surface a

--- a/packages/vscode/src/shared/projection.ts
+++ b/packages/vscode/src/shared/projection.ts
@@ -46,6 +46,11 @@ export interface ResponseGroup {
 	collapsed: boolean;
 	/** Provider failure text, if this run ended in an error. */
 	error?: string;
+	/** True when the run's last assistant message ended interrupted
+	 * (`stopReason: "aborted"`) — user-cancelled or recovered after a child crash.
+	 * Rendered as a subtle marker so a truncated answer isn't mistaken for a
+	 * complete one. */
+	aborted?: boolean;
 }
 
 export interface UserItem {
@@ -154,10 +159,22 @@ export interface TranscriptState {
 	suggestion?: SuggestionState;
 	/** Monotonic id source for response groups. */
 	nextResponseId: number;
+	/** Internal streaming bookkeeping: true once a `text_delta` arrived for the
+	 * current text block, so `text_end` knows the block's content is already
+	 * reflected in the answer. Non-streaming providers emit only `text_end` per
+	 * block, so a false value means the block content still needs adopting. */
+	sawTextDeltaInBlock: boolean;
 }
 
 export function createTranscriptState(): TranscriptState {
-	return { items: [], streaming: false, uiRequests: [], backgroundAgentIds: [], nextResponseId: 1 };
+	return {
+		items: [],
+		streaming: false,
+		uiRequests: [],
+		backgroundAgentIds: [],
+		nextResponseId: 1,
+		sawTextDeltaInBlock: false,
+	};
 }
 
 /** Flatten message content (string or content-part array) to plain text. */
@@ -357,6 +374,7 @@ export function applyEvent(state: TranscriptState, event: any): void {
 				// the previous turn is now stale.
 				state.suggestion = undefined;
 			} else if (message?.role === "assistant") {
+				state.sawTextDeltaInBlock = false;
 				activeResponse(state, true);
 			}
 			break;
@@ -368,12 +386,19 @@ export function applyEvent(state: TranscriptState, event: any): void {
 			if (!group) break;
 			switch (stream.type) {
 				case "text_delta":
+					state.sawTextDeltaInBlock = true;
 					appendAnswerText(group, stream.delta ?? "");
 					break;
 				case "text_end":
-					// text_end carries the authoritative block content; if no deltas
-					// were seen (e.g. a non-streaming provider), adopt it.
-					if (typeof stream.content === "string" && group.answer.length === 0) group.answer = stream.content;
+					// text_end carries the authoritative block content; streaming
+					// providers already delivered it via deltas, but a non-streaming
+					// provider emits only text_end per block. Adopt whenever no delta
+					// was seen for this block — not just when the answer is empty —
+					// so later blocks of a multi-block non-streaming reply aren't
+					// silently dropped.
+					if (typeof stream.content === "string" && !state.sawTextDeltaInBlock)
+						appendAnswerText(group, stream.content);
+					state.sawTextDeltaInBlock = false;
 					break;
 				case "thinking_start":
 					group.activity.push({ kind: "thinking", text: "" });
@@ -402,6 +427,13 @@ export function applyEvent(state: TranscriptState, event: any): void {
 				if (error) {
 					const group = activeResponse(state, true);
 					if (group) group.error = error;
+				}
+				// Mark interrupted turns so a truncated answer isn't mistaken for a
+				// complete one (mirrors the fold path, so a rebuilt transcript renders
+				// identically to the live one).
+				if (message.role === "assistant" && message.stopReason === "aborted") {
+					const group = activeResponse(state, true);
+					if (group) group.aborted = true;
 				}
 			}
 			break;
@@ -629,6 +661,7 @@ export function foldMessagesIntoState(state: TranscriptState, messages: readonly
 	state.statusText = undefined;
 	state.hostError = undefined;
 	state.nextResponseId = 1;
+	state.sawTextDeltaInBlock = false;
 
 	// The open response group for the current run, or undefined between runs (i.e.
 	// right after a user turn, before the next assistant message reopens one).
@@ -664,6 +697,10 @@ export function foldMessagesIntoState(state: TranscriptState, messages: readonly
 						: "Unknown error";
 				active.error = active.error ?? text;
 			}
+			// Interrupted turns (user-cancelled, or recovered after a child crash)
+			// keep their persisted marker so the rebuilt transcript renders the same
+			// "interrupted" cue the live projection shows.
+			if (message.stopReason === "aborted") active.aborted = true;
 		} else if (role === "toolResult") {
 			// Attach the result to its pending tool item in the open run's activity.
 			const tool = group ? findTool(group, String(message.toolCallId)) : undefined;

--- a/packages/vscode/src/webview/app.tsx
+++ b/packages/vscode/src/webview/app.tsx
@@ -441,6 +441,14 @@ export function ResponseView(props: { group: ResponseGroup; onRetry?: () => void
 					innerHTML={linkifyAnswer(renderMarkdown(props.group.answer), buildGroundedRefs(props.group.activity))}
 				/>
 			</Show>
+			<Show when={props.group.aborted}>
+				<div
+					class="dreb-aborted"
+					title="This turn was interrupted (cancelled, or recovered after a crash) — the reply may be incomplete"
+				>
+					Interrupted
+				</div>
+			</Show>
 			<Show when={props.group.error}>
 				<RetryBanner text={props.group.error ?? ""} onRetry={props.onRetry} />
 			</Show>

--- a/packages/vscode/src/webview/styles.css
+++ b/packages/vscode/src/webview/styles.css
@@ -258,6 +258,12 @@ body {
 	flex: 1 1 auto;
 	min-width: 0;
 }
+.dreb-aborted {
+	color: var(--vscode-descriptionForeground);
+	font-size: 0.85em;
+	font-style: italic;
+	margin-top: 4px;
+}
 .dreb-retry-btn {
 	flex: 0 0 auto;
 	font: inherit;

--- a/packages/vscode/test/app-retry.test.tsx
+++ b/packages/vscode/test/app-retry.test.tsx
@@ -73,6 +73,25 @@ describe("ResponseView retry control", () => {
 		expect(host.querySelector(".dreb-banner.error")).toBeNull();
 		expect(host.querySelector("button.dreb-retry-btn")).toBeNull();
 	});
+
+	it("renders the Interrupted marker when the group is aborted", () => {
+		const aborted: ResponseGroup = {
+			...erroredGroup(),
+			error: undefined,
+			answer: "partial reply",
+			aborted: true,
+		};
+		const host = mount(aborted);
+		const marker = host.querySelector(".dreb-aborted");
+		expect(marker).not.toBeNull();
+		expect(marker?.textContent).toContain("Interrupted");
+	});
+
+	it("renders no Interrupted marker for a non-aborted turn", () => {
+		const clean: ResponseGroup = { ...erroredGroup(), error: undefined, answer: "all done" };
+		const host = mount(clean);
+		expect(host.querySelector(".dreb-aborted")).toBeNull();
+	});
 });
 
 /**

--- a/packages/vscode/test/projection.test.ts
+++ b/packages/vscode/test/projection.test.ts
@@ -104,6 +104,43 @@ describe("projection", () => {
 		expect(onlyResponse(nonStreaming).answer).toBe("whole answer");
 	});
 
+	it("adopts every block of a multi-block non-streaming reply, and never double-appends streamed blocks", () => {
+		// A non-streaming provider emits only text_end per block; all blocks must land,
+		// not just the first.
+		const multiBlock = run([
+			{ type: "agent_start" },
+			{ type: "message_start", message: { role: "assistant" } },
+			{ type: "message_update", assistantMessageEvent: { type: "text_end", content: "first block" } },
+			{ type: "message_update", assistantMessageEvent: { type: "text_end", content: "second block" } },
+			{ type: "agent_end" },
+		]);
+		expect(onlyResponse(multiBlock).answer).toBe("first blocksecond block");
+
+		// A streaming provider sends deltas AND text_end with the same content — the
+		// text_end adoption must not duplicate it.
+		const streamed = run([
+			{ type: "agent_start" },
+			{ type: "message_start", message: { role: "assistant" } },
+			{ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "streamed" } },
+			{ type: "message_update", assistantMessageEvent: { type: "text_end", content: "streamed" } },
+			{ type: "agent_end" },
+		]);
+		expect(onlyResponse(streamed).answer).toBe("streamed");
+	});
+
+	it("marks a run aborted on an assistant message_end with stopReason aborted", () => {
+		const state = run([
+			{ type: "agent_start" },
+			{ type: "message_start", message: { role: "assistant" } },
+			{ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "partial ans" } },
+			{ type: "message_end", message: { role: "assistant", stopReason: "aborted" } },
+			{ type: "agent_end" },
+		]);
+		const group = onlyResponse(state);
+		expect(group.aborted).toBe(true);
+		expect(group.error).toBeUndefined();
+	});
+
 	it("maps an ask request's questions[] into a structured multi-question wizard", () => {
 		const state = createTranscriptState();
 		applyEvent(state, {
@@ -341,6 +378,20 @@ describe("projection", () => {
 });
 
 describe("foldMessagesIntoState (Phase 6 full-content rebuild)", () => {
+	it("marks a rebuilt group aborted when the persisted assistant message was interrupted", () => {
+		const state = createTranscriptState();
+		foldMessagesIntoState(state, [
+			{ role: "user", content: "question" },
+			// A recovered reply is persisted with stopReason "aborted" — the rebuilt
+			// transcript must carry the marker so the UI can show it was interrupted.
+			{ role: "assistant", content: [{ type: "text", text: "recovered reply" }], stopReason: "aborted" },
+		]);
+		const group = onlyResponse(state);
+		expect(group.answer).toBe("recovered reply");
+		expect(group.aborted).toBe(true);
+		expect(group.error).toBeUndefined();
+	});
+
 	it("rebuilds plain user/assistant turns in place with full answers (stable reference)", () => {
 		const state = createTranscriptState();
 		state.items.push({ kind: "user", text: "stale" });

--- a/packages/vscode/test/session-controller-review.test.ts
+++ b/packages/vscode/test/session-controller-review.test.ts
@@ -19,6 +19,12 @@ class MiniClient implements RpcClientLike {
 	private ev: ((e: any) => void) | undefined;
 	async start(): Promise<void> {}
 	async stop(): Promise<void> {}
+	// Recovery is a required member of RpcClientLike (kept in lockstep with the real
+	// RpcClient so a fake can never drift from production wiring); these tests never
+	// crash the fake child, so a no-op stub suffices.
+	async recoverInflightReply(): Promise<boolean> {
+		return false;
+	}
 	async prompt(): Promise<void> {}
 	async abort(): Promise<void> {}
 	async steer(): Promise<void> {}

--- a/packages/vscode/test/session-controller.test.ts
+++ b/packages/vscode/test/session-controller.test.ts
@@ -296,11 +296,15 @@ class FakeClient implements RpcClientLike {
 		this.eventListener?.(event);
 	}
 	recoverCalls: string[] = [];
-	/** When true, `recoverInFlightReply` reports it appended an entry (drives a
+	/** When true, `recoverInflightReply` reports it appended an entry (drives a
 	 * transcript rebuild); when false it reports a no-op. */
 	recoverResult = true;
-	async recoverInFlightReply(text: string): Promise<boolean> {
+	/** When set, `recoverInflightReply` rejects with this error (drives the
+	 * swallow-log-and-rearm path in the controller). */
+	recoverError: Error | undefined;
+	async recoverInflightReply(text: string): Promise<boolean> {
 		this.recoverCalls.push(text);
+		if (this.recoverError) throw this.recoverError;
 		return this.recoverResult;
 	}
 	emitExit(info: unknown): void {
@@ -2416,11 +2420,12 @@ describe("SessionController — auto-restart on crash", () => {
 	 * start() call, tracking them for inspection. The first client is started
 	 * immediately (like the real extension does) so the controller is "connected"
 	 * before a test drives an exit. */
-	async function setup(opts: { sessionPath?: string } = {}) {
+	async function setup(opts: { sessionPath?: string; configure?: (client: FakeClient, index: number) => void } = {}) {
 		const clients: FakeClient[] = [];
 		const factory = () => {
 			const c = new FakeClient();
 			c.state = { sessionFile: "/sessions/live.jsonl" };
+			opts.configure?.(c, clients.length);
 			clients.push(c);
 			return c;
 		};
@@ -2737,6 +2742,158 @@ describe("SessionController — auto-restart on crash", () => {
 		await vi.advanceTimersByTimeAsync(600);
 		expect(clients).toHaveLength(3);
 		expect(clients[2].recoverCalls).toEqual([]);
+	});
+
+	it("recovers only the second, unfinished reply of a multi-message turn", async () => {
+		const { clients } = await setup();
+		// First assistant message of the run completes (persisted by the child).
+		streamReply(clients[0], "first answer", true);
+		// A second assistant message in the same run starts streaming but never finishes.
+		clients[0].emit({ type: "message_start", message: { role: "assistant" } });
+		clients[0].emit({
+			type: "message_update",
+			assistantMessageEvent: { type: "text_delta", delta: "second answer" },
+		});
+		clients[0].emitExit({ code: 1, signal: null });
+		await vi.advanceTimersByTimeAsync(600);
+
+		expect(clients).toHaveLength(2);
+		// Only the truly-lost last message is recovered — the persisted first message
+		// must not be duplicated.
+		expect(clients[1].recoverCalls).toEqual(["second answer"]);
+	});
+
+	it("recovers a non-streaming text_end block (no deltas)", async () => {
+		const { clients } = await setup();
+		clients[0].emit({ type: "message_start", message: { role: "assistant" } });
+		clients[0].emit({
+			type: "message_update",
+			assistantMessageEvent: { type: "text_end", content: "full block at once" },
+		});
+		clients[0].emitExit({ code: 1, signal: null });
+		await vi.advanceTimersByTimeAsync(600);
+
+		expect(clients[1].recoverCalls).toEqual(["full block at once"]);
+	});
+
+	it("recovers every block of a multi-block non-streaming reply", async () => {
+		const { clients } = await setup();
+		clients[0].emit({ type: "message_start", message: { role: "assistant" } });
+		clients[0].emit({ type: "message_update", assistantMessageEvent: { type: "text_end", content: "block one" } });
+		clients[0].emit({ type: "message_update", assistantMessageEvent: { type: "text_end", content: "block two" } });
+		clients[0].emitExit({ code: 1, signal: null });
+		await vi.advanceTimersByTimeAsync(600);
+
+		// Both blocks must survive — the old first-block-only adoption dropped "block two".
+		expect(clients[1].recoverCalls).toEqual(["block oneblock two"]);
+	});
+
+	it("recovers a post-tool segment without a leading separator", async () => {
+		const { clients } = await setup();
+		// Persisted first segment, then tool activity, then a second segment that
+		// never reached message_end.
+		streamReply(clients[0], "let me check", true);
+		clients[0].emit({ type: "tool_execution_start", toolCallId: "t1", toolName: "bash" });
+		clients[0].emit({ type: "message_start", message: { role: "assistant" } });
+		clients[0].emit({
+			type: "message_update",
+			assistantMessageEvent: { type: "text_delta", delta: "here is the result" },
+		});
+		clients[0].emitExit({ code: 1, signal: null });
+		await vi.advanceTimersByTimeAsync(600);
+
+		// The projection renders the segments separated by a blank line; the recovered
+		// suffix is only the lost segment, without a stray leading blank line.
+		expect(clients[1].recoverCalls).toEqual(["here is the result"]);
+	});
+
+	it("does not rebuild the transcript when recovery is a no-op (recoverResult false)", async () => {
+		const { clients } = await setup({
+			configure: (c, i) => {
+				if (i === 1) c.recoverResult = false;
+			},
+		});
+		streamReply(clients[0], "refused reply", false);
+		clients[0].emitExit({ code: 1, signal: null });
+		await vi.advanceTimersByTimeAsync(600);
+
+		expect(clients).toHaveLength(2);
+		expect(clients[1].recoverCalls).toEqual(["refused reply"]);
+		// The restart's own resume rebuilt once; a no-op recovery must not rebuild again.
+		expect(clients[1].getMessagesCalls).toBe(1);
+	});
+
+	it("retries a failed recovery once on the next crash instead of dropping the reply", async () => {
+		const { clients, logs } = await setup({
+			configure: (c, i) => {
+				if (i === 1) c.recoverError = new Error("child died mid-recovery");
+			},
+		});
+		streamReply(clients[0], "precious reply", false);
+		clients[0].emitExit({ code: 1, signal: null });
+		await vi.advanceTimersByTimeAsync(600);
+
+		// First recovery attempt failed: logged and swallowed; the restart still completed.
+		expect(clients).toHaveLength(2);
+		expect(clients[1].recoverCalls).toEqual(["precious reply"]);
+		expect(logs.some((l) => l.includes("in-flight reply recovery failed"))).toBe(true);
+
+		// The child crashes again with no new text streamed: the snapshot is still armed,
+		// so the next restart retries it — and this time it succeeds.
+		clients[1].emitExit({ code: 1, signal: null });
+		await vi.advanceTimersByTimeAsync(600);
+		expect(clients).toHaveLength(3);
+		expect(clients[2].recoverCalls).toEqual(["precious reply"]);
+	});
+
+	it("gives up after one failed recovery retry (bounded, no loop, no third attempt)", async () => {
+		const { clients } = await setup({
+			configure: (c, i) => {
+				if (i >= 1) c.recoverError = new Error("always fails");
+			},
+		});
+		streamReply(clients[0], "doomed reply", false);
+		clients[0].emitExit({ code: 1, signal: null });
+		await vi.advanceTimersByTimeAsync(600);
+		expect(clients[1].recoverCalls).toEqual(["doomed reply"]);
+
+		// Second crash: the single allowed retry runs and also fails -> snapshot dropped.
+		clients[1].emitExit({ code: 1, signal: null });
+		await vi.advanceTimersByTimeAsync(600);
+		expect(clients).toHaveLength(3);
+		expect(clients[2].recoverCalls).toEqual(["doomed reply"]);
+
+		// Third crash: nothing left to recover — no further attempts.
+		clients[2].emitExit({ code: 1, signal: null });
+		await vi.advanceTimersByTimeAsync(600);
+		expect(clients).toHaveLength(4);
+		expect(clients[3].recoverCalls).toEqual([]);
+	});
+
+	it("never touches recovery or extra rebuilds during ordinary no-crash turns", async () => {
+		const { clients } = await setup();
+		const rebuildsAfterStart = clients[0].getMessagesCalls;
+
+		// Two ordinary completed turns, no crash anywhere.
+		streamReply(clients[0], "turn one", true);
+		clients[0].emit({ type: "agent_end" });
+		streamReply(clients[0], "turn two", true);
+		clients[0].emit({ type: "agent_end" });
+
+		expect(clients).toHaveLength(1);
+		expect(clients[0].recoverCalls).toEqual([]);
+		expect(clients[0].getMessagesCalls).toBe(rebuildsAfterStart);
+	});
+
+	it("real RpcClient satisfies the RpcClientLike recovery contract", async () => {
+		// Regression guard for the casing drift that made recovery a silent no-op in
+		// production (the interface declared `recoverInFlightReply`, the real client
+		// implements `recoverInflightReply`, and the optional member let structural
+		// typing stay silent). The member is now required, so a rename fails `tsgo`;
+		// this runtime assertion covers transpile-only runners (vitest/esbuild).
+		const { RpcClient } = await import("@dreb/coding-agent/rpc");
+		const real: RpcClientLike = new RpcClient({ cliPath: "/cli.js", cwd: "/tmp" });
+		expect(typeof real.recoverInflightReply).toBe("function");
 	});
 });
 

--- a/packages/vscode/test/session-controller.test.ts
+++ b/packages/vscode/test/session-controller.test.ts
@@ -2889,11 +2889,16 @@ describe("SessionController — auto-restart on crash", () => {
 		// Regression guard for the casing drift that made recovery a silent no-op in
 		// production (the interface declared `recoverInFlightReply`, the real client
 		// implements `recoverInflightReply`, and the optional member let structural
-		// typing stay silent). The member is now required, so a rename fails `tsgo`;
-		// this runtime assertion covers transpile-only runners (vitest/esbuild).
+		// typing stay silent). The member is now required, so a rename fails `tsgo`.
+		// The runtime assertion below covers transpile-only runners (vitest/esbuild)
+		// on BOTH sides: `methodName` is constrained to `keyof RpcClientLike`, so
+		// renaming the interface member (without updating this literal) fails `tsgo`,
+		// and looking that same name up on the concrete client catches a client-side
+		// rename at runtime even where types are erased.
 		const { RpcClient } = await import("@dreb/coding-agent/rpc");
 		const real: RpcClientLike = new RpcClient({ cliPath: "/cli.js", cwd: "/tmp" });
-		expect(typeof real.recoverInflightReply).toBe("function");
+		const methodName: keyof RpcClientLike = "recoverInflightReply";
+		expect(typeof (real as unknown as Record<string, unknown>)[methodName]).toBe("function");
 	});
 });
 

--- a/packages/vscode/test/session-controller.test.ts
+++ b/packages/vscode/test/session-controller.test.ts
@@ -2885,6 +2885,60 @@ describe("SessionController — auto-restart on crash", () => {
 		expect(clients[0].getMessagesCalls).toBe(rebuildsAfterStart);
 	});
 
+	it("does not re-append a recovered reply when the post-recovery rebuild fails", async () => {
+		// Recovery durably appends the reply, then the follow-up transcript rebuild
+		// throws (a transient RPC failure right after the append). The reply is
+		// already on disk, so the snapshot must NOT be re-armed — otherwise the next
+		// restart would append the same reply a second time (a double-persist that
+		// violates criterion 4, "no double-recovery across repeated crashes").
+		const { clients, logs } = await setup({
+			configure: (c, i) => {
+				if (i === 1) c.rebuildError = new Error("getMessages died right after append");
+			},
+		});
+		streamReply(clients[0], "recovered once", false);
+		clients[0].emitExit({ code: 1, signal: null });
+		await vi.advanceTimersByTimeAsync(600);
+
+		// The append happened exactly once, through the restarted child.
+		expect(clients[1].recoverCalls).toEqual(["recovered once"]);
+		// The rebuild-after-recovery failure is logged, not folded into a re-arm.
+		expect(logs.some((l) => l.includes("transcript rebuild after in-flight recovery failed"))).toBe(true);
+
+		// Second crash, no new text streamed: the snapshot was cleared once the append
+		// succeeded, so nothing is re-appended — no duplicate on disk.
+		clients[1].emitExit({ code: 1, signal: null });
+		await vi.advanceTimersByTimeAsync(600);
+		expect(clients).toHaveLength(3);
+		expect(clients[2].recoverCalls).toEqual([]);
+	});
+
+	it("combines a still-pending retry with newly streamed text on a later crash", async () => {
+		// A recovery fails once (snapshot stays armed). Before the next crash the
+		// restarted child streams *additional* unpersisted text. The following crash
+		// must recover both the previously-lost text and the new text together, in
+		// order — nothing dropped, nothing duplicated.
+		const { clients } = await setup({
+			configure: (c, i) => {
+				if (i === 1) c.recoverError = new Error("child died mid-recovery");
+			},
+		});
+		streamReply(clients[0], "first part", false);
+		clients[0].emitExit({ code: 1, signal: null });
+		await vi.advanceTimersByTimeAsync(600);
+		// First recovery failed and was re-armed for retry.
+		expect(clients[1].recoverCalls).toEqual(["first part"]);
+
+		// The restarted child streams more text, then crashes before persisting it.
+		streamReply(clients[1], "second part", false);
+		clients[1].emitExit({ code: 1, signal: null });
+		await vi.advanceTimersByTimeAsync(600);
+
+		// The next child recovers the combined text once.
+		expect(clients).toHaveLength(3);
+		expect(clients[2].recoverCalls).toEqual(["first partsecond part"]);
+	});
+
 	it("real RpcClient satisfies the RpcClientLike recovery contract", async () => {
 		// Regression guard for the casing drift that made recovery a silent no-op in
 		// production (the interface declared `recoverInFlightReply`, the real client

--- a/packages/vscode/test/session-controller.test.ts
+++ b/packages/vscode/test/session-controller.test.ts
@@ -2954,6 +2954,26 @@ describe("SessionController — auto-restart on crash", () => {
 		const methodName: keyof RpcClientLike = "recoverInflightReply";
 		expect(typeof (real as unknown as Record<string, unknown>)[methodName]).toBe("function");
 	});
+
+	it("reports the reply as restored (not lost) and suppresses Retry when recovery succeeds", async () => {
+		const { controller, clients } = await setup();
+		const recoveries = collectRecoveries(controller);
+
+		// A prompt was answered and the reply streamed, but the child died before
+		// persisting it. Recovery re-persists it, so the notice must say it was
+		// restored — not "not saved" — and must not offer Retry (that would resend
+		// an already-answered prompt).
+		await controller.submit("hello");
+		streamReply(clients[0], "the recovered answer", false);
+		clients[0].emitExit({ code: 1, signal: null });
+		await vi.advanceTimersByTimeAsync(600);
+
+		expect(clients[1].recoverCalls).toEqual(["the recovered answer"]);
+		expect(recoveries()).toHaveLength(1);
+		expect(recoveries()[0].message).toMatch(/restored/i);
+		expect(recoveries()[0].message).not.toMatch(/not saved/i);
+		expect(recoveries()[0].canRetry).toBe(false);
+	});
 });
 
 describe("extractCrashCause", () => {

--- a/packages/vscode/test/session-controller.test.ts
+++ b/packages/vscode/test/session-controller.test.ts
@@ -295,6 +295,14 @@ class FakeClient implements RpcClientLike {
 	emit(event: unknown): void {
 		this.eventListener?.(event);
 	}
+	recoverCalls: string[] = [];
+	/** When true, `recoverInFlightReply` reports it appended an entry (drives a
+	 * transcript rebuild); when false it reports a no-op. */
+	recoverResult = true;
+	async recoverInFlightReply(text: string): Promise<boolean> {
+		this.recoverCalls.push(text);
+		return this.recoverResult;
+	}
 	emitExit(info: unknown): void {
 		this.exitListener?.(info);
 	}
@@ -2664,6 +2672,71 @@ describe("SessionController — auto-restart on crash", () => {
 		expect(controller.hasFailed()).toBe(true);
 		expect(recoveries()).toHaveLength(3);
 		expect(controller.getStatus().error).toMatch(/recovery failed after repeated crashes/i);
+	});
+
+	// ---------------------------------------------------------------------
+	// In-flight reply recovery (issue 85): a reply the child streamed but died
+	// before persisting is re-persisted through the restarted child.
+	// ---------------------------------------------------------------------
+
+	/** Drive an assistant turn's streamed deltas onto a client. When
+	 * `finalize` is true, also emit the assistant `message_end` (the child
+	 * persisted the reply), so nothing should be recovered. */
+	function streamReply(client: FakeClient, text: string, finalize: boolean): void {
+		client.emit({ type: "message_start", message: { role: "assistant" } });
+		client.emit({ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: text } });
+		if (finalize) client.emit({ type: "message_end", message: { role: "assistant" } });
+	}
+
+	it("re-persists an in-flight reply after an unexpected crash, then rebuilds", async () => {
+		const { clients } = await setup();
+		// The user saw a full reply stream, but the child dies before message_end.
+		streamReply(clients[0], "the answer the user already saw", false);
+		clients[0].emitExit({ code: 1, signal: null });
+		await vi.advanceTimersByTimeAsync(600);
+
+		expect(clients).toHaveLength(2);
+		// Recovery ran exactly once with the streamed text, through the new child.
+		expect(clients[1].recoverCalls).toEqual(["the answer the user already saw"]);
+		// A recovered reply drives a transcript rebuild so it renders in place.
+		expect(clients[1].getMessagesCalls).toBeGreaterThan(0);
+	});
+
+	it("does not recover a reply the child already persisted (message_end seen)", async () => {
+		const { clients } = await setup();
+		// A normal completed turn: message_end fired, so the reply is on disk.
+		streamReply(clients[0], "a completed reply", true);
+		clients[0].emitExit({ code: 1, signal: null });
+		await vi.advanceTimersByTimeAsync(600);
+
+		expect(clients).toHaveLength(2);
+		expect(clients[1].recoverCalls).toEqual([]);
+	});
+
+	it("does not recover an empty interrupted turn (no ghost reply)", async () => {
+		const { clients } = await setup();
+		// An assistant turn started but produced no text before the crash.
+		clients[0].emit({ type: "message_start", message: { role: "assistant" } });
+		clients[0].emitExit({ code: 1, signal: null });
+		await vi.advanceTimersByTimeAsync(600);
+
+		expect(clients).toHaveLength(2);
+		expect(clients[1].recoverCalls).toEqual([]);
+	});
+
+	it("recovers a lost reply only once across repeated crashes", async () => {
+		const { clients } = await setup();
+		streamReply(clients[0], "lost reply", false);
+		// Crash 1: recovers.
+		clients[0].emitExit({ code: 1, signal: null });
+		await vi.advanceTimersByTimeAsync(600);
+		expect(clients[1].recoverCalls).toEqual(["lost reply"]);
+
+		// Crash 2 (no new reply streamed): must not re-append the same reply.
+		clients[1].emitExit({ code: 1, signal: null });
+		await vi.advanceTimersByTimeAsync(600);
+		expect(clients).toHaveLength(3);
+		expect(clients[2].recoverCalls).toEqual([]);
 	});
 });
 

--- a/packages/vscode/test/webview-bridge.test.ts
+++ b/packages/vscode/test/webview-bridge.test.ts
@@ -23,6 +23,12 @@ class BridgeFakeClient implements RpcClientLike {
 	private ex: ((info: any) => void) | undefined;
 	async start(): Promise<void> {}
 	async stop(): Promise<void> {}
+	// Recovery is a required member of RpcClientLike (kept in lockstep with the real
+	// RpcClient so a fake can never drift from production wiring); these tests never
+	// crash the fake child, so a no-op stub suffices.
+	async recoverInflightReply(): Promise<boolean> {
+		return false;
+	}
 	async prompt(): Promise<void> {}
 	async abort(): Promise<void> {}
 	async steer(): Promise<void> {}


### PR DESCRIPTION
Closes #85

Persist the in-flight assistant reply on an unexpected RPC child exit so it survives auto-restart instead of being silently dropped. Host-side recovery buffers the streamed reply and re-persists it through the restarted child.

Implementation plan posted as a comment below.
