### PR TITLE
Zero-config VSCode extension install from the dreb folder (repo-local install + robust Node spawn)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ The same agent runtime powers multiple surfaces:
 - **SDK** — import `@dreb/coding-agent` and create agent sessions directly in TypeScript.
 - **Telegram** — `@dreb/telegram` runs dreb as a bot with sessions, model controls, file upload/download, live tool status, and visible results for user-facing tools.
 - **Web dashboard** — `dreb dashboard` serves a browser UI (fleet overview of all sessions, full chat with steering, subagent observability, host file browser, dreb memory editor); local-only by default, remote via Tailscale + rotating pairing code. See [dashboard docs](packages/coding-agent/docs/dashboard.md).
-- **VS Code extension** *(early)* — `packages/vscode` embeds a native chat webview driven over RPC: streaming responses with a collapsible thinking/tool activity box, slash commands, and inline prompts. See [its README](packages/vscode/README.md).
+- **VS Code extension** *(early)* — `packages/vscode` embeds a native chat webview driven over RPC: streaming responses with a collapsible thinking/tool activity box, slash commands, and inline prompts. Install it from your dreb folder with `npm run install-vscode` (symlinks it into VS Code so it runs from the repo). See [its README](packages/vscode/README.md).
 
 ### Web dashboard
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
 		"verify-workspace-links": "node scripts/verify-workspace-links.js",
 		"verify-engines": "node scripts/verify-engines.js",
 		"test": "npm run test --workspaces --if-present",
+		"install-vscode": "npm run build && node packages/vscode/scripts/install-extension.mjs",
+		"uninstall-vscode": "node packages/vscode/scripts/uninstall-extension.mjs",
 		"coverage": "vitest --run --coverage --coverage.reporter=json-summary --coverage.reporter=text-summary",
 		"prepare": "husky"
 	},

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -55,6 +55,14 @@ type RpcCommandBody = DistributiveOmit<RpcCommand, "id">;
 export interface RpcClientOptions {
 	/** Path to the CLI entry point (default: searches for dist/cli.js) */
 	cliPath?: string;
+	/**
+	 * Absolute path to the Node.js executable used to spawn the CLI child.
+	 * Defaults to `"node"` (resolved via `PATH`). Callers that cannot rely on
+	 * `PATH` — e.g. a GUI-launched editor whose extension host has no shell
+	 * `PATH` — pass a discovered absolute Node path (or the editor's own
+	 * runtime), so the spawn does not fail with `ENOENT`.
+	 */
+	nodePath?: string;
 	/** Working directory for the agent */
 	cwd?: string;
 	/** Environment variables */
@@ -176,7 +184,7 @@ export class RpcClient {
 			args.push(...this.options.args);
 		}
 
-		this.process = spawn("node", [cliPath, ...args], {
+		this.process = spawn(this.options.nodePath ?? "node", [cliPath, ...args], {
 			cwd: this.options.cwd,
 			env: { ...process.env, ...this.options.env },
 			stdio: ["pipe", "pipe", "pipe"],

--- a/packages/coding-agent/src/utils/shell.ts
+++ b/packages/coding-agent/src/utils/shell.ts
@@ -126,10 +126,17 @@ export function getShellEnv(): NodeJS.ProcessEnv {
 	const hasBinDir = pathEntries.includes(binDir);
 	const updatedPath = hasBinDir ? currentPath : [binDir, currentPath].filter(Boolean).join(delimiter);
 
-	return {
+	const env: NodeJS.ProcessEnv = {
 		...process.env,
 		[pathKey]: updatedPath,
 	};
+	// When dreb itself is running under the editor's Electron runtime as Node
+	// (ELECTRON_RUN_AS_NODE=1, the VS Code extension's last-resort spawn), that
+	// flag must not leak into shell tool commands: a command like `code .` would
+	// otherwise run the Electron binary headless as Node instead of opening a
+	// window. Subagent/CLI re-spawns pass process.env directly and keep the flag.
+	delete env.ELECTRON_RUN_AS_NODE;
+	return env;
 }
 
 /**

--- a/packages/coding-agent/test/rpc-client-spawn.test.ts
+++ b/packages/coding-agent/test/rpc-client-spawn.test.ts
@@ -50,6 +50,12 @@ function lastSpawnOptions(): Record<string, unknown> {
 	return calls[calls.length - 1][2] as Record<string, unknown>;
 }
 
+/** Executable (first argument) passed to spawn(). */
+function lastSpawnCommand(): string {
+	const calls = vi.mocked(spawn).mock.calls;
+	return calls[calls.length - 1][0] as string;
+}
+
 beforeEach(() => {
 	vi.mocked(spawn).mockReset();
 });
@@ -208,5 +214,51 @@ describe("RpcClient spawn failure handling", () => {
 		expect(seen).toHaveLength(1);
 		expect((seen[0] as any).stderr).toBe("Fatal: something broke\n");
 		expect((seen[0] as any).code).toBe(1);
+	});
+});
+
+describe("RpcClient nodePath / env forwarding", () => {
+	test("defaults the executable to 'node' when nodePath is unset", async () => {
+		const child = makeFakeChild();
+		vi.mocked(spawn).mockReturnValue(child);
+
+		const client = new RpcClient({ cliPath: "dist/cli.js" });
+		await client.start();
+
+		expect(lastSpawnCommand()).toBe("node");
+
+		await client.stop();
+	});
+
+	test("spawns with the provided nodePath executable", async () => {
+		const child = makeFakeChild();
+		vi.mocked(spawn).mockReturnValue(child);
+
+		const client = new RpcClient({ cliPath: "dist/cli.js", nodePath: "/opt/node22/bin/node" });
+		await client.start();
+
+		expect(lastSpawnCommand()).toBe("/opt/node22/bin/node");
+
+		await client.stop();
+	});
+
+	test("merges injected env (e.g. ELECTRON_RUN_AS_NODE) over process.env", async () => {
+		const child = makeFakeChild();
+		vi.mocked(spawn).mockReturnValue(child);
+
+		const client = new RpcClient({
+			cliPath: "dist/cli.js",
+			nodePath: "/path/to/code",
+			env: { ELECTRON_RUN_AS_NODE: "1" },
+		});
+		await client.start();
+
+		const opts = lastSpawnOptions();
+		const env = opts.env as Record<string, string>;
+		expect(env.ELECTRON_RUN_AS_NODE).toBe("1");
+		// Existing process env is still present (merged, not replaced).
+		expect(env.PATH).toBe(process.env.PATH);
+
+		await client.stop();
 	});
 });

--- a/packages/coding-agent/test/shell-env.test.ts
+++ b/packages/coding-agent/test/shell-env.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getShellEnv } from "../src/utils/shell.js";
+
+/**
+ * Regression guard for the ELECTRON_RUN_AS_NODE leak (PR #91, finding 3).
+ *
+ * When the VS Code extension can't find a real Node >=22, it spawns the dreb CLI
+ * via the editor's own Electron binary with ELECTRON_RUN_AS_NODE=1. That flag must
+ * NOT propagate to shell tool commands: otherwise a command like `code .` would run
+ * the Electron binary headless as Node instead of opening an editor window.
+ */
+describe("getShellEnv — ELECTRON_RUN_AS_NODE isolation", () => {
+	const original = process.env.ELECTRON_RUN_AS_NODE;
+
+	beforeEach(() => {
+		process.env.ELECTRON_RUN_AS_NODE = "1";
+	});
+
+	afterEach(() => {
+		if (original === undefined) delete process.env.ELECTRON_RUN_AS_NODE;
+		else process.env.ELECTRON_RUN_AS_NODE = original;
+	});
+
+	it("strips ELECTRON_RUN_AS_NODE from the shell environment", () => {
+		const env = getShellEnv();
+		expect(env.ELECTRON_RUN_AS_NODE).toBeUndefined();
+		expect("ELECTRON_RUN_AS_NODE" in env).toBe(false);
+	});
+
+	it("does not mutate the parent process.env", () => {
+		getShellEnv();
+		expect(process.env.ELECTRON_RUN_AS_NODE).toBe("1");
+	});
+
+	it("still returns a usable PATH", () => {
+		const env = getShellEnv();
+		const pathKey = Object.keys(env).find((k) => k.toLowerCase() === "path");
+		expect(pathKey).toBeDefined();
+		expect(env[pathKey as string]).toBeTruthy();
+	});
+});

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -178,23 +178,48 @@ The message composer can be **dragged taller** so long prompts get more room, up
 ## Requirements
 
 - **VS Code 1.100+** — this is an [ESM extension](https://code.visualstudio.com/updates/v1_100#_esm-support-for-extensions) (`"type": "module"`), which requires the ESM-capable extension host.
-- **Node 22.x** available to the extension host — `RpcClient` spawns `node <cli.js> --mode rpc`.
-- A resolvable dreb CLI (see below).
+- **A built dreb monorepo** — the extension is installed from within your dreb folder, where `@dreb/coding-agent` is already built. `npm run build` at the repo root produces both the extension and the CLI it spawns.
+- **Node 22.x** — the extension resolves a Node ≥ 22 to spawn the CLI (see "Locating the Node runtime"). No global install of `@dreb/coding-agent` and no network are required.
+
+## Installation (from your dreb folder)
+
+This extension is distributed as part of the dreb repo, not as a published `.vsix`. Install it by **symlinking** it into VS Code's extensions directory, so it keeps running from inside the monorepo and resolves `@dreb/coding-agent` straight from the workspace.
+
+```bash
+# from the repo root
+npm run install-vscode        # builds the repo, then links packages/vscode into ~/.vscode/extensions
+```
+
+Then reload the editor (**Developer: Reload Window**) and run **dreb: Open Chat**.
+
+- VS Code Insiders: `node packages/vscode/scripts/install-extension.mjs --insiders`
+- Custom extensions dir: `... --dir <path>`
+- Remove the link: `npm run uninstall-vscode`
+
+Because it's a symlink, rebuilding the repo (`npm run build`) is picked up automatically — no re-install or re-packaging. Installing a **copied** `.vsix` instead detaches the extension from the repo and is not supported (it cannot resolve the CLI or the in-process runtime).
 
 ## Locating the dreb CLI
 
 `RpcClient` spawns the compiled dreb CLI. The host resolves its absolute path in this order:
 
-1. the **`dreb.cliPath`** setting, if set (absolute path to `@dreb/coding-agent`'s `dist/cli.js`);
-2. dependency resolution via the bundled `@dreb/coding-agent` (works out of the box in the F5 dev host).
+1. the **`dreb.cliPath`** setting, if set (absolute path to `packages/coding-agent/dist/cli.js`);
+2. the CLI in the **same monorepo**, resolved relative to the extension's own (symlink-resolved) location — `packages/vscode` → `../coding-agent/dist/cli.js`. This is what a repo-local install uses; no setting needed;
+3. dependency resolution via a resolvable `@dreb/coding-agent` (F5 dev host / non-monorepo fallback).
 
-When running a packaged `.vsix` that does not ship the CLI, set `dreb.cliPath` to a local dreb install's `dist/cli.js`.
+## Locating the Node runtime
+
+A GUI-launched editor (Dock/Finder/Explorer) does not inherit your shell `PATH`, so a bare `node` spawn fails. The host resolves a Node executable in this order:
+
+1. the **`dreb.nodePath`** setting, if set;
+2. the first **Node ≥ 22** found among `PATH` entries, then common install locations (Homebrew, `/usr/local/bin`, nvm versions — newest first);
+3. the **editor's own runtime** (`process.execPath` run as Node via `ELECTRON_RUN_AS_NODE=1`) — always available, so a session can always start.
 
 ## Settings
 
 | Setting | Description |
 | --- | --- |
-| `dreb.cliPath` | Absolute path to the dreb CLI (`dist/cli.js`). Empty = auto-resolve. |
+| `dreb.cliPath` | Absolute path to the dreb CLI (`packages/coding-agent/dist/cli.js`). Empty = auto-resolve (repo-relative, then dependency). |
+| `dreb.nodePath` | Absolute path to a Node ≥ 22 used to spawn the CLI. Empty = auto-resolve (PATH / common locations / editor runtime). |
 | `dreb.provider` | Optional provider passed to dreb (e.g. `anthropic`). |
 | `dreb.model` | Optional model id/pattern passed to dreb. |
 | `dreb.session.idleSleepMinutes` | Minutes a detached + idle session stays alive before sleeping (releasing its RPC child). Reopening before then reattaches losslessly. Default `60`; `0` disables; an invalid value falls back to the default. |
@@ -219,7 +244,7 @@ Then press **F5** ("Run Extension") to launch an Extension Development Host and 
 npm run package          # → dreb-vscode-<version>.vsix (via @vscode/vsce)
 ```
 
-Install the `.vsix` with `code --install-extension dreb-vscode-<version>.vsix`.
+A packaged `.vsix` is a **copied**, repo-detached artifact: it ships no `node_modules` and cannot resolve the CLI or the in-process runtime, so `code --install-extension` is not the supported install path. Use the repo-local symlink install (see [Installation](#installation-from-your-dreb-folder)) instead.
 
 ## Testing notes
 

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -170,7 +170,12 @@
 				"dreb.cliPath": {
 					"type": "string",
 					"default": "",
-					"markdownDescription": "Absolute path to the dreb CLI entry point (`dist/cli.js`). Leave empty to auto-resolve the bundled `@dreb/coding-agent`. Required when running a packaged `.vsix` that does not ship the CLI."
+					"markdownDescription": "Absolute path to the dreb CLI entry point (`packages/coding-agent/dist/cli.js`). Leave empty to auto-resolve: the extension uses the CLI in the same dreb monorepo it is installed from, else the resolvable `@dreb/coding-agent` dependency."
+				},
+				"dreb.nodePath": {
+					"type": "string",
+					"default": "",
+					"markdownDescription": "Absolute path to a Node.js executable (>= 22) used to spawn the dreb CLI. Leave empty to auto-resolve: a Node >= 22 from `PATH` or a common install location, else the editor's own runtime. Set this if a GUI-launched editor cannot find your Node install."
 				},
 				"dreb.provider": {
 					"type": "string",

--- a/packages/vscode/scripts/install-extension.d.mts
+++ b/packages/vscode/scripts/install-extension.d.mts
@@ -11,3 +11,28 @@ export function installPlan(opts: {
 export function parseArgs(argv: string[]): { insiders: boolean; dir: string | undefined };
 
 export function removeExisting(linkPath: string, log?: (msg: string) => void): void;
+
+export function safeReadlink(p: string): string | undefined;
+
+export function isDirectRun(importMetaUrl: string, argv1?: string): boolean;
+
+export interface RunInstallDeps {
+	pkgRoot: string;
+	pkg: { publisher?: string; name: string };
+	extDir: string;
+	fileExists?: (path: string) => boolean;
+	makeDir?: (dir: string) => void;
+	isLink?: (path: string) => boolean;
+	readLink?: (path: string) => string | undefined;
+	createSymlink?: (target: string, link: string) => void;
+	remove?: (linkPath: string, log?: (msg: string) => void) => void;
+	log?: (msg: string) => void;
+	error?: (msg: string) => void;
+	exit?: (code: number) => void;
+}
+
+export type RunInstallResult =
+	| { ok: false; reason: "missing-build"; missing: string[] }
+	| { ok: true; reason: "already-linked" | "linked"; linkPath: string; targetPath: string };
+
+export function runInstall(deps: RunInstallDeps): RunInstallResult;

--- a/packages/vscode/scripts/install-extension.d.mts
+++ b/packages/vscode/scripts/install-extension.d.mts
@@ -1,0 +1,13 @@
+export function extensionsDir(opts?: { home?: string; insiders?: boolean; override?: string }): string;
+
+export function linkName(pkg: { publisher?: string; name: string }): string;
+
+export function installPlan(opts: {
+	extDir: string;
+	pkg: { publisher?: string; name: string };
+	target: string;
+}): { linkPath: string; targetPath: string };
+
+export function parseArgs(argv: string[]): { insiders: boolean; dir: string | undefined };
+
+export function removeExisting(linkPath: string, log?: (msg: string) => void): void;

--- a/packages/vscode/scripts/install-extension.d.mts
+++ b/packages/vscode/scripts/install-extension.d.mts
@@ -12,6 +12,8 @@ export function parseArgs(argv: string[]): { insiders: boolean; dir: string | un
 
 export function removeExisting(linkPath: string, log?: (msg: string) => void): void;
 
+export function isSymlink(p: string): boolean;
+
 export function safeReadlink(p: string): string | undefined;
 
 export function isDirectRun(importMetaUrl: string, argv1?: string): boolean;

--- a/packages/vscode/scripts/install-extension.mjs
+++ b/packages/vscode/scripts/install-extension.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+/**
+ * Repo-local install for the dreb VSCode extension.
+ *
+ * Distribution model: the repo itself, not a shipped `.vsix`. This **symlinks**
+ * `packages/vscode` into the editor's extensions directory so the extension runs
+ * from inside the monorepo — Node then resolves `@dreb/coding-agent` (the CLI +
+ * in-process `RpcClient`/`SessionManager`) straight from the workspace, with no
+ * copy, no global install, and no network.
+ *
+ * Usage (from the repo root):
+ *   npm run install-vscode            # build the repo, then link into ~/.vscode
+ *   node packages/vscode/scripts/install-extension.mjs [--insiders] [--dir <path>]
+ *
+ * The pure helpers are exported for unit tests; `main()` runs only when the file
+ * is executed directly.
+ */
+
+import { existsSync, lstatSync, mkdirSync, readlinkSync, rmSync, symlinkSync } from "node:fs";
+import { createRequire } from "node:module";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// ---------------------------------------------------------------------------
+// Pure helpers (unit-tested; no side effects)
+// ---------------------------------------------------------------------------
+
+/** The editor's extensions directory. Stable/VS Code Insiders, or an override. */
+export function extensionsDir({ home = homedir(), insiders = false, override } = {}) {
+	if (override) return override;
+	return join(home, insiders ? ".vscode-insiders" : ".vscode", "extensions");
+}
+
+/** Stable link folder name derived from the manifest (`<publisher>.<name>`). */
+export function linkName(pkg) {
+	const publisher = pkg.publisher ?? "unknown";
+	return `${publisher}.${pkg.name}`;
+}
+
+/** Absolute link path + symlink target for an install. */
+export function installPlan({ extDir, pkg, target }) {
+	return { linkPath: join(extDir, linkName(pkg)), targetPath: target };
+}
+
+/** Parse the supported flags: `--insiders` and `--dir <path>`. */
+export function parseArgs(argv) {
+	const out = { insiders: false, dir: undefined };
+	for (let i = 0; i < argv.length; i++) {
+		if (argv[i] === "--insiders") out.insiders = true;
+		else if (argv[i] === "--dir") out.dir = argv[++i];
+	}
+	return out;
+}
+
+// ---------------------------------------------------------------------------
+// Side-effecting install
+// ---------------------------------------------------------------------------
+
+/** Remove an existing link/dir at `linkPath`. Symlinks are unlinked; a real
+ * directory (e.g. a stale copied `.vsix` install) is removed with a warning. */
+export function removeExisting(linkPath, log = console.log) {
+	if (!existsSync(linkPath) && !isSymlink(linkPath)) return;
+	if (isSymlink(linkPath)) {
+		rmSync(linkPath);
+		return;
+	}
+	log(`Replacing existing non-symlink install at ${linkPath}`);
+	rmSync(linkPath, { recursive: true, force: true });
+}
+
+function isSymlink(p) {
+	try {
+		return lstatSync(p).isSymbolicLink();
+	} catch {
+		return false;
+	}
+}
+
+function pkgRootDir() {
+	// scripts/ -> packages/vscode
+	return resolve(dirname(fileURLToPath(import.meta.url)), "..");
+}
+
+function main() {
+	const pkgRoot = pkgRootDir();
+	const require = createRequire(import.meta.url);
+	const pkg = require(join(pkgRoot, "package.json"));
+
+	// Prerequisites: both the extension host and the sibling CLI must be built.
+	const hostEntry = join(pkgRoot, "dist", "host", "extension.js");
+	const cliEntry = resolve(pkgRoot, "..", "coding-agent", "dist", "cli.js");
+	const missing = [hostEntry, cliEntry].filter((p) => !existsSync(p));
+	if (missing.length > 0) {
+		console.error("dreb: build outputs missing — run `npm run build` at the repo root first.");
+		for (const m of missing) console.error(`  missing: ${m}`);
+		process.exit(1);
+	}
+
+	const args = parseArgs(process.argv.slice(2));
+	const extDir = extensionsDir({ insiders: args.insiders, override: args.dir });
+	mkdirSync(extDir, { recursive: true });
+
+	const { linkPath, targetPath } = installPlan({ extDir, pkg, target: pkgRoot });
+
+	// Idempotent: if already linked to this target, nothing to do.
+	if (isSymlink(linkPath) && safeReadlink(linkPath) === targetPath) {
+		console.log(`Already linked: ${linkPath} -> ${targetPath}`);
+	} else {
+		removeExisting(linkPath);
+		symlinkSync(targetPath, linkPath, "dir");
+		console.log(`Linked ${linkPath} -> ${targetPath}`);
+	}
+	console.log('Reload the editor ("Developer: Reload Window") to activate the extension.');
+}
+
+function safeReadlink(p) {
+	try {
+		return readlinkSync(p);
+	} catch {
+		return undefined;
+	}
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) main();

--- a/packages/vscode/scripts/install-extension.mjs
+++ b/packages/vscode/scripts/install-extension.mjs
@@ -72,7 +72,10 @@ export function removeExisting(linkPath, log = console.log) {
 	rmSync(linkPath, { recursive: true, force: true });
 }
 
-function isSymlink(p) {
+/** True when `p` is a symlink (broken or not). Uses `lstat`, so — unlike
+ * `existsSync` — it does not follow the link and correctly detects a dangling
+ * symlink whose target no longer exists. */
+export function isSymlink(p) {
 	try {
 		return lstatSync(p).isSymbolicLink();
 	} catch {

--- a/packages/vscode/scripts/install-extension.mjs
+++ b/packages/vscode/scripts/install-extension.mjs
@@ -16,11 +16,11 @@
  * is executed directly.
  */
 
-import { existsSync, lstatSync, mkdirSync, readlinkSync, rmSync, symlinkSync } from "node:fs";
+import { existsSync, lstatSync, mkdirSync, readlinkSync, realpathSync, rmSync, symlinkSync } from "node:fs";
 import { createRequire } from "node:module";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 // ---------------------------------------------------------------------------
 // Pure helpers (unit-tested; no side effects)
@@ -60,11 +60,14 @@ export function parseArgs(argv) {
 /** Remove an existing link/dir at `linkPath`. Symlinks are unlinked; a real
  * directory (e.g. a stale copied `.vsix` install) is removed with a warning. */
 export function removeExisting(linkPath, log = console.log) {
-	if (!existsSync(linkPath) && !isSymlink(linkPath)) return;
+	// Symlink (valid or broken) — unlink it; the real target is untouched.
 	if (isSymlink(linkPath)) {
 		rmSync(linkPath);
 		return;
 	}
+	// Nothing there.
+	if (!existsSync(linkPath)) return;
+	// A real directory (e.g. a stale copied .vsix install) — remove with a warning.
 	log(`Replacing existing non-symlink install at ${linkPath}`);
 	rmSync(linkPath, { recursive: true, force: true });
 }
@@ -82,39 +85,65 @@ function pkgRootDir() {
 	return resolve(dirname(fileURLToPath(import.meta.url)), "..");
 }
 
+/**
+ * Core install logic, with every side effect injectable so it can be unit-tested
+ * without touching the real filesystem or exiting the process. Verifies the build
+ * prerequisites, is idempotent (no-op when already linked to the same target), and
+ * otherwise (re)creates the symlink.
+ */
+export function runInstall({
+	pkgRoot,
+	pkg,
+	extDir,
+	fileExists = existsSync,
+	makeDir = (d) => mkdirSync(d, { recursive: true }),
+	isLink = isSymlink,
+	readLink = safeReadlink,
+	createSymlink = (target, link) => symlinkSync(target, link, "dir"),
+	remove = removeExisting,
+	log = console.log,
+	error = console.error,
+	exit = process.exit,
+}) {
+	// Prerequisites: both the extension host and the sibling CLI must be built.
+	const hostEntry = join(pkgRoot, "dist", "host", "extension.js");
+	const cliEntry = resolve(pkgRoot, "..", "coding-agent", "dist", "cli.js");
+	const missing = [hostEntry, cliEntry].filter((p) => !fileExists(p));
+	if (missing.length > 0) {
+		error("dreb: build outputs missing — run `npm run build` at the repo root first.");
+		for (const m of missing) error(`  missing: ${m}`);
+		exit(1);
+		return { ok: false, reason: "missing-build", missing };
+	}
+
+	makeDir(extDir);
+	const { linkPath, targetPath } = installPlan({ extDir, pkg, target: pkgRoot });
+
+	// Idempotent: if already linked to this target, nothing to do.
+	if (isLink(linkPath) && readLink(linkPath) === targetPath) {
+		log(`Already linked: ${linkPath} -> ${targetPath}`);
+		log('Reload the editor ("Developer: Reload Window") to activate the extension.');
+		return { ok: true, reason: "already-linked", linkPath, targetPath };
+	}
+
+	remove(linkPath);
+	createSymlink(targetPath, linkPath);
+	log(`Linked ${linkPath} -> ${targetPath}`);
+	log('Reload the editor ("Developer: Reload Window") to activate the extension.');
+	return { ok: true, reason: "linked", linkPath, targetPath };
+}
+
 function main() {
 	const pkgRoot = pkgRootDir();
 	const require = createRequire(import.meta.url);
 	const pkg = require(join(pkgRoot, "package.json"));
-
-	// Prerequisites: both the extension host and the sibling CLI must be built.
-	const hostEntry = join(pkgRoot, "dist", "host", "extension.js");
-	const cliEntry = resolve(pkgRoot, "..", "coding-agent", "dist", "cli.js");
-	const missing = [hostEntry, cliEntry].filter((p) => !existsSync(p));
-	if (missing.length > 0) {
-		console.error("dreb: build outputs missing — run `npm run build` at the repo root first.");
-		for (const m of missing) console.error(`  missing: ${m}`);
-		process.exit(1);
-	}
-
 	const args = parseArgs(process.argv.slice(2));
 	const extDir = extensionsDir({ insiders: args.insiders, override: args.dir });
-	mkdirSync(extDir, { recursive: true });
-
-	const { linkPath, targetPath } = installPlan({ extDir, pkg, target: pkgRoot });
-
-	// Idempotent: if already linked to this target, nothing to do.
-	if (isSymlink(linkPath) && safeReadlink(linkPath) === targetPath) {
-		console.log(`Already linked: ${linkPath} -> ${targetPath}`);
-	} else {
-		removeExisting(linkPath);
-		symlinkSync(targetPath, linkPath, "dir");
-		console.log(`Linked ${linkPath} -> ${targetPath}`);
-	}
-	console.log('Reload the editor ("Developer: Reload Window") to activate the extension.');
+	runInstall({ pkgRoot, pkg, extDir });
 }
 
-function safeReadlink(p) {
+/** Read a symlink target, or `undefined` if the path is not a readable symlink. */
+export function safeReadlink(p) {
 	try {
 		return readlinkSync(p);
 	} catch {
@@ -122,4 +151,25 @@ function safeReadlink(p) {
 	}
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) main();
+/**
+ * True when this module is the process entry point (run directly, not imported).
+ *
+ * A naive `import.meta.url === \`file://${process.argv[1]}\`` breaks two ways:
+ *   - `import.meta.url` is a percent-encoded file URL while `process.argv[1]` is a
+ *     raw path, so any space or special char (e.g. `~/My Projects/dreb`) fails to
+ *     match — the script then silently does nothing and exits 0; and
+ *   - Node realpath-resolves `import.meta.url` but not `process.argv[1]`, so a
+ *     symlinked path component (common: macOS `/tmp` -> `/private/tmp`) also fails.
+ * Comparing canonical, realpath-resolved file URLs handles both.
+ */
+export function isDirectRun(importMetaUrl, argv1 = process.argv[1]) {
+	if (!argv1) return false;
+	try {
+		if (importMetaUrl === pathToFileURL(realpathSync(argv1)).href) return true;
+	} catch {
+		// realpath can throw (e.g. argv1 no longer exists); fall back to the raw path.
+	}
+	return importMetaUrl === pathToFileURL(argv1).href;
+}
+
+if (isDirectRun(import.meta.url)) main();

--- a/packages/vscode/scripts/uninstall-extension.mjs
+++ b/packages/vscode/scripts/uninstall-extension.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+/**
+ * Remove a repo-local install of the dreb VSCode extension (the symlink created
+ * by `install-extension.mjs`).
+ *
+ * Usage (from the repo root):
+ *   npm run uninstall-vscode
+ *   node packages/vscode/scripts/uninstall-extension.mjs [--insiders] [--dir <path>]
+ */
+
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { extensionsDir, installPlan, parseArgs, removeExisting } from "./install-extension.mjs";
+
+function main() {
+	const pkgRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+	const require = createRequire(import.meta.url);
+	const pkg = require(join(pkgRoot, "package.json"));
+
+	const args = parseArgs(process.argv.slice(2));
+	const extDir = extensionsDir({ insiders: args.insiders, override: args.dir });
+	const { linkPath } = installPlan({ extDir, pkg, target: pkgRoot });
+
+	if (!existsSync(linkPath)) {
+		console.log(`Nothing to remove: ${linkPath} does not exist.`);
+		return;
+	}
+	removeExisting(linkPath);
+	console.log(`Removed ${linkPath}`);
+	console.log('Reload the editor ("Developer: Reload Window") to deactivate the extension.');
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) main();

--- a/packages/vscode/scripts/uninstall-extension.mjs
+++ b/packages/vscode/scripts/uninstall-extension.mjs
@@ -12,7 +12,7 @@ import { existsSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { extensionsDir, installPlan, parseArgs, removeExisting } from "./install-extension.mjs";
+import { extensionsDir, installPlan, isDirectRun, parseArgs, removeExisting } from "./install-extension.mjs";
 
 function main() {
 	const pkgRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -32,4 +32,5 @@ function main() {
 	console.log('Reload the editor ("Developer: Reload Window") to deactivate the extension.');
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) main();
+// Run only when executed directly (see isDirectRun in install-extension.mjs).
+if (isDirectRun(import.meta.url)) main();

--- a/packages/vscode/scripts/uninstall-extension.mjs
+++ b/packages/vscode/scripts/uninstall-extension.mjs
@@ -12,7 +12,7 @@ import { existsSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { extensionsDir, installPlan, isDirectRun, parseArgs, removeExisting } from "./install-extension.mjs";
+import { extensionsDir, installPlan, isDirectRun, isSymlink, parseArgs, removeExisting } from "./install-extension.mjs";
 
 function main() {
 	const pkgRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -23,7 +23,11 @@ function main() {
 	const extDir = extensionsDir({ insiders: args.insiders, override: args.dir });
 	const { linkPath } = installPlan({ extDir, pkg, target: pkgRoot });
 
-	if (!existsSync(linkPath)) {
+	// Check the link's own existence with `isSymlink` (lstat-based), not
+	// `existsSync`, which follows the symlink: after the user moves or deletes
+	// their dreb repo the link is dangling, and `existsSync` would report it as
+	// gone — silently leaving the broken extension entry behind.
+	if (!isSymlink(linkPath) && !existsSync(linkPath)) {
 		console.log(`Nothing to remove: ${linkPath} does not exist.`);
 		return;
 	}

--- a/packages/vscode/src/host/cli-path.ts
+++ b/packages/vscode/src/host/cli-path.ts
@@ -72,7 +72,7 @@ export function resolveCliPath(sources: CliPathSources = {}): CliPathResult {
 }
 
 /** `packages/vscode` -> `packages/coding-agent/dist/cli.js` (sibling package). */
-function repoRelativeCliPath(extensionDir: string): string {
+export function repoRelativeCliPath(extensionDir: string): string {
 	return join(extensionDir, "..", "coding-agent", "dist", "cli.js");
 }
 
@@ -82,7 +82,7 @@ function repoRelativeCliPath(extensionDir: string): string {
  * hops land on `packages/vscode`. Under a symlinked repo-local install Node
  * resolves real paths, so this lands inside the actual repo.
  */
-function defaultExtensionDir(): string | undefined {
+export function defaultExtensionDir(): string | undefined {
 	try {
 		const here = fileURLToPath(import.meta.url); // .../packages/vscode/dist/host/cli-path.js
 		return dirname(dirname(dirname(here))); // .../packages/vscode

--- a/packages/vscode/src/host/cli-path.ts
+++ b/packages/vscode/src/host/cli-path.ts
@@ -3,10 +3,14 @@
  * `RpcClient` spawns as `node <cliPath> --mode rpc`. `RpcClient` defaults to a
  * cwd-relative `"dist/cli.js"`, so the host must always pass an absolute path.
  *
- * Precedence (mirrors the plan's layered resolution):
- *   1. the `dreb.cliPath` setting (explicit override, required for packaged
- *      `.vsix` installs that do not ship the CLI on disk);
- *   2. dependency resolution via `@dreb/coding-agent`'s package entry.
+ * Precedence (repo-as-distribution: the extension is installed from within a
+ * user's dreb monorepo, where a built `@dreb/coding-agent` already exists):
+ *   1. the `dreb.cliPath` setting (explicit override);
+ *   2. the CLI shipped in the same monorepo, resolved relative to this
+ *      extension's own location (`packages/vscode` -> `../coding-agent/dist/cli.js`).
+ *      This is deterministic and does not depend on `node_modules` layout, so a
+ *      symlinked repo-local install "just works" with no setting;
+ *   3. dependency resolution via `@dreb/coding-agent`'s package entry (dev fallback).
  *
  * All I/O is injectable so the precedence logic is unit-testable without a real
  * filesystem or a resolvable dependency.
@@ -19,17 +23,24 @@ import { fileURLToPath } from "node:url";
 export interface CliPathSources {
 	/** The `dreb.cliPath` setting value; empty/whitespace means unset. */
 	configuredPath?: string;
+	/** This extension's own directory (`packages/vscode`), used to resolve the
+	 * sibling `packages/coding-agent/dist/cli.js` in the same monorepo. Defaults
+	 * to a location derived from this module's URL. */
+	extensionDir?: string;
 	/** Directory that should contain `cli.js` (defaults to dependency resolution). */
 	resolveCliDir?: () => string | undefined;
 	/** Existence probe (defaults to `fs.existsSync`). */
 	fileExists?: (path: string) => boolean;
 }
 
-export type CliPathResult = { ok: true; path: string; source: "setting" | "dependency" } | { ok: false; error: string };
+export type CliPathResult =
+	| { ok: true; path: string; source: "setting" | "repo" | "dependency" }
+	| { ok: false; error: string };
 
 export function resolveCliPath(sources: CliPathSources = {}): CliPathResult {
 	const exists = sources.fileExists ?? existsSync;
 
+	// 1. Explicit setting wins when it points at a real file.
 	const configured = sources.configuredPath?.trim();
 	if (configured) {
 		if (exists(configured)) return { ok: true, path: configured, source: "setting" };
@@ -39,6 +50,14 @@ export function resolveCliPath(sources: CliPathSources = {}): CliPathResult {
 		};
 	}
 
+	// 2. Sibling CLI in the same monorepo, resolved relative to this extension.
+	const extensionDir = sources.extensionDir ?? defaultExtensionDir();
+	if (extensionDir) {
+		const candidate = repoRelativeCliPath(extensionDir);
+		if (exists(candidate)) return { ok: true, path: candidate, source: "repo" };
+	}
+
+	// 3. Dependency resolution (dev / non-monorepo fallback).
 	const resolveCliDir = sources.resolveCliDir ?? defaultResolveCliDir;
 	const dir = resolveCliDir();
 	if (dir) {
@@ -48,8 +67,28 @@ export function resolveCliPath(sources: CliPathSources = {}): CliPathResult {
 
 	return {
 		ok: false,
-		error: 'Could not locate the dreb CLI. Ensure @dreb/coding-agent is installed, or set the "dreb.cliPath" setting to the absolute path of its dist/cli.js.',
+		error: 'Could not locate the dreb CLI. Install the extension from within your dreb folder (run the repo-local install), or set the "dreb.cliPath" setting to the absolute path of packages/coding-agent/dist/cli.js.',
 	};
+}
+
+/** `packages/vscode` -> `packages/coding-agent/dist/cli.js` (sibling package). */
+function repoRelativeCliPath(extensionDir: string): string {
+	return join(extensionDir, "..", "coding-agent", "dist", "cli.js");
+}
+
+/**
+ * Derive this extension's directory from the compiled module location. At
+ * runtime this file is `packages/vscode/dist/host/cli-path.js`, so three parent
+ * hops land on `packages/vscode`. Under a symlinked repo-local install Node
+ * resolves real paths, so this lands inside the actual repo.
+ */
+function defaultExtensionDir(): string | undefined {
+	try {
+		const here = fileURLToPath(import.meta.url); // .../packages/vscode/dist/host/cli-path.js
+		return dirname(dirname(dirname(here))); // .../packages/vscode
+	} catch {
+		return undefined;
+	}
 }
 
 /**

--- a/packages/vscode/src/host/extension.ts
+++ b/packages/vscode/src/host/extension.ts
@@ -21,7 +21,8 @@ import type { LiveSessionInput } from "../shared/session-list.js";
 import { formatTabTitle } from "../shared/tab-title.js";
 import { buildArgs } from "./build-args.js";
 import { resolveCliPath } from "./cli-path.js";
-import { MIN_NODE_MAJOR, resolveNodePath } from "./node-path.js";
+import type { resolveNodePath } from "./node-path.js";
+import { createNodeRuntimeCacheState, resolveNodeRuntimeCached } from "./node-runtime-cache.js";
 import type { ReviewUi } from "./review-ui.js";
 import { SessionController } from "./session-controller.js";
 import { SessionFlagsStore } from "./session-flags.js";
@@ -571,13 +572,10 @@ function extensionDirReal(): string | undefined {
  * the editor's own runtime). Centralized so every controller call site stays in
  * sync.
  *
- * The Node result is cached (keyed by the `dreb.nodePath` setting) because
- * resolving it spawns a synchronous `node --version` probe per candidate; without
- * caching, every `createSession`/`renameSession` would re-probe and could briefly
- * stall the extension host. The cache is invalidated when the setting changes.
+ * The Node runtime resolution (cache invalidation + one-time older-runtime
+ * warning) lives in the pure, unit-tested `node-runtime-cache` module.
  */
-let nodeRuntimeCache: { key: string; result: ReturnType<typeof resolveNodePath> } | undefined;
-let warnedElectronNodeVersion = false;
+const nodeRuntimeCacheState = createNodeRuntimeCacheState();
 
 function resolveRuntime(config: vscode.WorkspaceConfiguration): {
 	cli: ReturnType<typeof resolveCliPath>;
@@ -588,21 +586,10 @@ function resolveRuntime(config: vscode.WorkspaceConfiguration): {
 		extensionDir: extensionDirReal(),
 	});
 
-	const configuredNode = config.get<string>("nodePath") ?? "";
-	if (nodeRuntimeCache?.key !== configuredNode) {
-		nodeRuntimeCache = { key: configuredNode, result: resolveNodePath({ configuredPath: configuredNode }) };
-	}
-	const node = nodeRuntimeCache.result;
-
-	// The Electron fallback is not version-gated (it must always yield a runnable
-	// executable), but the CLI targets Node >=22. Warn once if the editor's own
-	// runtime is older, so a subtle version mismatch is diagnosable.
-	if (node.source === "electron" && node.major != null && node.major < MIN_NODE_MAJOR && !warnedElectronNodeVersion) {
-		warnedElectronNodeVersion = true;
-		vscode.window.showWarningMessage(
-			`dreb: no Node ${MIN_NODE_MAJOR}+ found on PATH; falling back to the editor's Node ${node.major} runtime, which is older than dreb requires. Set "dreb.nodePath" to a Node ${MIN_NODE_MAJOR}+ executable if you hit runtime errors.`,
-		);
-	}
+	const node = resolveNodeRuntimeCached(nodeRuntimeCacheState, {
+		configuredNodePath: config.get<string>("nodePath") ?? "",
+		warn: (message) => vscode.window.showWarningMessage(message),
+	});
 
 	return { cli, node };
 }

--- a/packages/vscode/src/host/extension.ts
+++ b/packages/vscode/src/host/extension.ts
@@ -13,6 +13,7 @@
  */
 
 import { randomUUID } from "node:crypto";
+import { realpathSync } from "node:fs";
 import { homedir } from "node:os";
 import { relative, sep } from "node:path";
 import * as vscode from "vscode";
@@ -20,6 +21,7 @@ import type { LiveSessionInput } from "../shared/session-list.js";
 import { formatTabTitle } from "../shared/tab-title.js";
 import { buildArgs } from "./build-args.js";
 import { resolveCliPath } from "./cli-path.js";
+import { resolveNodePath } from "./node-path.js";
 import type { ReviewUi } from "./review-ui.js";
 import { SessionController } from "./session-controller.js";
 import { SessionFlagsStore } from "./session-flags.js";
@@ -292,12 +294,14 @@ function selectionTagDeps(open: () => Promise<ChatSession | undefined>): TagSele
 function createSession(context: vscode.ExtensionContext, key: string, sessionPath?: string): ChatSession {
 	const config = vscode.workspace.getConfiguration("dreb");
 	const cwd = workspaceCwd();
-	const cli = resolveCliPath({ configuredPath: config.get<string>("cliPath") });
+	const { cli, node } = resolveRuntime(config);
 
 	const reviewUi = createVscodeReviewUi(cwd);
 	const controller = new SessionController({
 		cwd,
 		cliPath: cli.ok ? cli.path : "",
+		nodePath: node.nodePath,
+		env: node.env,
 		args: buildArgs(config),
 		sessionPath,
 		ui: createVscodeHostUi(),
@@ -480,7 +484,7 @@ async function renameSession(key: string, name: string): Promise<void> {
 	const all = await inventory.listAll();
 	const cwd = all.find((s) => s.path === path)?.cwd ?? workspaceCwd();
 	const config = vscode.workspace.getConfiguration("dreb");
-	const cli = resolveCliPath({ configuredPath: config.get<string>("cliPath") });
+	const { cli, node } = resolveRuntime(config);
 	if (!cli.ok) {
 		vscode.window.showErrorMessage(`dreb: cannot rename — ${cli.error}`);
 		return;
@@ -488,6 +492,8 @@ async function renameSession(key: string, name: string): Promise<void> {
 	const controller = new SessionController({
 		cwd,
 		cliPath: cli.path,
+		nodePath: node.nodePath,
+		env: node.env,
 		args: buildArgs(config),
 		sessionPath: path,
 		logger: (line) => console.warn(`[dreb] ${line}`),
@@ -536,6 +542,45 @@ async function deleteSession(key: string): Promise<void> {
 
 function workspaceCwd(): string {
 	return vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? homedir();
+}
+
+/** Cached real (symlink-resolved) directory of this extension's install. */
+let extensionRealDirCache: string | undefined;
+
+/**
+ * This extension's own directory with symlinks resolved. A repo-local install
+ * symlinks `packages/vscode` into `~/.vscode/extensions`, so `extensionUri.fsPath`
+ * is the symlink; `realpath` yields the actual monorepo path, which repo-relative
+ * CLI resolution needs to reach the sibling `packages/coding-agent`.
+ */
+function extensionDirReal(): string | undefined {
+	if (extensionRealDirCache) return extensionRealDirCache;
+	const raw = extensionContext?.extensionUri.fsPath;
+	if (!raw) return undefined;
+	try {
+		extensionRealDirCache = realpathSync(raw);
+	} catch {
+		extensionRealDirCache = raw;
+	}
+	return extensionRealDirCache;
+}
+
+/**
+ * Resolve the runtime a session needs: the CLI entry point (repo-relative by
+ * default) and the Node executable to spawn it with (a discovered Node >=22 or
+ * the editor's own runtime). Centralized so every controller call site stays in
+ * sync.
+ */
+function resolveRuntime(config: vscode.WorkspaceConfiguration): {
+	cli: ReturnType<typeof resolveCliPath>;
+	node: ReturnType<typeof resolveNodePath>;
+} {
+	const cli = resolveCliPath({
+		configuredPath: config.get<string>("cliPath"),
+		extensionDir: extensionDirReal(),
+	});
+	const node = resolveNodePath({ configuredPath: config.get<string>("nodePath") });
+	return { cli, node };
 }
 
 function makeNonce(): string {

--- a/packages/vscode/src/host/extension.ts
+++ b/packages/vscode/src/host/extension.ts
@@ -21,7 +21,7 @@ import type { LiveSessionInput } from "../shared/session-list.js";
 import { formatTabTitle } from "../shared/tab-title.js";
 import { buildArgs } from "./build-args.js";
 import { resolveCliPath } from "./cli-path.js";
-import { resolveNodePath } from "./node-path.js";
+import { MIN_NODE_MAJOR, resolveNodePath } from "./node-path.js";
 import type { ReviewUi } from "./review-ui.js";
 import { SessionController } from "./session-controller.js";
 import { SessionFlagsStore } from "./session-flags.js";
@@ -570,7 +570,15 @@ function extensionDirReal(): string | undefined {
  * default) and the Node executable to spawn it with (a discovered Node >=22 or
  * the editor's own runtime). Centralized so every controller call site stays in
  * sync.
+ *
+ * The Node result is cached (keyed by the `dreb.nodePath` setting) because
+ * resolving it spawns a synchronous `node --version` probe per candidate; without
+ * caching, every `createSession`/`renameSession` would re-probe and could briefly
+ * stall the extension host. The cache is invalidated when the setting changes.
  */
+let nodeRuntimeCache: { key: string; result: ReturnType<typeof resolveNodePath> } | undefined;
+let warnedElectronNodeVersion = false;
+
 function resolveRuntime(config: vscode.WorkspaceConfiguration): {
 	cli: ReturnType<typeof resolveCliPath>;
 	node: ReturnType<typeof resolveNodePath>;
@@ -579,7 +587,23 @@ function resolveRuntime(config: vscode.WorkspaceConfiguration): {
 		configuredPath: config.get<string>("cliPath"),
 		extensionDir: extensionDirReal(),
 	});
-	const node = resolveNodePath({ configuredPath: config.get<string>("nodePath") });
+
+	const configuredNode = config.get<string>("nodePath") ?? "";
+	if (nodeRuntimeCache?.key !== configuredNode) {
+		nodeRuntimeCache = { key: configuredNode, result: resolveNodePath({ configuredPath: configuredNode }) };
+	}
+	const node = nodeRuntimeCache.result;
+
+	// The Electron fallback is not version-gated (it must always yield a runnable
+	// executable), but the CLI targets Node >=22. Warn once if the editor's own
+	// runtime is older, so a subtle version mismatch is diagnosable.
+	if (node.source === "electron" && node.major != null && node.major < MIN_NODE_MAJOR && !warnedElectronNodeVersion) {
+		warnedElectronNodeVersion = true;
+		vscode.window.showWarningMessage(
+			`dreb: no Node ${MIN_NODE_MAJOR}+ found on PATH; falling back to the editor's Node ${node.major} runtime, which is older than dreb requires. Set "dreb.nodePath" to a Node ${MIN_NODE_MAJOR}+ executable if you hit runtime errors.`,
+		);
+	}
+
 	return { cli, node };
 }
 

--- a/packages/vscode/src/host/node-path.ts
+++ b/packages/vscode/src/host/node-path.ts
@@ -32,8 +32,9 @@ export interface NodePathSources {
 	/** Existence probe (defaults to `fs.existsSync`). */
 	fileExists?: (path: string) => boolean;
 	/** Return the major version of a Node executable, or `undefined` if it cannot
-	 * be run / parsed (defaults to executing `<nodePath> --version`). */
-	probeVersion?: (nodePath: string) => number | undefined;
+	 * be run / parsed (defaults to executing `<nodePath> --version`). An optional
+	 * env is merged for the probe (used to pass `ELECTRON_RUN_AS_NODE=1`). */
+	probeVersion?: (nodePath: string, extraEnv?: Record<string, string>) => number | undefined;
 	/** Ordered, highest-priority-first list of candidate Node executables
 	 * (defaults to PATH entries then common install locations). */
 	candidatePaths?: () => string[];
@@ -52,6 +53,11 @@ export type NodePathResult = {
 	env?: Record<string, string>;
 	/** Which rung of the precedence ladder produced the result. */
 	source: "setting" | "discovered" | "electron";
+	/** The resolved runtime's major version, when it could be determined. For the
+	 * Electron fallback this lets the host warn when the editor runtime is older
+	 * than {@link MIN_NODE_MAJOR} (it is not version-gated, since it is the
+	 * last-resort rung that must always produce a runnable executable). */
+	major?: number;
 };
 
 export function resolveNodePath(sources: NodePathSources = {}): NodePathResult {
@@ -72,22 +78,35 @@ export function resolveNodePath(sources: NodePathSources = {}): NodePathResult {
 		if (!exists(candidate)) continue;
 		const major = probe(candidate);
 		if (major != null && major >= MIN_NODE_MAJOR) {
-			return { nodePath: candidate, source: "discovered" };
+			return { nodePath: candidate, source: "discovered", major };
 		}
 	}
 
 	// 3. Editor runtime as plain Node — always present, so resolution never fails.
+	// Probe its version (via ELECTRON_RUN_AS_NODE so the Electron binary reports
+	// Node's version instead of launching a GUI) so the host can warn if it is
+	// older than MIN_NODE_MAJOR. This rung is intentionally NOT version-gated.
+	const execPath = sources.execPath ?? process.execPath;
+	const electronEnv = { ELECTRON_RUN_AS_NODE: "1" };
+	const major = probe(execPath, electronEnv);
 	return {
-		nodePath: sources.execPath ?? process.execPath,
-		env: { ELECTRON_RUN_AS_NODE: "1" },
+		nodePath: execPath,
+		env: electronEnv,
 		source: "electron",
+		...(major != null ? { major } : {}),
 	};
 }
 
-/** Run `<nodePath> --version` and parse the major version (e.g. `v22.3.1` -> 22). */
-function defaultProbeVersion(nodePath: string): number | undefined {
+/** Run `<nodePath> --version` and parse the major version (e.g. `v22.3.1` -> 22).
+ * `extraEnv` is merged into the child (used to pass `ELECTRON_RUN_AS_NODE=1` when
+ * probing the editor's own Electron binary). */
+export function defaultProbeVersion(nodePath: string, extraEnv?: Record<string, string>): number | undefined {
 	try {
-		const out = execFileSync(nodePath, ["--version"], { encoding: "utf8", timeout: 3000 }).trim();
+		const out = execFileSync(nodePath, ["--version"], {
+			encoding: "utf8",
+			timeout: 3000,
+			...(extraEnv ? { env: { ...process.env, ...extraEnv } } : {}),
+		}).trim();
 		const match = /^v?(\d+)\./.exec(out);
 		return match ? Number(match[1]) : undefined;
 	} catch {
@@ -95,9 +114,25 @@ function defaultProbeVersion(nodePath: string): number | undefined {
 	}
 }
 
+/** Injectable dependencies for {@link defaultCandidatePaths} (for testing). */
+export interface CandidatePathDeps {
+	/** The raw `PATH` string (defaults to `process.env.PATH`). */
+	pathEnv?: string;
+	/** Home directory used to locate nvm versions (defaults to `os.homedir()`). */
+	homeDir?: string;
+	/** Directory lister used for nvm expansion (defaults to `fs.readdirSync`). */
+	readdir?: (dir: string) => string[];
+}
+
 /** Build the ordered candidate list: PATH entries first, then common install
  * locations (Homebrew, /usr/local/bin, nvm versions — newest first). */
-function defaultCandidatePaths(platform: NodeJS.Platform = process.platform): string[] {
+export function defaultCandidatePaths(
+	platform: NodeJS.Platform = process.platform,
+	deps: CandidatePathDeps = {},
+): string[] {
+	const pathEnv = deps.pathEnv ?? process.env.PATH ?? "";
+	const homeDir = deps.homeDir ?? homedir();
+	const readdir = deps.readdir ?? readdirSync;
 	const exe = platform === "win32" ? "node.exe" : "node";
 	const seen = new Set<string>();
 	const out: string[] = [];
@@ -109,7 +144,7 @@ function defaultCandidatePaths(platform: NodeJS.Platform = process.platform): st
 	};
 
 	// PATH entries (the user's chosen Node, when the process inherited a PATH).
-	for (const dir of (process.env.PATH ?? "").split(delimiter)) {
+	for (const dir of pathEnv.split(delimiter)) {
 		if (dir) add(join(dir, exe));
 	}
 
@@ -118,16 +153,16 @@ function defaultCandidatePaths(platform: NodeJS.Platform = process.platform): st
 		add(join("/opt/homebrew/bin", exe)); // Apple-silicon Homebrew
 		add(join("/usr/local/bin", exe)); // Intel Homebrew / manual installs
 	}
-	for (const p of nvmNodePaths(exe)) add(p);
+	for (const p of nvmNodePaths(exe, homeDir, readdir)) add(p);
 
 	return out;
 }
 
 /** Expand `~/.nvm/versions/node/<version>/bin/<exe>`, newest version first. */
-function nvmNodePaths(exe: string): string[] {
-	const base = join(homedir(), ".nvm", "versions", "node");
+function nvmNodePaths(exe: string, homeDir: string, readdir: (dir: string) => string[]): string[] {
+	const base = join(homeDir, ".nvm", "versions", "node");
 	try {
-		return readdirSync(base)
+		return readdir(base)
 			.sort(compareVersionDesc)
 			.map((v) => join(base, v, "bin", exe));
 	} catch {
@@ -136,7 +171,7 @@ function nvmNodePaths(exe: string): string[] {
 }
 
 /** Descending semver-ish compare on directory names like `v22.3.1`. */
-function compareVersionDesc(a: string, b: string): number {
+export function compareVersionDesc(a: string, b: string): number {
 	const parse = (s: string) => s.replace(/^v/, "").split(".").map(Number);
 	const [a0 = 0, a1 = 0, a2 = 0] = parse(a);
 	const [b0 = 0, b1 = 0, b2 = 0] = parse(b);

--- a/packages/vscode/src/host/node-path.ts
+++ b/packages/vscode/src/host/node-path.ts
@@ -1,0 +1,144 @@
+/**
+ * Resolve an absolute Node.js executable to spawn the dreb RPC child with.
+ *
+ * `RpcClient` otherwise runs the bare command `"node"`, relying on `PATH`. A
+ * GUI-launched editor (macOS Dock/Finder, Windows Explorer) does NOT inherit the
+ * shell `PATH`, so `spawn("node")` fails with `ENOENT` and the child never
+ * starts. This resolver finds a real Node >=22 the child can actually run.
+ *
+ * Precedence:
+ *   1. the `dreb.nodePath` setting (explicit override) when the file exists;
+ *   2. the first Node >=22 among discovered candidates (PATH entries first, then
+ *      common install locations — Homebrew, /usr/local/bin, nvm versions);
+ *   3. the editor's own runtime (`process.execPath`) run as Node via
+ *      `ELECTRON_RUN_AS_NODE=1` — always available, so resolution never fails.
+ *
+ * All I/O (existence, version probe, candidate list, editor runtime) is
+ * injectable so the precedence logic is unit-testable without a real filesystem
+ * or spawning processes.
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { delimiter, join } from "node:path";
+
+/** Minimum Node major version (`engines.node: "22.x"` in coding-agent). */
+export const MIN_NODE_MAJOR = 22;
+
+export interface NodePathSources {
+	/** The `dreb.nodePath` setting value; empty/whitespace means unset. */
+	configuredPath?: string;
+	/** Existence probe (defaults to `fs.existsSync`). */
+	fileExists?: (path: string) => boolean;
+	/** Return the major version of a Node executable, or `undefined` if it cannot
+	 * be run / parsed (defaults to executing `<nodePath> --version`). */
+	probeVersion?: (nodePath: string) => number | undefined;
+	/** Ordered, highest-priority-first list of candidate Node executables
+	 * (defaults to PATH entries then common install locations). */
+	candidatePaths?: () => string[];
+	/** The editor's own runtime, used as the final fallback (defaults to
+	 * `process.execPath`). */
+	execPath?: string;
+	/** Platform, used to pick the executable name (defaults to `process.platform`). */
+	platform?: NodeJS.Platform;
+}
+
+export type NodePathResult = {
+	/** Absolute path (or bare `"node"`) to spawn the CLI child with. */
+	nodePath: string;
+	/** Extra environment to merge for the child (set only for the Electron
+	 * fallback, which needs `ELECTRON_RUN_AS_NODE=1` to behave as plain Node). */
+	env?: Record<string, string>;
+	/** Which rung of the precedence ladder produced the result. */
+	source: "setting" | "discovered" | "electron";
+};
+
+export function resolveNodePath(sources: NodePathSources = {}): NodePathResult {
+	const exists = sources.fileExists ?? existsSync;
+	const probe = sources.probeVersion ?? defaultProbeVersion;
+
+	// 1. Explicit setting wins when it points at a real file.
+	const configured = sources.configuredPath?.trim();
+	if (configured && exists(configured)) {
+		return { nodePath: configured, source: "setting" };
+	}
+
+	// 2. First candidate that both exists and reports Node >=22. Candidates are
+	// already in priority order (the user's PATH first), so we honor that order
+	// rather than globally preferring the highest version.
+	const candidates = (sources.candidatePaths ?? (() => defaultCandidatePaths(sources.platform)))();
+	for (const candidate of candidates) {
+		if (!exists(candidate)) continue;
+		const major = probe(candidate);
+		if (major != null && major >= MIN_NODE_MAJOR) {
+			return { nodePath: candidate, source: "discovered" };
+		}
+	}
+
+	// 3. Editor runtime as plain Node — always present, so resolution never fails.
+	return {
+		nodePath: sources.execPath ?? process.execPath,
+		env: { ELECTRON_RUN_AS_NODE: "1" },
+		source: "electron",
+	};
+}
+
+/** Run `<nodePath> --version` and parse the major version (e.g. `v22.3.1` -> 22). */
+function defaultProbeVersion(nodePath: string): number | undefined {
+	try {
+		const out = execFileSync(nodePath, ["--version"], { encoding: "utf8", timeout: 3000 }).trim();
+		const match = /^v?(\d+)\./.exec(out);
+		return match ? Number(match[1]) : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+/** Build the ordered candidate list: PATH entries first, then common install
+ * locations (Homebrew, /usr/local/bin, nvm versions — newest first). */
+function defaultCandidatePaths(platform: NodeJS.Platform = process.platform): string[] {
+	const exe = platform === "win32" ? "node.exe" : "node";
+	const seen = new Set<string>();
+	const out: string[] = [];
+	const add = (p: string) => {
+		if (p && !seen.has(p)) {
+			seen.add(p);
+			out.push(p);
+		}
+	};
+
+	// PATH entries (the user's chosen Node, when the process inherited a PATH).
+	for (const dir of (process.env.PATH ?? "").split(delimiter)) {
+		if (dir) add(join(dir, exe));
+	}
+
+	// Common install locations for GUI launches that lack a shell PATH.
+	if (platform !== "win32") {
+		add(join("/opt/homebrew/bin", exe)); // Apple-silicon Homebrew
+		add(join("/usr/local/bin", exe)); // Intel Homebrew / manual installs
+	}
+	for (const p of nvmNodePaths(exe)) add(p);
+
+	return out;
+}
+
+/** Expand `~/.nvm/versions/node/<version>/bin/<exe>`, newest version first. */
+function nvmNodePaths(exe: string): string[] {
+	const base = join(homedir(), ".nvm", "versions", "node");
+	try {
+		return readdirSync(base)
+			.sort(compareVersionDesc)
+			.map((v) => join(base, v, "bin", exe));
+	} catch {
+		return [];
+	}
+}
+
+/** Descending semver-ish compare on directory names like `v22.3.1`. */
+function compareVersionDesc(a: string, b: string): number {
+	const parse = (s: string) => s.replace(/^v/, "").split(".").map(Number);
+	const [a0 = 0, a1 = 0, a2 = 0] = parse(a);
+	const [b0 = 0, b1 = 0, b2 = 0] = parse(b);
+	return b0 - a0 || b1 - a1 || b2 - a2;
+}

--- a/packages/vscode/src/host/node-runtime-cache.ts
+++ b/packages/vscode/src/host/node-runtime-cache.ts
@@ -1,0 +1,72 @@
+/**
+ * Cache + one-time-warning glue around {@link resolveNodePath}.
+ *
+ * Resolving a Node runtime spawns a synchronous `node --version` probe per
+ * candidate, so the result is memoized (keyed by the `dreb.nodePath` setting) to
+ * avoid re-probing — and stalling the extension host — on every session
+ * create/rename. The cache is invalidated when the setting value changes.
+ *
+ * The Electron fallback rung is intentionally not version-gated (it must always
+ * yield a runnable executable), but the CLI targets Node >=22, so we warn once
+ * when the editor's own runtime is older than {@link MIN_NODE_MAJOR}.
+ *
+ * All of this is pure and injectable (no `vscode` import) so it is unit-testable
+ * without loading the extension host.
+ */
+
+import { MIN_NODE_MAJOR, type NodePathResult, resolveNodePath } from "./node-path.js";
+
+/** Mutable state carried across `resolveNodeRuntimeCached` calls. */
+export interface NodeRuntimeCacheState {
+	/** Last resolution, keyed by the `dreb.nodePath` setting it was resolved for. */
+	cache?: { key: string; result: NodePathResult };
+	/** Whether the older-editor-runtime warning has already been shown. */
+	warnedElectronVersion: boolean;
+}
+
+/** Fresh state for a session/extension activation. */
+export function createNodeRuntimeCacheState(): NodeRuntimeCacheState {
+	return { warnedElectronVersion: false };
+}
+
+export interface ResolveNodeRuntimeDeps {
+	/** The current `dreb.nodePath` setting value (empty string when unset). */
+	configuredNodePath: string;
+	/** Resolver (defaults to {@link resolveNodePath}); injectable for tests. */
+	resolve?: (opts: { configuredPath: string }) => NodePathResult;
+	/** Called at most once with the warning message when the editor's own Node
+	 * runtime is older than {@link MIN_NODE_MAJOR}. */
+	warn?: (message: string) => void;
+}
+
+/** The message shown when falling back to an editor runtime older than required. */
+export function electronVersionWarning(major: number): string {
+	return `dreb: no Node ${MIN_NODE_MAJOR}+ found on PATH; falling back to the editor's Node ${major} runtime, which is older than dreb requires. Set "dreb.nodePath" to a Node ${MIN_NODE_MAJOR}+ executable if you hit runtime errors.`;
+}
+
+/**
+ * Resolve the Node runtime, reusing the cached result when the `dreb.nodePath`
+ * setting is unchanged and warning once when the editor runtime is too old.
+ * Mutates `state`.
+ */
+export function resolveNodeRuntimeCached(state: NodeRuntimeCacheState, deps: ResolveNodeRuntimeDeps): NodePathResult {
+	const configuredNode = deps.configuredNodePath;
+	const resolve = deps.resolve ?? resolveNodePath;
+
+	if (state.cache?.key !== configuredNode) {
+		state.cache = { key: configuredNode, result: resolve({ configuredPath: configuredNode }) };
+	}
+	const node = state.cache.result;
+
+	if (
+		node.source === "electron" &&
+		node.major != null &&
+		node.major < MIN_NODE_MAJOR &&
+		!state.warnedElectronVersion
+	) {
+		state.warnedElectronVersion = true;
+		deps.warn?.(electronVersionWarning(node.major));
+	}
+
+	return node;
+}

--- a/packages/vscode/src/host/session-controller.ts
+++ b/packages/vscode/src/host/session-controller.ts
@@ -175,11 +175,25 @@ export type RpcClientFactory = (options: {
 	cliPath: string;
 	cwd: string;
 	args: string[];
+	/** Absolute Node executable to spawn the CLI with (see `nodePath` on the
+	 * controller options). Forwarded to `RpcClient`; omit to default to `"node"`. */
+	nodePath?: string;
+	/** Extra environment for the child (e.g. `ELECTRON_RUN_AS_NODE` when the
+	 * editor's own runtime is used as the Node executable). */
+	env?: Record<string, string>;
 }) => RpcClientLike | Promise<RpcClientLike>;
 
 export interface SessionControllerOptions {
 	cwd: string;
 	cliPath: string;
+	/** Absolute path to the Node executable used to spawn the RPC child. Omit to
+	 * let `RpcClient` default to `"node"` (PATH lookup). Set by the extension to a
+	 * discovered Node >=22 or the editor's own runtime so a GUI-launched editor
+	 * with no shell PATH can still spawn the child. */
+	nodePath?: string;
+	/** Extra environment for the RPC child (merged over `process.env`), e.g.
+	 * `ELECTRON_RUN_AS_NODE` when `nodePath` is the editor's Electron binary. */
+	env?: Record<string, string>;
 	/** Extra CLI args (e.g. --provider/--model), appended verbatim. */
 	args?: string[];
 	/** Resume a specific session .jsonl by passing `--session <path>` to the RPC
@@ -230,7 +244,13 @@ export type ControllerUpdate =
  * never pull it in. */
 const defaultClientFactory: RpcClientFactory = async (options) => {
 	const { RpcClient } = await import("@dreb/coding-agent/rpc");
-	return new RpcClient({ cliPath: options.cliPath, cwd: options.cwd, args: options.args });
+	return new RpcClient({
+		cliPath: options.cliPath,
+		cwd: options.cwd,
+		args: options.args,
+		nodePath: options.nodePath,
+		env: options.env,
+	});
 };
 
 function formatExit(info: { code?: number | null; signal?: string | null; error?: Error; stderr?: string }): string {
@@ -593,6 +613,8 @@ export class SessionController {
 			cliPath: this.options.cliPath,
 			cwd: this.options.cwd,
 			args,
+			nodePath: this.options.nodePath,
+			env: this.options.env,
 		});
 		this.client = client;
 		this.unsubEvent = client.onEvent((event) => this.handleEvent(event));

--- a/packages/vscode/test/cli-path.test.ts
+++ b/packages/vscode/test/cli-path.test.ts
@@ -1,5 +1,7 @@
+import { basename, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
-import { resolveCliPath } from "../src/host/cli-path.js";
+import { defaultExtensionDir, repoRelativeCliPath, resolveCliPath } from "../src/host/cli-path.js";
 
 describe("cli-path resolution", () => {
 	it("prefers the configured setting when the file exists", () => {
@@ -63,5 +65,32 @@ describe("cli-path resolution", () => {
 		});
 		expect(result.ok).toBe(false);
 		if (!result.ok) expect(result.error).toContain("dreb folder");
+	});
+});
+
+describe("repo-relative walk (the real un-injected mechanism)", () => {
+	it("repoRelativeCliPath points at the sibling coding-agent package", () => {
+		expect(repoRelativeCliPath("/repo/packages/vscode")).toBe("/repo/packages/coding-agent/dist/cli.js");
+	});
+
+	it("defaultExtensionDir walks up exactly to packages/vscode (load-bearing hop count)", () => {
+		// This is the assumption the whole repo-local install rests on: three parent
+		// hops from the module (`.../packages/vscode/<dist|src>/host/cli-path.<js|ts>`)
+		// must land on `packages/vscode`. If the compiled layout ever changes, this
+		// test fails instead of silently resolving the wrong directory.
+		const dir = defaultExtensionDir();
+		expect(dir).toBeDefined();
+		expect(basename(dir as string)).toBe("vscode");
+		expect(basename(dirname(dir as string))).toBe("packages");
+
+		// And it matches a direct three-hop computation from this test's own module URL,
+		// which lives one level deeper (test/ vs host/) — so hop from its parent.
+		const hereDir = dirname(fileURLToPath(import.meta.url)); // .../packages/vscode/test
+		expect(dir).toBe(dirname(hereDir)); // .../packages/vscode
+	});
+
+	it("the derived dir yields a real sibling cli.js candidate shape", () => {
+		const dir = defaultExtensionDir() as string;
+		expect(repoRelativeCliPath(dir)).toBe(join(dir, "..", "coding-agent", "dist", "cli.js"));
 	});
 });

--- a/packages/vscode/test/cli-path.test.ts
+++ b/packages/vscode/test/cli-path.test.ts
@@ -19,9 +19,27 @@ describe("cli-path resolution", () => {
 		if (!result.ok) expect(result.error).toContain("/nope/cli.js");
 	});
 
+	it("resolves the sibling CLI relative to the extension dir (repo-local install)", () => {
+		const result = resolveCliPath({
+			extensionDir: "/repo/packages/vscode",
+			fileExists: (p) => p === "/repo/packages/coding-agent/dist/cli.js",
+		});
+		expect(result).toEqual({ ok: true, path: "/repo/packages/coding-agent/dist/cli.js", source: "repo" });
+	});
+
+	it("prefers the repo-relative CLI over dependency resolution", () => {
+		const result = resolveCliPath({
+			extensionDir: "/repo/packages/vscode",
+			resolveCliDir: () => "/pkgs/coding-agent/dist",
+			fileExists: () => true, // both candidates would exist
+		});
+		expect(result).toEqual({ ok: true, path: "/repo/packages/coding-agent/dist/cli.js", source: "repo" });
+	});
+
 	it("falls back to dependency resolution when no setting is present", () => {
 		const result = resolveCliPath({
 			configuredPath: "  ",
+			extensionDir: "/repo/packages/vscode",
 			resolveCliDir: () => "/pkgs/coding-agent/dist",
 			fileExists: (p) => p === "/pkgs/coding-agent/dist/cli.js",
 		});
@@ -30,17 +48,20 @@ describe("cli-path resolution", () => {
 
 	it("errors when dependency resolution yields nothing", () => {
 		const result = resolveCliPath({
+			extensionDir: undefined,
 			resolveCliDir: () => undefined,
 			fileExists: () => false,
 		});
 		expect(result.ok).toBe(false);
 	});
 
-	it("errors when the resolved dependency dir has no cli.js", () => {
+	it("errors when neither the repo-relative nor the dependency dir has cli.js", () => {
 		const result = resolveCliPath({
+			extensionDir: "/repo/packages/vscode",
 			resolveCliDir: () => "/pkgs/coding-agent/dist",
 			fileExists: () => false,
 		});
 		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.error).toContain("dreb folder");
 	});
 });

--- a/packages/vscode/test/install-extension.test.ts
+++ b/packages/vscode/test/install-extension.test.ts
@@ -1,0 +1,97 @@
+import { existsSync, lstatSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { extensionsDir, installPlan, linkName, parseArgs, removeExisting } from "../scripts/install-extension.mjs";
+
+describe("install-extension helpers", () => {
+	describe("extensionsDir", () => {
+		it("defaults to ~/.vscode/extensions", () => {
+			expect(extensionsDir({ home: "/home/u" })).toBe("/home/u/.vscode/extensions");
+		});
+
+		it("uses the Insiders dir when requested", () => {
+			expect(extensionsDir({ home: "/home/u", insiders: true })).toBe("/home/u/.vscode-insiders/extensions");
+		});
+
+		it("honors an explicit override", () => {
+			expect(extensionsDir({ home: "/home/u", override: "/custom/ext" })).toBe("/custom/ext");
+		});
+	});
+
+	describe("linkName", () => {
+		it("combines publisher and name", () => {
+			expect(linkName({ publisher: "hrovatin", name: "dreb-vscode" })).toBe("hrovatin.dreb-vscode");
+		});
+
+		it("falls back to 'unknown' when publisher is missing", () => {
+			expect(linkName({ name: "dreb-vscode" })).toBe("unknown.dreb-vscode");
+		});
+	});
+
+	describe("installPlan", () => {
+		it("computes the link path and target", () => {
+			const plan = installPlan({
+				extDir: "/home/u/.vscode/extensions",
+				pkg: { publisher: "hrovatin", name: "dreb-vscode" },
+				target: "/repo/packages/vscode",
+			});
+			expect(plan).toEqual({
+				linkPath: "/home/u/.vscode/extensions/hrovatin.dreb-vscode",
+				targetPath: "/repo/packages/vscode",
+			});
+		});
+	});
+
+	describe("parseArgs", () => {
+		it("parses --insiders and --dir", () => {
+			expect(parseArgs(["--insiders", "--dir", "/x"])).toEqual({ insiders: true, dir: "/x" });
+		});
+
+		it("defaults to stable dir and no override", () => {
+			expect(parseArgs([])).toEqual({ insiders: false, dir: undefined });
+		});
+	});
+
+	describe("removeExisting", () => {
+		let dir: string;
+		beforeEach(() => {
+			dir = mkdtempSync(join(tmpdir(), "dreb-install-"));
+		});
+		afterEach(() => {
+			rmSync(dir, { recursive: true, force: true });
+		});
+
+		it("no-ops when nothing exists", () => {
+			const link = join(dir, "link");
+			expect(() => removeExisting(link, () => {})).not.toThrow();
+			expect(existsSync(link)).toBe(false);
+		});
+
+		it("unlinks an existing symlink", () => {
+			const target = join(dir, "target");
+			mkdirSync(target);
+			const link = join(dir, "link");
+			symlinkSync(target, link, "dir");
+			expect(lstatSync(link).isSymbolicLink()).toBe(true);
+
+			removeExisting(link, () => {});
+
+			expect(existsSync(link)).toBe(false);
+			// The real target is untouched.
+			expect(existsSync(target)).toBe(true);
+		});
+
+		it("removes a stale non-symlink directory (with a warning)", () => {
+			const link = join(dir, "copied-install");
+			mkdirSync(link);
+			writeFileSync(join(link, "package.json"), "{}");
+			const warnings: string[] = [];
+
+			removeExisting(link, (m: string) => warnings.push(m));
+
+			expect(existsSync(link)).toBe(false);
+			expect(warnings.join("\n")).toContain("non-symlink");
+		});
+	});
+});

--- a/packages/vscode/test/install-extension.test.ts
+++ b/packages/vscode/test/install-extension.test.ts
@@ -1,8 +1,28 @@
-import { existsSync, lstatSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	lstatSync,
+	mkdirSync,
+	mkdtempSync,
+	readlinkSync,
+	realpathSync,
+	rmSync,
+	symlinkSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { extensionsDir, installPlan, linkName, parseArgs, removeExisting } from "../scripts/install-extension.mjs";
+import {
+	extensionsDir,
+	installPlan,
+	isDirectRun,
+	linkName,
+	parseArgs,
+	removeExisting,
+	runInstall,
+	safeReadlink,
+} from "../scripts/install-extension.mjs";
 
 describe("install-extension helpers", () => {
 	describe("extensionsDir", () => {
@@ -93,5 +113,197 @@ describe("install-extension helpers", () => {
 			expect(existsSync(link)).toBe(false);
 			expect(warnings.join("\n")).toContain("non-symlink");
 		});
+	});
+});
+
+describe("runInstall (side-effecting install core)", () => {
+	const pkg = { publisher: "hrovatin", name: "dreb-vscode" };
+
+	it("exits(1) and reports missing build outputs without touching the filesystem", () => {
+		const codes: number[] = [];
+		const errors: string[] = [];
+		let made = false;
+		let linked = false;
+		const result = runInstall({
+			pkgRoot: "/repo/packages/vscode",
+			pkg,
+			extDir: "/ext",
+			fileExists: () => false, // nothing is built
+			makeDir: () => {
+				made = true;
+			},
+			createSymlink: () => {
+				linked = true;
+			},
+			log: () => {},
+			error: (m: string) => errors.push(m),
+			exit: (c: number) => codes.push(c),
+		});
+		expect(codes).toEqual([1]);
+		expect(result).toMatchObject({ ok: false, reason: "missing-build" });
+		expect(result.ok === false && result.missing).toEqual([
+			"/repo/packages/vscode/dist/host/extension.js",
+			"/repo/packages/coding-agent/dist/cli.js",
+		]);
+		expect(errors.join("\n")).toContain("npm run build");
+		// No filesystem mutation occurred.
+		expect(made).toBe(false);
+		expect(linked).toBe(false);
+	});
+
+	it("is a no-op when already linked to the same target", () => {
+		let symlinkCalls = 0;
+		let removeCalls = 0;
+		const logs: string[] = [];
+		const result = runInstall({
+			pkgRoot: "/repo/packages/vscode",
+			pkg,
+			extDir: "/ext",
+			fileExists: () => true, // build present
+			makeDir: () => {},
+			isLink: () => true,
+			readLink: () => "/repo/packages/vscode", // already points at the target
+			createSymlink: () => {
+				symlinkCalls++;
+			},
+			remove: () => {
+				removeCalls++;
+			},
+			log: (m: string) => logs.push(m),
+			error: () => {},
+			exit: () => {},
+		});
+		expect(result).toMatchObject({ ok: true, reason: "already-linked" });
+		expect(symlinkCalls).toBe(0);
+		expect(removeCalls).toBe(0);
+		expect(logs.join("\n")).toContain("Already linked");
+	});
+
+	it("removes any existing entry and creates the symlink when not yet linked", () => {
+		const symlinks: Array<[string, string]> = [];
+		const removed: string[] = [];
+		const result = runInstall({
+			pkgRoot: "/repo/packages/vscode",
+			pkg,
+			extDir: "/ext",
+			fileExists: () => true,
+			makeDir: () => {},
+			isLink: () => false,
+			readLink: () => undefined,
+			remove: (p: string) => removed.push(p),
+			createSymlink: (target: string, link: string) => symlinks.push([target, link]),
+			log: () => {},
+			error: () => {},
+			exit: () => {},
+		});
+		expect(result).toMatchObject({ ok: true, reason: "linked" });
+		expect(removed).toEqual(["/ext/hrovatin.dreb-vscode"]);
+		expect(symlinks).toEqual([["/repo/packages/vscode", "/ext/hrovatin.dreb-vscode"]]);
+	});
+
+	it("re-links when an existing symlink points at a different target", () => {
+		const symlinks: Array<[string, string]> = [];
+		const removed: string[] = [];
+		const result = runInstall({
+			pkgRoot: "/repo/packages/vscode",
+			pkg,
+			extDir: "/ext",
+			fileExists: () => true,
+			makeDir: () => {},
+			isLink: () => true,
+			readLink: () => "/some/OTHER/old/checkout", // stale target
+			remove: (p: string) => removed.push(p),
+			createSymlink: (target: string, link: string) => symlinks.push([target, link]),
+			log: () => {},
+			error: () => {},
+			exit: () => {},
+		});
+		expect(result).toMatchObject({ ok: true, reason: "linked" });
+		expect(removed).toEqual(["/ext/hrovatin.dreb-vscode"]);
+		expect(symlinks).toEqual([["/repo/packages/vscode", "/ext/hrovatin.dreb-vscode"]]);
+	});
+
+	describe("against a real temp filesystem", () => {
+		let dir: string;
+		beforeEach(() => {
+			dir = mkdtempSync(join(tmpdir(), "dreb-runinstall-"));
+		});
+		afterEach(() => {
+			rmSync(dir, { recursive: true, force: true });
+		});
+
+		it("creates a real symlink and is idempotent on a second run", () => {
+			// Fake a built repo layout the prereq check will accept.
+			const pkgRoot = join(dir, "packages", "vscode");
+			mkdirSync(join(pkgRoot, "dist", "host"), { recursive: true });
+			writeFileSync(join(pkgRoot, "dist", "host", "extension.js"), "");
+			mkdirSync(join(dir, "packages", "coding-agent", "dist"), { recursive: true });
+			writeFileSync(join(dir, "packages", "coding-agent", "dist", "cli.js"), "");
+			const extDir = join(dir, "ext");
+
+			const first = runInstall({ pkgRoot, pkg, extDir, log: () => {}, error: () => {}, exit: () => {} });
+			expect(first).toMatchObject({ ok: true, reason: "linked" });
+			const linkPath = join(extDir, "hrovatin.dreb-vscode");
+			expect(lstatSync(linkPath).isSymbolicLink()).toBe(true);
+			expect(readlinkSync(linkPath)).toBe(pkgRoot);
+
+			const second = runInstall({ pkgRoot, pkg, extDir, log: () => {}, error: () => {}, exit: () => {} });
+			expect(second).toMatchObject({ ok: true, reason: "already-linked" });
+			expect(lstatSync(linkPath).isSymbolicLink()).toBe(true);
+		});
+	});
+
+	it("safeReadlink returns undefined for a non-symlink path", () => {
+		expect(safeReadlink("/definitely/not/a/link")).toBeUndefined();
+	});
+});
+
+describe("isDirectRun (entrypoint guard — finding 1)", () => {
+	let dir: string;
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "dreb-directrun-"));
+	});
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("is true when argv[1] is the module's own path", () => {
+		const file = join(dir, "script.mjs");
+		writeFileSync(file, "");
+		const url = pathToFileURL(file).href;
+		expect(isDirectRun(url, file)).toBe(true);
+	});
+
+	it("is true when the path contains spaces (the regressed case)", () => {
+		const spaced = join(dir, "My Scripts");
+		mkdirSync(spaced);
+		const file = join(spaced, "script.mjs");
+		writeFileSync(file, "");
+		// import.meta.url is percent-encoded; the raw argv path is not.
+		const url = pathToFileURL(file).href;
+		expect(url).toContain("%20"); // sanity: the space really is encoded
+		expect(isDirectRun(url, file)).toBe(true);
+	});
+
+	it("is true when argv[1] reaches the module through a symlink", () => {
+		const real = join(dir, "real.mjs");
+		writeFileSync(real, "");
+		const link = join(dir, "link.mjs");
+		symlinkSync(real, link);
+		// Node realpath-resolves import.meta.url to the real file; argv[1] is the symlink.
+		const url = pathToFileURL(realpathSync(real)).href;
+		expect(isDirectRun(url, link)).toBe(true);
+	});
+
+	it("is false when imported rather than run directly (argv[1] is another file)", () => {
+		const module = join(dir, "lib.mjs");
+		const entry = join(dir, "main.mjs");
+		writeFileSync(module, "");
+		writeFileSync(entry, "");
+		expect(isDirectRun(pathToFileURL(module).href, entry)).toBe(false);
+	});
+
+	it("is false when there is no argv[1]", () => {
+		expect(isDirectRun("file:///whatever.mjs", undefined)).toBe(false);
 	});
 });

--- a/packages/vscode/test/install-extension.test.ts
+++ b/packages/vscode/test/install-extension.test.ts
@@ -17,6 +17,7 @@ import {
 	extensionsDir,
 	installPlan,
 	isDirectRun,
+	isSymlink,
 	linkName,
 	parseArgs,
 	removeExisting,
@@ -305,5 +306,44 @@ describe("isDirectRun (entrypoint guard — finding 1)", () => {
 
 	it("is false when there is no argv[1]", () => {
 		expect(isDirectRun("file:///whatever.mjs", undefined)).toBe(false);
+	});
+});
+
+describe("isSymlink (uninstall guard for dangling links — finding 1)", () => {
+	let dir: string;
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "dreb-symlink-"));
+	});
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("detects a symlink whose target still exists", () => {
+		const target = join(dir, "target");
+		const link = join(dir, "link");
+		writeFileSync(target, "");
+		symlinkSync(target, link);
+		expect(isSymlink(link)).toBe(true);
+	});
+
+	it("detects a DANGLING symlink where existsSync would report false", () => {
+		// Reproduces the uninstall scenario: the dreb repo (the link target) is
+		// moved/deleted, so the extension link dangles. existsSync follows the
+		// link and returns false; isSymlink (lstat-based) still returns true, so
+		// uninstall proceeds to remove it instead of silently no-op'ing.
+		const target = join(dir, "gone");
+		const link = join(dir, "link");
+		writeFileSync(target, "");
+		symlinkSync(target, link);
+		rmSync(target); // target now gone → link dangles
+		expect(existsSync(link)).toBe(false);
+		expect(isSymlink(link)).toBe(true);
+		// removeExisting cleans a dangling link (this is what the guard now reaches).
+		removeExisting(link, () => {});
+		expect(isSymlink(link)).toBe(false);
+	});
+
+	it("returns false for a non-existent path", () => {
+		expect(isSymlink(join(dir, "nope"))).toBe(false);
 	});
 });

--- a/packages/vscode/test/node-path.test.ts
+++ b/packages/vscode/test/node-path.test.ts
@@ -1,5 +1,13 @@
+import { execFileSync } from "node:child_process";
+import { delimiter, join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { MIN_NODE_MAJOR, resolveNodePath } from "../src/host/node-path.js";
+import {
+	compareVersionDesc,
+	defaultCandidatePaths,
+	defaultProbeVersion,
+	MIN_NODE_MAJOR,
+	resolveNodePath,
+} from "../src/host/node-path.js";
 
 describe("resolveNodePath", () => {
 	it("prefers the configured setting when the file exists", () => {
@@ -20,10 +28,10 @@ describe("resolveNodePath", () => {
 			candidatePaths: () => ["/usr/bin/node"],
 			execPath: "/electron",
 		});
-		expect(result).toEqual({ nodePath: "/usr/bin/node", source: "discovered" });
+		expect(result).toEqual({ nodePath: "/usr/bin/node", source: "discovered", major: 22 });
 	});
 
-	it("returns the first candidate that is Node >= 22, honoring priority order", () => {
+	it("returns the first candidate that is Node >=22, honoring priority order", () => {
 		const versions: Record<string, number> = {
 			"/a/node": 20,
 			"/b/node": 24,
@@ -37,7 +45,7 @@ describe("resolveNodePath", () => {
 			execPath: "/electron",
 		});
 		// /a is too old (20); /b is the first >= 22 and wins even though /c is also valid.
-		expect(result).toEqual({ nodePath: "/b/node", source: "discovered" });
+		expect(result).toEqual({ nodePath: "/b/node", source: "discovered", major: 24 });
 	});
 
 	it("skips candidates that do not exist", () => {
@@ -52,10 +60,11 @@ describe("resolveNodePath", () => {
 		expect(result.source).toBe("discovered");
 	});
 
-	it("rejects candidates below the minimum major version", () => {
+	it("rejects candidates below the minimum major version and reports the fallback's version", () => {
 		const result = resolveNodePath({
 			configuredPath: "",
 			fileExists: () => true,
+			// Every candidate (including the electron execPath probe) reports 21.
 			probeVersion: () => MIN_NODE_MAJOR - 1,
 			candidatePaths: () => ["/old/node"],
 			execPath: "/electron",
@@ -64,7 +73,30 @@ describe("resolveNodePath", () => {
 			nodePath: "/electron",
 			env: { ELECTRON_RUN_AS_NODE: "1" },
 			source: "electron",
+			major: MIN_NODE_MAJOR - 1,
 		});
+	});
+
+	it("probes the editor runtime with ELECTRON_RUN_AS_NODE so it reports Node's version", () => {
+		const probedWith: Array<[string, Record<string, string> | undefined]> = [];
+		const result = resolveNodePath({
+			configuredPath: "",
+			fileExists: () => false,
+			candidatePaths: () => [],
+			execPath: "/path/to/code",
+			probeVersion: (p, env) => {
+				probedWith.push([p, env]);
+				return 20;
+			},
+		});
+		expect(result).toEqual({
+			nodePath: "/path/to/code",
+			env: { ELECTRON_RUN_AS_NODE: "1" },
+			source: "electron",
+			major: 20,
+		});
+		// The electron runtime is probed with ELECTRON_RUN_AS_NODE=1.
+		expect(probedWith).toEqual([["/path/to/code", { ELECTRON_RUN_AS_NODE: "1" }]]);
 	});
 
 	it("skips candidates whose version cannot be determined", () => {
@@ -76,6 +108,8 @@ describe("resolveNodePath", () => {
 			execPath: "/electron",
 		});
 		expect(result.source).toBe("electron");
+		// No major when even the fallback runtime's version can't be parsed.
+		expect(result.major).toBeUndefined();
 	});
 
 	it("falls back to the editor runtime as plain Node when nothing else qualifies", () => {
@@ -84,11 +118,102 @@ describe("resolveNodePath", () => {
 			fileExists: () => false,
 			candidatePaths: () => [],
 			execPath: "/path/to/code-electron",
+			// A bogus execPath cannot be probed → undefined, so no major is attached.
+			probeVersion: () => undefined,
 		});
 		expect(result).toEqual({
 			nodePath: "/path/to/code-electron",
 			env: { ELECTRON_RUN_AS_NODE: "1" },
 			source: "electron",
 		});
+	});
+});
+
+describe("defaultProbeVersion (real child process)", () => {
+	it("returns the running Node's major version for the current executable", () => {
+		const expectedMajor = Number(process.versions.node.split(".")[0]);
+		expect(defaultProbeVersion(process.execPath)).toBe(expectedMajor);
+	});
+
+	it("returns undefined for a non-existent executable instead of throwing", () => {
+		expect(defaultProbeVersion("/definitely/not/a/real/node/binary")).toBeUndefined();
+	});
+
+	it("parses the same version the executable prints", () => {
+		const printed = execFileSync(process.execPath, ["--version"], { encoding: "utf8" }).trim();
+		const printedMajor = Number(printed.replace(/^v/, "").split(".")[0]);
+		expect(defaultProbeVersion(process.execPath)).toBe(printedMajor);
+	});
+});
+
+describe("compareVersionDesc", () => {
+	it("orders versions newest-first, not lexically", () => {
+		const sorted = ["v9.0.0", "v22.3.1", "v20.11.0", "v22.10.0", "v18.0.0"].sort(compareVersionDesc);
+		expect(sorted).toEqual(["v22.10.0", "v22.3.1", "v20.11.0", "v18.0.0", "v9.0.0"]);
+	});
+
+	it("compares minor and patch when majors tie", () => {
+		expect(["v22.1.0", "v22.1.5", "v22.0.9"].sort(compareVersionDesc)).toEqual(["v22.1.5", "v22.1.0", "v22.0.9"]);
+	});
+});
+
+describe("defaultCandidatePaths", () => {
+	it("lists PATH entries first, in order, then common install locations", () => {
+		const pathEnv = ["/usr/bin", "/home/me/.local/bin"].join(delimiter);
+		const out = defaultCandidatePaths("linux", { pathEnv, homeDir: "/home/me", readdir: () => [] });
+		expect(out.slice(0, 2)).toEqual([join("/usr/bin", "node"), join("/home/me/.local/bin", "node")]);
+		// Homebrew + /usr/local/bin appended after PATH.
+		expect(out).toContain(join("/opt/homebrew/bin", "node"));
+		expect(out).toContain(join("/usr/local/bin", "node"));
+	});
+
+	it("deduplicates repeated PATH/common entries", () => {
+		const pathEnv = ["/usr/local/bin", "/usr/local/bin"].join(delimiter);
+		const out = defaultCandidatePaths("linux", { pathEnv, homeDir: "/home/me", readdir: () => [] });
+		const usrLocal = out.filter((p) => p === join("/usr/local/bin", "node"));
+		expect(usrLocal).toHaveLength(1);
+	});
+
+	it("expands nvm versions newest-first", () => {
+		const out = defaultCandidatePaths("linux", {
+			pathEnv: "",
+			homeDir: "/home/me",
+			readdir: () => ["v18.20.0", "v22.3.1", "v20.11.0"],
+		});
+		const nvm = out.filter((p) => p.includes(join(".nvm", "versions", "node")));
+		expect(nvm).toEqual([
+			join("/home/me/.nvm/versions/node", "v22.3.1", "bin", "node"),
+			join("/home/me/.nvm/versions/node", "v20.11.0", "bin", "node"),
+			join("/home/me/.nvm/versions/node", "v18.20.0", "bin", "node"),
+		]);
+	});
+
+	it("uses node.exe and skips the POSIX common dirs on Windows", () => {
+		// Note: path.delimiter is host-based, so avoid embedding it in pathEnv here;
+		// drive the exe-name assertion via the nvm expansion instead.
+		const out = defaultCandidatePaths("win32", {
+			pathEnv: "",
+			homeDir: "C:\\Users\\me",
+			readdir: () => ["v22.3.1"],
+		});
+		expect(out.length).toBeGreaterThan(0);
+		expect(out.every((p) => p.endsWith("node.exe"))).toBe(true);
+		expect(out.some((p) => p.startsWith("/opt/homebrew"))).toBe(false);
+		expect(out.some((p) => p.startsWith("/usr/local/bin"))).toBe(false);
+	});
+
+	it("tolerates a missing nvm directory (readdir throws)", () => {
+		const out = defaultCandidatePaths("linux", {
+			pathEnv: "/usr/bin",
+			homeDir: "/home/me",
+			readdir: () => {
+				throw new Error("ENOENT");
+			},
+		});
+		expect(out).toEqual([
+			join("/usr/bin", "node"),
+			join("/opt/homebrew/bin", "node"),
+			join("/usr/local/bin", "node"),
+		]);
 	});
 });

--- a/packages/vscode/test/node-path.test.ts
+++ b/packages/vscode/test/node-path.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { MIN_NODE_MAJOR, resolveNodePath } from "../src/host/node-path.js";
+
+describe("resolveNodePath", () => {
+	it("prefers the configured setting when the file exists", () => {
+		const result = resolveNodePath({
+			configuredPath: "/opt/node22/bin/node",
+			fileExists: (p) => p === "/opt/node22/bin/node",
+			candidatePaths: () => [],
+			execPath: "/electron",
+		});
+		expect(result).toEqual({ nodePath: "/opt/node22/bin/node", source: "setting" });
+	});
+
+	it("ignores a configured setting that does not exist and falls through", () => {
+		const result = resolveNodePath({
+			configuredPath: "/nope/node",
+			fileExists: (p) => p === "/usr/bin/node",
+			probeVersion: () => 22,
+			candidatePaths: () => ["/usr/bin/node"],
+			execPath: "/electron",
+		});
+		expect(result).toEqual({ nodePath: "/usr/bin/node", source: "discovered" });
+	});
+
+	it("returns the first candidate that is Node >= 22, honoring priority order", () => {
+		const versions: Record<string, number> = {
+			"/a/node": 20,
+			"/b/node": 24,
+			"/c/node": 22,
+		};
+		const result = resolveNodePath({
+			configuredPath: "",
+			fileExists: () => true,
+			probeVersion: (p) => versions[p],
+			candidatePaths: () => ["/a/node", "/b/node", "/c/node"],
+			execPath: "/electron",
+		});
+		// /a is too old (20); /b is the first >= 22 and wins even though /c is also valid.
+		expect(result).toEqual({ nodePath: "/b/node", source: "discovered" });
+	});
+
+	it("skips candidates that do not exist", () => {
+		const result = resolveNodePath({
+			configuredPath: "",
+			fileExists: (p) => p === "/real/node",
+			probeVersion: () => 22,
+			candidatePaths: () => ["/ghost/node", "/real/node"],
+			execPath: "/electron",
+		});
+		expect(result.nodePath).toBe("/real/node");
+		expect(result.source).toBe("discovered");
+	});
+
+	it("rejects candidates below the minimum major version", () => {
+		const result = resolveNodePath({
+			configuredPath: "",
+			fileExists: () => true,
+			probeVersion: () => MIN_NODE_MAJOR - 1,
+			candidatePaths: () => ["/old/node"],
+			execPath: "/electron",
+		});
+		expect(result).toEqual({
+			nodePath: "/electron",
+			env: { ELECTRON_RUN_AS_NODE: "1" },
+			source: "electron",
+		});
+	});
+
+	it("skips candidates whose version cannot be determined", () => {
+		const result = resolveNodePath({
+			configuredPath: "",
+			fileExists: () => true,
+			probeVersion: () => undefined,
+			candidatePaths: () => ["/broken/node"],
+			execPath: "/electron",
+		});
+		expect(result.source).toBe("electron");
+	});
+
+	it("falls back to the editor runtime as plain Node when nothing else qualifies", () => {
+		const result = resolveNodePath({
+			configuredPath: "",
+			fileExists: () => false,
+			candidatePaths: () => [],
+			execPath: "/path/to/code-electron",
+		});
+		expect(result).toEqual({
+			nodePath: "/path/to/code-electron",
+			env: { ELECTRON_RUN_AS_NODE: "1" },
+			source: "electron",
+		});
+	});
+});

--- a/packages/vscode/test/node-runtime-cache.test.ts
+++ b/packages/vscode/test/node-runtime-cache.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from "vitest";
+import type { NodePathResult } from "../src/host/node-path.js";
+import {
+	createNodeRuntimeCacheState,
+	electronVersionWarning,
+	resolveNodeRuntimeCached,
+} from "../src/host/node-runtime-cache.js";
+
+const discovered: NodePathResult = { nodePath: "/usr/bin/node", source: "discovered", major: 22 };
+const electronOld: NodePathResult = {
+	nodePath: "/electron",
+	env: { ELECTRON_RUN_AS_NODE: "1" },
+	source: "electron",
+	major: 20,
+};
+
+describe("resolveNodeRuntimeCached — caching (finding 2)", () => {
+	it("resolves once and reuses the cache while the setting is unchanged", () => {
+		const state = createNodeRuntimeCacheState();
+		const resolve = vi.fn(() => discovered);
+
+		const a = resolveNodeRuntimeCached(state, { configuredNodePath: "", resolve });
+		const b = resolveNodeRuntimeCached(state, { configuredNodePath: "", resolve });
+
+		expect(a).toBe(discovered);
+		expect(b).toBe(discovered);
+		// Only one probe — the second call is served from cache.
+		expect(resolve).toHaveBeenCalledTimes(1);
+	});
+
+	it("re-resolves when the dreb.nodePath setting changes", () => {
+		const state = createNodeRuntimeCacheState();
+		const custom: NodePathResult = { nodePath: "/opt/node22/bin/node", source: "setting" };
+		const resolve = vi.fn((opts: { configuredPath: string }) => (opts.configuredPath ? custom : discovered));
+
+		expect(resolveNodeRuntimeCached(state, { configuredNodePath: "", resolve })).toBe(discovered);
+		expect(resolveNodeRuntimeCached(state, { configuredNodePath: "/opt/node22/bin/node", resolve })).toBe(custom);
+		expect(resolve).toHaveBeenCalledTimes(2);
+		expect(resolve).toHaveBeenLastCalledWith({ configuredPath: "/opt/node22/bin/node" });
+
+		// Reverting to the previous key re-resolves again (cache holds only the last).
+		expect(resolveNodeRuntimeCached(state, { configuredNodePath: "", resolve })).toBe(discovered);
+		expect(resolve).toHaveBeenCalledTimes(3);
+	});
+});
+
+describe("resolveNodeRuntimeCached — one-time old-runtime warning (finding 3)", () => {
+	it("warns exactly once when the editor runtime is older than the minimum", () => {
+		const state = createNodeRuntimeCacheState();
+		const warn = vi.fn();
+		const resolve = () => electronOld;
+
+		resolveNodeRuntimeCached(state, { configuredNodePath: "", resolve, warn });
+		resolveNodeRuntimeCached(state, { configuredNodePath: "", resolve, warn });
+
+		expect(warn).toHaveBeenCalledTimes(1);
+		expect(warn).toHaveBeenCalledWith(electronVersionWarning(20));
+	});
+
+	it("does not warn when the editor runtime meets the minimum", () => {
+		const state = createNodeRuntimeCacheState();
+		const warn = vi.fn();
+		resolveNodeRuntimeCached(state, {
+			configuredNodePath: "",
+			resolve: () => ({ nodePath: "/electron", source: "electron", major: 22 }),
+			warn,
+		});
+		expect(warn).not.toHaveBeenCalled();
+	});
+
+	it("does not warn when the runtime version is unknown", () => {
+		const state = createNodeRuntimeCacheState();
+		const warn = vi.fn();
+		resolveNodeRuntimeCached(state, {
+			configuredNodePath: "",
+			resolve: () => ({ nodePath: "/electron", source: "electron" }),
+			warn,
+		});
+		expect(warn).not.toHaveBeenCalled();
+	});
+
+	it("does not warn for a discovered (non-electron) runtime", () => {
+		const state = createNodeRuntimeCacheState();
+		const warn = vi.fn();
+		resolveNodeRuntimeCached(state, { configuredNodePath: "", resolve: () => discovered, warn });
+		expect(warn).not.toHaveBeenCalled();
+	});
+
+	it("tolerates no warn callback", () => {
+		const state = createNodeRuntimeCacheState();
+		expect(() =>
+			resolveNodeRuntimeCached(state, { configuredNodePath: "", resolve: () => electronOld }),
+		).not.toThrow();
+	});
+});

--- a/packages/vscode/test/session-controller.test.ts
+++ b/packages/vscode/test/session-controller.test.ts
@@ -1661,6 +1661,46 @@ describe("SessionController", () => {
 		expect(capturedArgs).not.toContain("--session");
 	});
 
+	it("forwards nodePath and env to the client factory", async () => {
+		const fake = new FakeClient();
+		let captured: { nodePath?: string; env?: Record<string, string> } | undefined;
+		const controller = new SessionController({
+			cwd: "/tmp/project",
+			cliPath: "/cli.js",
+			nodePath: "/opt/node22/bin/node",
+			env: { ELECTRON_RUN_AS_NODE: "1" },
+			clientFactory: (opts) => {
+				captured = { nodePath: opts.nodePath, env: opts.env };
+				return fake;
+			},
+		});
+
+		await controller.start();
+
+		expect(captured).toEqual({
+			nodePath: "/opt/node22/bin/node",
+			env: { ELECTRON_RUN_AS_NODE: "1" },
+		});
+	});
+
+	it("omits nodePath and env from the factory options when unset", async () => {
+		const fake = new FakeClient();
+		let captured: { nodePath?: string; env?: Record<string, string> } | undefined;
+		const controller = new SessionController({
+			cwd: "/tmp/project",
+			cliPath: "/cli.js",
+			clientFactory: (opts) => {
+				captured = { nodePath: opts.nodePath, env: opts.env };
+				return fake;
+			},
+		});
+
+		await controller.start();
+
+		expect(captured?.nodePath).toBeUndefined();
+		expect(captured?.env).toBeUndefined();
+	});
+
 	it("rename() forwards the name to the client's setSessionName", async () => {
 		const fake = new FakeClient();
 		const controller = makeController(fake);

--- a/packages/vscode/test/uninstall-extension.test.ts
+++ b/packages/vscode/test/uninstall-extension.test.ts
@@ -1,0 +1,74 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { isSymlink, linkName } from "../scripts/install-extension.mjs";
+
+/**
+ * End-to-end guard for the round-2 dangling-symlink uninstall fix (PR #91,
+ * finding 2). The unit tests cover `isSymlink`/`removeExisting` in isolation, but
+ * the composed guard in `uninstall-extension.mjs` `main()`
+ * (`!isSymlink(linkPath) && !existsSync(linkPath)`) is only decisive at the
+ * observable outcome: a dangling link must be REMOVED, not reported as "Nothing
+ * to remove." A regression dropping the `isSymlink` term would pass every unit
+ * test but silently leave the broken extension entry behind.
+ */
+const scriptPath = join(dirname(fileURLToPath(import.meta.url)), "..", "scripts", "uninstall-extension.mjs");
+
+// The manifest the script reads to derive the link folder name.
+const pkg = { publisher: "hrovatin", name: "dreb-vscode" };
+
+function runUninstall(extDir: string): string {
+	return execFileSync(process.execPath, [scriptPath, "--dir", extDir], { encoding: "utf8" });
+}
+
+describe("uninstall-extension.mjs main() — end-to-end (finding 2)", () => {
+	let dir: string;
+	let extDir: string;
+	let linkPath: string;
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "dreb-uninstall-"));
+		extDir = join(dir, "extensions");
+		mkdirSync(extDir, { recursive: true });
+		linkPath = join(extDir, linkName(pkg));
+	});
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("removes a DANGLING symlink instead of reporting 'Nothing to remove'", () => {
+		// Install (symlink) then delete the target so the link dangles — the exact
+		// state after a user moves or deletes their dreb repo.
+		const target = join(dir, "repo");
+		mkdirSync(target);
+		symlinkSync(target, linkPath, "dir");
+		rmSync(target, { recursive: true, force: true });
+
+		expect(existsSync(linkPath)).toBe(false); // existsSync follows the dead link
+		expect(isSymlink(linkPath)).toBe(true); // but the link itself is still there
+
+		const out = runUninstall(extDir);
+		expect(out).toContain("Removed");
+		expect(out).not.toContain("Nothing to remove");
+		expect(isSymlink(linkPath)).toBe(false); // the dangling link is gone
+	});
+
+	it("removes a valid (live-target) symlink", () => {
+		const target = join(dir, "repo");
+		mkdirSync(target);
+		symlinkSync(target, linkPath, "dir");
+
+		const out = runUninstall(extDir);
+		expect(out).toContain("Removed");
+		expect(isSymlink(linkPath)).toBe(false);
+		expect(existsSync(target)).toBe(true); // real target untouched
+	});
+
+	it("reports 'Nothing to remove' when no link exists (guard's other arm)", () => {
+		const out = runUninstall(extDir);
+		expect(out).toContain("Nothing to remove");
+	});
+});


### PR DESCRIPTION
Closes #90

Make the dreb VSCode extension work out of the box when installed from within a user's dreb folder (repo-as-distribution): a repo-local symlink install that stays bound to the workspace, robust Node runtime resolution for the RPC child, and deterministic repo-relative CLI resolution.

Base branch: `vscode`. Implementation plan posted as a comment below.
