### PR TITLE
Register the VSCode extension in extensions.json on repo-local install/uninstall

### DIFF
--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -196,6 +196,8 @@ Then reload the editor (**Developer: Reload Window**) and run **dreb: Open Chat*
 - Custom extensions dir: `... --dir <path>`
 - Remove the link: `npm run uninstall-vscode`
 
+The installer also registers the extension in VS Code's `extensions.json` control file (modern VS Code no longer discovers a bare symlinked folder on its own), reconciles any prior install of dreb (including a stale copied `.vsix` folder), and `uninstall-vscode` removes both the link and that entry — so you never end up with a half-registered or dangling extension.
+
 Because it's a symlink, rebuilding the repo (`npm run build`) is picked up automatically — no re-install or re-packaging. Installing a **copied** `.vsix` instead detaches the extension from the repo and is not supported (it cannot resolve the CLI or the in-process runtime).
 
 ## Locating the dreb CLI

--- a/packages/vscode/scripts/install-extension.d.mts
+++ b/packages/vscode/scripts/install-extension.d.mts
@@ -8,6 +8,37 @@ export function installPlan(opts: {
 	target: string;
 }): { linkPath: string; targetPath: string };
 
+export function manifestPath(extDir: string): string;
+
+export interface ManifestEntry {
+	identifier: { id: string };
+	version: string;
+	location: { $mid: number; fsPath: string; external: string; path: string; scheme: string };
+	relativeLocation: string;
+	metadata: { installedTimestamp: number; pinned: boolean; source: string };
+}
+
+export function readManifest(raw: string | undefined): ManifestEntry[];
+
+export function buildManifestEntry(opts: {
+	id: string;
+	version?: string;
+	linkPath: string;
+	now?: number;
+}): ManifestEntry;
+
+export function sameId(a: unknown, b: unknown): boolean;
+
+export function upsertEntry(entries: ManifestEntry[], entry: ManifestEntry): ManifestEntry[];
+
+export function removeEntry(entries: ManifestEntry[], id: string): ManifestEntry[];
+
+export function staleInstallNames(names: string[], name: string): string[];
+
+export function safeReadFile(p: string): string | undefined;
+
+export function safeReaddir(d: string): string[];
+
 export function parseArgs(argv: string[]): { insiders: boolean; dir: string | undefined };
 
 export function removeExisting(linkPath: string, log?: (msg: string) => void): void;
@@ -20,7 +51,7 @@ export function isDirectRun(importMetaUrl: string, argv1?: string): boolean;
 
 export interface RunInstallDeps {
 	pkgRoot: string;
-	pkg: { publisher?: string; name: string };
+	pkg: { publisher?: string; name: string; version?: string };
 	extDir: string;
 	fileExists?: (path: string) => boolean;
 	makeDir?: (dir: string) => void;
@@ -28,6 +59,10 @@ export interface RunInstallDeps {
 	readLink?: (path: string) => string | undefined;
 	createSymlink?: (target: string, link: string) => void;
 	remove?: (linkPath: string, log?: (msg: string) => void) => void;
+	readDir?: (dir: string) => string[];
+	readManifestFile?: (path: string) => string | undefined;
+	writeManifestFile?: (path: string, data: string) => void;
+	now?: () => number;
 	log?: (msg: string) => void;
 	error?: (msg: string) => void;
 	exit?: (code: number) => void;
@@ -38,3 +73,19 @@ export type RunInstallResult =
 	| { ok: true; reason: "already-linked" | "linked"; linkPath: string; targetPath: string };
 
 export function runInstall(deps: RunInstallDeps): RunInstallResult;
+
+export interface RunUninstallDeps {
+	extDir: string;
+	pkg: { publisher?: string; name: string };
+	isLink?: (path: string) => boolean;
+	fileExists?: (path: string) => boolean;
+	remove?: (linkPath: string, log?: (msg: string) => void) => void;
+	readDir?: (dir: string) => string[];
+	readManifestFile?: (path: string) => string | undefined;
+	writeManifestFile?: (path: string, data: string) => void;
+	log?: (msg: string) => void;
+}
+
+export type RunUninstallResult = { ok: true; reason: "nothing" | "removed" };
+
+export function runUninstall(deps: RunUninstallDeps): RunUninstallResult;

--- a/packages/vscode/scripts/install-extension.d.mts
+++ b/packages/vscode/scripts/install-extension.d.mts
@@ -20,6 +20,8 @@ export interface ManifestEntry {
 
 export function readManifest(raw: string | undefined): ManifestEntry[];
 
+export function parseManifest(raw: string | undefined): { entries: ManifestEntry[]; malformed: boolean };
+
 export function buildManifestEntry(opts: {
 	id: string;
 	version?: string;
@@ -70,6 +72,7 @@ export interface RunInstallDeps {
 
 export type RunInstallResult =
 	| { ok: false; reason: "missing-build"; missing: string[] }
+	| { ok: false; reason: "manifest-malformed"; linkPath: string; targetPath: string }
 	| { ok: true; reason: "already-linked" | "linked"; linkPath: string; targetPath: string };
 
 export function runInstall(deps: RunInstallDeps): RunInstallResult;

--- a/packages/vscode/scripts/install-extension.mjs
+++ b/packages/vscode/scripts/install-extension.mjs
@@ -68,16 +68,34 @@ export function manifestPath(extDir) {
 	return join(extDir, "extensions.json");
 }
 
-/** Parse the manifest's raw JSON into an array of entries. Tolerant: a missing
- * (`undefined`), empty, non-array, or malformed file yields `[]` — never throws. */
-export function readManifest(raw) {
-	if (!raw) return [];
+/** Parse the manifest's raw JSON into `{ entries, malformed }`.
+ *
+ * - absent (`undefined`) or empty/whitespace-only → `{ entries: [], malformed: false }`
+ *   (nothing to preserve; safe to create fresh);
+ * - a valid JSON array → `{ entries, malformed: false }`;
+ * - present but non-array or unparseable → `{ entries: [], malformed: true }`.
+ *
+ * The `malformed` flag lets a caller refuse to overwrite a file it could not
+ * understand — the manifest lists *every* installed extension, so blindly
+ * rewriting an unreadable one would silently deregister the others. Never throws. */
+export function parseManifest(raw) {
+	if (raw === undefined || raw.trim() === "") return { entries: [], malformed: false };
 	try {
 		const parsed = JSON.parse(raw);
-		return Array.isArray(parsed) ? parsed : [];
+		if (Array.isArray(parsed)) return { entries: parsed, malformed: false };
 	} catch {
-		return [];
+		// fall through to malformed
 	}
+	return { entries: [], malformed: true };
+}
+
+/** Parse the manifest's raw JSON into an array of entries. Tolerant: a missing
+ * (`undefined`), empty, non-array, or malformed file yields `[]` — never throws.
+ * Use this where a malformed manifest should be treated as empty (e.g. uninstall,
+ * which then simply finds nothing to remove); prefer `parseManifest` when the
+ * malformed case must be distinguished before overwriting the file. */
+export function readManifest(raw) {
+	return parseManifest(raw).entries;
 }
 
 /** Build the manifest entry VS Code expects for a symlinked (dev) extension. */
@@ -117,9 +135,12 @@ export function removeEntry(entries, id) {
 /** Stale on-disk install folders belonging to this extension: versioned-copy
  * variants like `<id>-0.1.0` (a prior `.vsix`-style install). The canonical
  * `<id>` link itself is excluded — install (re)creates it, uninstall removes it
- * via the normal link path. */
+ * via the normal link path. Only a *version-shaped* suffix (`-` followed by a
+ * digit) counts, so a genuinely different sibling extension that merely shares
+ * the id prefix (e.g. `<id>-extras`) is never matched and never deleted. */
 export function staleInstallNames(names, name) {
-	return names.filter((n) => n !== name && n.startsWith(`${name}-`));
+	const prefix = `${name}-`;
+	return names.filter((n) => n !== name && n.startsWith(prefix) && /^\d/.test(n.slice(prefix.length)));
 }
 
 
@@ -166,6 +187,16 @@ export function isSymlink(p) {
 function pkgRootDir() {
 	// scripts/ -> packages/vscode
 	return resolve(dirname(fileURLToPath(import.meta.url)), "..");
+}
+
+/** Remove every stale versioned-copy folder in `staleNames`, logging each. Shared
+ * by install and uninstall so their cleanup wording/semantics can't drift apart. */
+function removeStaleInstalls(staleNames, extDir, remove, log) {
+	for (const n of staleNames) {
+		const stalePath = join(extDir, n);
+		remove(stalePath, log);
+		log(`Removed stale install: ${stalePath}`);
+	}
 }
 
 /**
@@ -222,19 +253,27 @@ export function runInstall({
 
 	// Reconcile any prior install state: remove leftover versioned-copy folders
 	// (e.g. a stale `.vsix`-style `<id>-0.1.0`) so the editor sees exactly one.
-	for (const stale of staleInstallNames(readDir(extDir), name)) {
-		const stalePath = join(extDir, stale);
-		remove(stalePath, log);
-		log(`Removed stale install: ${stalePath}`);
-	}
+	removeStaleInstalls(staleInstallNames(readDir(extDir), name), extDir, remove, log);
 
 	// Register (or refresh) the extensions.json entry. Runs on both paths so a
 	// pre-existing symlink with a missing/stale manifest entry self-heals —
 	// without this, modern VS Code silently never loads the extension.
+	//
+	// The manifest lists *every* installed extension. If the file is present but
+	// unparseable (truncated by a concurrent editor write, hand-edited, etc.),
+	// refuse to overwrite it — collapsing it to `[]` and rewriting would silently
+	// deregister all the user's other extensions. `runUninstall` guards the same
+	// way. An absent/empty file is fine to create fresh.
 	const manifestFile = manifestPath(extDir);
+	const { entries: existing, malformed } = parseManifest(readManifestFile(manifestFile));
+	if (malformed) {
+		error(`dreb: ${manifestFile} exists but is not a valid JSON array — refusing to overwrite it.`);
+		error("  Fix or remove that file, then re-run — otherwise your other extensions would be deregistered.");
+		exit(1);
+		return { ok: false, reason: "manifest-malformed", linkPath, targetPath };
+	}
 	const entry = buildManifestEntry({ id: name, version: pkg.version, linkPath, now: now() });
-	const entries = upsertEntry(readManifest(readManifestFile(manifestFile)), entry);
-	writeManifestFile(manifestFile, JSON.stringify(entries, null, 0));
+	writeManifestFile(manifestFile, JSON.stringify(upsertEntry(existing, entry), null, 0));
 	log(`Registered ${name} in ${manifestFile}`);
 
 	log('Reload the editor ("Developer: Reload Window") to activate the extension.');
@@ -260,7 +299,7 @@ export function runUninstall({
 	log = console.log,
 }) {
 	const name = linkName(pkg);
-	const { linkPath } = installPlan({ extDir, pkg, target: "" });
+	const linkPath = join(extDir, name);
 
 	// The link itself: check with `isSymlink` (lstat-based), not `existsSync`,
 	// which follows the link — after the user moves/deletes their dreb repo the
@@ -287,11 +326,7 @@ export function runUninstall({
 		remove(linkPath);
 		log(`Removed ${linkPath}`);
 	}
-	for (const n of stale) {
-		const stalePath = join(extDir, n);
-		remove(stalePath, log);
-		log(`Removed stale install: ${stalePath}`);
-	}
+	removeStaleInstalls(stale, extDir, remove, log);
 	if (manifestChanged) {
 		writeManifestFile(manifestFile, JSON.stringify(after, null, 0));
 		log(`Deregistered ${name} from ${manifestFile}`);

--- a/packages/vscode/scripts/install-extension.mjs
+++ b/packages/vscode/scripts/install-extension.mjs
@@ -16,7 +16,18 @@
  * is executed directly.
  */
 
-import { existsSync, lstatSync, mkdirSync, readlinkSync, realpathSync, rmSync, symlinkSync } from "node:fs";
+import {
+	existsSync,
+	lstatSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	readlinkSync,
+	realpathSync,
+	rmSync,
+	symlinkSync,
+	writeFileSync,
+} from "node:fs";
 import { createRequire } from "node:module";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -42,6 +53,75 @@ export function linkName(pkg) {
 export function installPlan({ extDir, pkg, target }) {
 	return { linkPath: join(extDir, linkName(pkg)), targetPath: target };
 }
+
+// ---------------------------------------------------------------------------
+// extensions.json manifest helpers (pure; unit-tested)
+//
+// Modern VS Code (verified on 1.134.0) treats `<extensionsDir>/extensions.json`
+// as the authoritative list of user-installed extensions and no longer purely
+// directory-scans, so a bare symlink is invisible unless it is also registered
+// here. These helpers build/merge that manifest with no side effects.
+// ---------------------------------------------------------------------------
+
+/** Path to the editor's user-extensions control file. */
+export function manifestPath(extDir) {
+	return join(extDir, "extensions.json");
+}
+
+/** Parse the manifest's raw JSON into an array of entries. Tolerant: a missing
+ * (`undefined`), empty, non-array, or malformed file yields `[]` — never throws. */
+export function readManifest(raw) {
+	if (!raw) return [];
+	try {
+		const parsed = JSON.parse(raw);
+		return Array.isArray(parsed) ? parsed : [];
+	} catch {
+		return [];
+	}
+}
+
+/** Build the manifest entry VS Code expects for a symlinked (dev) extension. */
+export function buildManifestEntry({ id, version, linkPath, now = Date.now() }) {
+	return {
+		identifier: { id },
+		version: version ?? "0.0.0",
+		location: {
+			$mid: 1,
+			fsPath: linkPath,
+			external: pathToFileURL(linkPath).href,
+			path: linkPath,
+			scheme: "file",
+		},
+		relativeLocation: id,
+		metadata: { installedTimestamp: now, pinned: true, source: "vsix" },
+	};
+}
+
+/** True when two extension ids match. VS Code compares ids case-insensitively. */
+export function sameId(a, b) {
+	return String(a ?? "").toLowerCase() === String(b ?? "").toLowerCase();
+}
+
+/** Return a new array with every existing entry for `entry.identifier.id`
+ * dropped and `entry` appended — so re-installs never duplicate the extension. */
+export function upsertEntry(entries, entry) {
+	const id = entry.identifier?.id;
+	return [...entries.filter((e) => !sameId(e?.identifier?.id, id)), entry];
+}
+
+/** Return a new array with every entry for `id` removed. */
+export function removeEntry(entries, id) {
+	return entries.filter((e) => !sameId(e?.identifier?.id, id));
+}
+
+/** Stale on-disk install folders belonging to this extension: versioned-copy
+ * variants like `<id>-0.1.0` (a prior `.vsix`-style install). The canonical
+ * `<id>` link itself is excluded — install (re)creates it, uninstall removes it
+ * via the normal link path. */
+export function staleInstallNames(names, name) {
+	return names.filter((n) => n !== name && n.startsWith(`${name}-`));
+}
+
 
 /** Parse the supported flags: `--insiders` and `--dir <path>`. */
 export function parseArgs(argv) {
@@ -104,6 +184,10 @@ export function runInstall({
 	readLink = safeReadlink,
 	createSymlink = (target, link) => symlinkSync(target, link, "dir"),
 	remove = removeExisting,
+	readDir = safeReaddir,
+	readManifestFile = safeReadFile,
+	writeManifestFile = (p, data) => writeFileSync(p, data),
+	now = Date.now,
 	log = console.log,
 	error = console.error,
 	exit = process.exit,
@@ -120,20 +204,101 @@ export function runInstall({
 	}
 
 	makeDir(extDir);
+	const name = linkName(pkg);
 	const { linkPath, targetPath } = installPlan({ extDir, pkg, target: pkgRoot });
 
-	// Idempotent: if already linked to this target, nothing to do.
+	// (Re)establish the canonical symlink. Idempotent: leave it in place when it
+	// already points at this target, otherwise remove-and-relink.
+	let reason;
 	if (isLink(linkPath) && readLink(linkPath) === targetPath) {
+		reason = "already-linked";
 		log(`Already linked: ${linkPath} -> ${targetPath}`);
-		log('Reload the editor ("Developer: Reload Window") to activate the extension.');
-		return { ok: true, reason: "already-linked", linkPath, targetPath };
+	} else {
+		remove(linkPath);
+		createSymlink(targetPath, linkPath);
+		reason = "linked";
+		log(`Linked ${linkPath} -> ${targetPath}`);
 	}
 
-	remove(linkPath);
-	createSymlink(targetPath, linkPath);
-	log(`Linked ${linkPath} -> ${targetPath}`);
+	// Reconcile any prior install state: remove leftover versioned-copy folders
+	// (e.g. a stale `.vsix`-style `<id>-0.1.0`) so the editor sees exactly one.
+	for (const stale of staleInstallNames(readDir(extDir), name)) {
+		const stalePath = join(extDir, stale);
+		remove(stalePath, log);
+		log(`Removed stale install: ${stalePath}`);
+	}
+
+	// Register (or refresh) the extensions.json entry. Runs on both paths so a
+	// pre-existing symlink with a missing/stale manifest entry self-heals —
+	// without this, modern VS Code silently never loads the extension.
+	const manifestFile = manifestPath(extDir);
+	const entry = buildManifestEntry({ id: name, version: pkg.version, linkPath, now: now() });
+	const entries = upsertEntry(readManifest(readManifestFile(manifestFile)), entry);
+	writeManifestFile(manifestFile, JSON.stringify(entries, null, 0));
+	log(`Registered ${name} in ${manifestFile}`);
+
 	log('Reload the editor ("Developer: Reload Window") to activate the extension.');
-	return { ok: true, reason: "linked", linkPath, targetPath };
+	return { ok: true, reason, linkPath, targetPath };
+}
+
+/**
+ * Core uninstall logic (paired with `runInstall`), with every side effect
+ * injectable so it can be unit-tested without touching the real filesystem.
+ * Removes the symlink, any stale versioned-copy folders, and this extension's
+ * `extensions.json` entry. Safe when nothing is installed and when the manifest
+ * is absent/malformed. The `uninstall-extension.mjs` CLI is a thin wrapper.
+ */
+export function runUninstall({
+	extDir,
+	pkg,
+	isLink = isSymlink,
+	fileExists = existsSync,
+	remove = removeExisting,
+	readDir = safeReaddir,
+	readManifestFile = safeReadFile,
+	writeManifestFile = (p, data) => writeFileSync(p, data),
+	log = console.log,
+}) {
+	const name = linkName(pkg);
+	const { linkPath } = installPlan({ extDir, pkg, target: "" });
+
+	// The link itself: check with `isSymlink` (lstat-based), not `existsSync`,
+	// which follows the link — after the user moves/deletes their dreb repo the
+	// link dangles and `existsSync` would report it gone, silently leaving the
+	// broken extension entry behind.
+	const linkPresent = isLink(linkPath) || fileExists(linkPath);
+
+	// Leftover versioned-copy folders from a prior `.vsix`-style install.
+	const stale = staleInstallNames(readDir(extDir), name);
+
+	// The manifest entry (only rewrite when it actually changes / exists).
+	const manifestFile = manifestPath(extDir);
+	const raw = readManifestFile(manifestFile);
+	const before = readManifest(raw);
+	const after = removeEntry(before, name);
+	const manifestChanged = raw !== undefined && after.length !== before.length;
+
+	if (!linkPresent && stale.length === 0 && !manifestChanged) {
+		log(`Nothing to remove: ${linkPath} does not exist.`);
+		return { ok: true, reason: "nothing" };
+	}
+
+	if (linkPresent) {
+		remove(linkPath);
+		log(`Removed ${linkPath}`);
+	}
+	for (const n of stale) {
+		const stalePath = join(extDir, n);
+		remove(stalePath, log);
+		log(`Removed stale install: ${stalePath}`);
+	}
+	if (manifestChanged) {
+		writeManifestFile(manifestFile, JSON.stringify(after, null, 0));
+		log(`Deregistered ${name} from ${manifestFile}`);
+	}
+
+	log('Reload the editor ("Developer: Reload Window") to deactivate the extension.');
+	return { ok: true, reason: "removed" };
 }
 
 function main() {
@@ -151,6 +316,24 @@ export function safeReadlink(p) {
 		return readlinkSync(p);
 	} catch {
 		return undefined;
+	}
+}
+
+/** Read a file as UTF-8, or `undefined` if it does not exist / is unreadable. */
+export function safeReadFile(p) {
+	try {
+		return readFileSync(p, "utf8");
+	} catch {
+		return undefined;
+	}
+}
+
+/** List a directory's entries, or `[]` if it does not exist / is unreadable. */
+export function safeReaddir(d) {
+	try {
+		return readdirSync(d);
+	} catch {
+		return [];
 	}
 }
 

--- a/packages/vscode/scripts/uninstall-extension.mjs
+++ b/packages/vscode/scripts/uninstall-extension.mjs
@@ -1,18 +1,25 @@
 #!/usr/bin/env node
 /**
- * Remove a repo-local install of the dreb VSCode extension (the symlink created
- * by `install-extension.mjs`).
+ * Remove a repo-local install of the dreb VSCode extension.
+ *
+ * Undoes everything `install-extension.mjs` creates: the symlink, any leftover
+ * versioned-copy folders, and the `extensions.json` registration entry — so no
+ * dangling reference is left behind for VS Code to trip over.
+ *
+ * The core logic lives in `install-extension.mjs` (`runUninstall`, unit-tested
+ * there); this file is the thin CLI wrapper. Keeping the testable core in the
+ * install module also avoids importing this file in-process from tests, which
+ * would trip its `isDirectRun` entrypoint guard under some runners.
  *
  * Usage (from the repo root):
  *   npm run uninstall-vscode
  *   node packages/vscode/scripts/uninstall-extension.mjs [--insiders] [--dir <path>]
  */
 
-import { existsSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { extensionsDir, installPlan, isDirectRun, isSymlink, parseArgs, removeExisting } from "./install-extension.mjs";
+import { extensionsDir, isDirectRun, parseArgs, runUninstall } from "./install-extension.mjs";
 
 function main() {
 	const pkgRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -21,19 +28,7 @@ function main() {
 
 	const args = parseArgs(process.argv.slice(2));
 	const extDir = extensionsDir({ insiders: args.insiders, override: args.dir });
-	const { linkPath } = installPlan({ extDir, pkg, target: pkgRoot });
-
-	// Check the link's own existence with `isSymlink` (lstat-based), not
-	// `existsSync`, which follows the symlink: after the user moves or deletes
-	// their dreb repo the link is dangling, and `existsSync` would report it as
-	// gone — silently leaving the broken extension entry behind.
-	if (!isSymlink(linkPath) && !existsSync(linkPath)) {
-		console.log(`Nothing to remove: ${linkPath} does not exist.`);
-		return;
-	}
-	removeExisting(linkPath);
-	console.log(`Removed ${linkPath}`);
-	console.log('Reload the editor ("Developer: Reload Window") to deactivate the extension.');
+	runUninstall({ extDir, pkg });
 }
 
 // Run only when executed directly (see isDirectRun in install-extension.mjs).

--- a/packages/vscode/test/install-extension.test.ts
+++ b/packages/vscode/test/install-extension.test.ts
@@ -14,15 +14,23 @@ import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+	buildManifestEntry,
 	extensionsDir,
 	installPlan,
 	isDirectRun,
 	isSymlink,
 	linkName,
+	manifestPath,
 	parseArgs,
+	readManifest,
+	removeEntry,
 	removeExisting,
 	runInstall,
+	runUninstall,
 	safeReadlink,
+	sameId,
+	staleInstallNames,
+	upsertEntry,
 } from "../scripts/install-extension.mjs";
 
 describe("install-extension helpers", () => {
@@ -118,7 +126,14 @@ describe("install-extension helpers", () => {
 });
 
 describe("runInstall (side-effecting install core)", () => {
-	const pkg = { publisher: "hrovatin", name: "dreb-vscode" };
+	const pkg = { publisher: "hrovatin", name: "dreb-vscode", version: "0.1.0" };
+	// Manifest deps that keep the abstract tests off the real filesystem.
+	const noFs = () => ({
+		readDir: () => [] as string[],
+		readManifestFile: () => undefined as string | undefined,
+		writeManifestFile: () => {},
+		now: () => 12345,
+	});
 
 	it("exits(1) and reports missing build outputs without touching the filesystem", () => {
 		const codes: number[] = [];
@@ -152,10 +167,11 @@ describe("runInstall (side-effecting install core)", () => {
 		expect(linked).toBe(false);
 	});
 
-	it("is a no-op when already linked to the same target", () => {
+	it("is a no-op (symlink) but still registers the manifest when already linked", () => {
 		let symlinkCalls = 0;
 		let removeCalls = 0;
 		const logs: string[] = [];
+		const writes: Array<[string, string]> = [];
 		const result = runInstall({
 			pkgRoot: "/repo/packages/vscode",
 			pkg,
@@ -170,6 +186,8 @@ describe("runInstall (side-effecting install core)", () => {
 			remove: () => {
 				removeCalls++;
 			},
+			...noFs(),
+			writeManifestFile: (p: string, d: string) => writes.push([p, d]),
 			log: (m: string) => logs.push(m),
 			error: () => {},
 			exit: () => {},
@@ -178,11 +196,16 @@ describe("runInstall (side-effecting install core)", () => {
 		expect(symlinkCalls).toBe(0);
 		expect(removeCalls).toBe(0);
 		expect(logs.join("\n")).toContain("Already linked");
+		// Self-heals a missing manifest entry even when the symlink already exists.
+		expect(writes).toHaveLength(1);
+		expect(writes[0][0]).toBe("/ext/extensions.json");
+		expect(JSON.parse(writes[0][1])[0].identifier.id).toBe("hrovatin.dreb-vscode");
 	});
 
 	it("removes any existing entry and creates the symlink when not yet linked", () => {
 		const symlinks: Array<[string, string]> = [];
 		const removed: string[] = [];
+		const writes: Array<[string, string]> = [];
 		const result = runInstall({
 			pkgRoot: "/repo/packages/vscode",
 			pkg,
@@ -193,6 +216,8 @@ describe("runInstall (side-effecting install core)", () => {
 			readLink: () => undefined,
 			remove: (p: string) => removed.push(p),
 			createSymlink: (target: string, link: string) => symlinks.push([target, link]),
+			...noFs(),
+			writeManifestFile: (p: string, d: string) => writes.push([p, d]),
 			log: () => {},
 			error: () => {},
 			exit: () => {},
@@ -200,6 +225,52 @@ describe("runInstall (side-effecting install core)", () => {
 		expect(result).toMatchObject({ ok: true, reason: "linked" });
 		expect(removed).toEqual(["/ext/hrovatin.dreb-vscode"]);
 		expect(symlinks).toEqual([["/repo/packages/vscode", "/ext/hrovatin.dreb-vscode"]]);
+		// A well-formed manifest entry pointing at the symlink is written.
+		const entry = JSON.parse(writes[0][1])[0];
+		expect(entry).toMatchObject({
+			identifier: { id: "hrovatin.dreb-vscode" },
+			version: "0.1.0",
+			relativeLocation: "hrovatin.dreb-vscode",
+		});
+		expect(entry.location.path).toBe("/ext/hrovatin.dreb-vscode");
+	});
+
+	it("reconciles a stale versioned-copy folder and dedupes an existing manifest entry", () => {
+		const removed: string[] = [];
+		const writes: Array<[string, string]> = [];
+		// Prior state: a copied `.vsix`-style folder and a stale manifest entry.
+		const prior = JSON.stringify([
+			{ identifier: { id: "hrovatin.dreb-vscode" }, version: "0.0.9" },
+			{ identifier: { id: "other.ext" }, version: "1.0.0" },
+		]);
+		runInstall({
+			pkgRoot: "/repo/packages/vscode",
+			pkg,
+			extDir: "/ext",
+			fileExists: () => true,
+			makeDir: () => {},
+			isLink: () => false,
+			readLink: () => undefined,
+			remove: (p: string) => removed.push(p),
+			createSymlink: () => {},
+			readDir: () => ["hrovatin.dreb-vscode", "hrovatin.dreb-vscode-0.1.0", "unrelated.ext"],
+			readManifestFile: () => prior,
+			writeManifestFile: (p: string, d: string) => writes.push([p, d]),
+			now: () => 12345,
+			log: () => {},
+			error: () => {},
+			exit: () => {},
+		});
+		// The canonical link is (re)removed; the versioned copy is cleaned; the
+		// unrelated extension is left alone.
+		expect(removed).toContain("/ext/hrovatin.dreb-vscode-0.1.0");
+		expect(removed).not.toContain("/ext/unrelated.ext");
+		const entries = JSON.parse(writes[0][1]);
+		// Exactly one dreb entry (deduped), unrelated entry preserved.
+		expect(
+			entries.filter((e: { identifier: { id: string } }) => e.identifier.id === "hrovatin.dreb-vscode"),
+		).toHaveLength(1);
+		expect(entries.some((e: { identifier: { id: string } }) => e.identifier.id === "other.ext")).toBe(true);
 	});
 
 	it("re-links when an existing symlink points at a different target", () => {
@@ -215,6 +286,7 @@ describe("runInstall (side-effecting install core)", () => {
 			readLink: () => "/some/OTHER/old/checkout", // stale target
 			remove: (p: string) => removed.push(p),
 			createSymlink: (target: string, link: string) => symlinks.push([target, link]),
+			...noFs(),
 			log: () => {},
 			error: () => {},
 			exit: () => {},
@@ -345,5 +417,219 @@ describe("isSymlink (uninstall guard for dangling links — finding 1)", () => {
 
 	it("returns false for a non-existent path", () => {
 		expect(isSymlink(join(dir, "nope"))).toBe(false);
+	});
+});
+
+describe("extensions.json manifest helpers (issue 92)", () => {
+	describe("manifestPath", () => {
+		it("resolves to <extDir>/extensions.json", () => {
+			expect(manifestPath("/home/u/.vscode/extensions")).toBe("/home/u/.vscode/extensions/extensions.json");
+		});
+	});
+
+	describe("readManifest", () => {
+		it("parses a JSON array of entries", () => {
+			expect(readManifest('[{"identifier":{"id":"a.b"}}]')).toEqual([{ identifier: { id: "a.b" } }]);
+		});
+		it("returns [] for undefined (missing file)", () => {
+			expect(readManifest(undefined)).toEqual([]);
+		});
+		it("returns [] for an empty string", () => {
+			expect(readManifest("")).toEqual([]);
+		});
+		it("returns [] for malformed JSON", () => {
+			expect(readManifest("{not json")).toEqual([]);
+		});
+		it("returns [] when the JSON is not an array", () => {
+			expect(readManifest('{"identifier":{"id":"a.b"}}')).toEqual([]);
+		});
+	});
+
+	describe("buildManifestEntry", () => {
+		it("builds the VS Code entry shape with a file:// location and metadata", () => {
+			const entry = buildManifestEntry({
+				id: "hrovatin.dreb-vscode",
+				version: "0.1.0",
+				linkPath: "/ext/hrovatin.dreb-vscode",
+				now: 999,
+			});
+			expect(entry).toEqual({
+				identifier: { id: "hrovatin.dreb-vscode" },
+				version: "0.1.0",
+				location: {
+					$mid: 1,
+					fsPath: "/ext/hrovatin.dreb-vscode",
+					external: "file:///ext/hrovatin.dreb-vscode",
+					path: "/ext/hrovatin.dreb-vscode",
+					scheme: "file",
+				},
+				relativeLocation: "hrovatin.dreb-vscode",
+				metadata: { installedTimestamp: 999, pinned: true, source: "vsix" },
+			});
+		});
+		it("percent-encodes spaces in the external file URL", () => {
+			const entry = buildManifestEntry({ id: "x.y", version: "1.0.0", linkPath: "/My Ext/x.y", now: 1 });
+			expect(entry.location.external).toContain("%20");
+		});
+		it("falls back to 0.0.0 when version is missing", () => {
+			expect(buildManifestEntry({ id: "x.y", linkPath: "/e/x.y", now: 1 }).version).toBe("0.0.0");
+		});
+	});
+
+	describe("sameId", () => {
+		it("matches case-insensitively", () => {
+			expect(sameId("Hrovatin.Dreb-VSCode", "hrovatin.dreb-vscode")).toBe(true);
+			expect(sameId("a.b", "a.c")).toBe(false);
+		});
+	});
+
+	describe("upsertEntry", () => {
+		it("adds to an empty manifest", () => {
+			const e = buildManifestEntry({ id: "a.b", version: "1.0.0", linkPath: "/e/a.b", now: 1 });
+			expect(upsertEntry([], e)).toEqual([e]);
+		});
+		it("replaces an existing entry with the same id (no duplicate)", () => {
+			const old = { identifier: { id: "a.b" }, version: "0.0.9" };
+			const e = buildManifestEntry({ id: "a.b", version: "1.0.0", linkPath: "/e/a.b", now: 1 });
+			const out = upsertEntry([old, { identifier: { id: "c.d" } }], e);
+			expect(out).toHaveLength(2);
+			expect(out.filter((x) => x.identifier.id === "a.b")).toEqual([e]);
+			expect(out.some((x) => x.identifier.id === "c.d")).toBe(true);
+		});
+		it("treats ids case-insensitively when replacing", () => {
+			const old = { identifier: { id: "A.B" }, version: "0.0.9" };
+			const e = buildManifestEntry({ id: "a.b", version: "1.0.0", linkPath: "/e/a.b", now: 1 });
+			expect(upsertEntry([old], e)).toEqual([e]);
+		});
+	});
+
+	describe("removeEntry", () => {
+		it("removes the matching id and preserves others", () => {
+			const entries = [{ identifier: { id: "a.b" } }, { identifier: { id: "c.d" } }];
+			expect(removeEntry(entries, "a.b")).toEqual([{ identifier: { id: "c.d" } }]);
+		});
+		it("is case-insensitive and a no-op when absent", () => {
+			const entries = [{ identifier: { id: "A.B" } }];
+			expect(removeEntry(entries, "a.b")).toEqual([]);
+			expect(removeEntry(entries, "z.z")).toEqual(entries);
+		});
+	});
+
+	describe("staleInstallNames", () => {
+		it("matches versioned-copy variants but not the canonical link or others", () => {
+			const names = [
+				"hrovatin.dreb-vscode",
+				"hrovatin.dreb-vscode-0.1.0",
+				"hrovatin.dreb-vscode-0.2.0",
+				"other.ext",
+			];
+			expect(staleInstallNames(names, "hrovatin.dreb-vscode")).toEqual([
+				"hrovatin.dreb-vscode-0.1.0",
+				"hrovatin.dreb-vscode-0.2.0",
+			]);
+		});
+		it("returns [] when only the canonical link is present", () => {
+			expect(staleInstallNames(["hrovatin.dreb-vscode"], "hrovatin.dreb-vscode")).toEqual([]);
+		});
+	});
+});
+
+describe("runUninstall (side-effecting uninstall core — issue 92)", () => {
+	const pkg = { publisher: "hrovatin", name: "dreb-vscode" };
+
+	it("removes the symlink and deregisters the manifest entry (keeps unrelated)", () => {
+		const removed: string[] = [];
+		const writes: Array<[string, string]> = [];
+		const result = runUninstall({
+			extDir: "/ext",
+			pkg,
+			isLink: () => true,
+			fileExists: () => true,
+			readDir: () => ["hrovatin.dreb-vscode"],
+			readManifestFile: () =>
+				JSON.stringify([{ identifier: { id: "hrovatin.dreb-vscode" } }, { identifier: { id: "other.ext" } }]),
+			remove: (p: string) => removed.push(p),
+			writeManifestFile: (p: string, d: string) => writes.push([p, d]),
+			log: () => {},
+		});
+		expect(result).toMatchObject({ reason: "removed" });
+		expect(removed).toEqual(["/ext/hrovatin.dreb-vscode"]);
+		expect(JSON.parse(writes[0][1])).toEqual([{ identifier: { id: "other.ext" } }]);
+	});
+
+	it("removes leftover versioned-copy folders alongside the symlink", () => {
+		const removed: string[] = [];
+		runUninstall({
+			extDir: "/ext",
+			pkg,
+			isLink: () => true,
+			fileExists: () => true,
+			readDir: () => ["hrovatin.dreb-vscode", "hrovatin.dreb-vscode-0.1.0", "unrelated.ext"],
+			readManifestFile: () => undefined,
+			remove: (p: string) => removed.push(p),
+			writeManifestFile: () => {},
+			log: () => {},
+		});
+		expect(removed).toContain("/ext/hrovatin.dreb-vscode");
+		expect(removed).toContain("/ext/hrovatin.dreb-vscode-0.1.0");
+		expect(removed).not.toContain("/ext/unrelated.ext");
+	});
+
+	it("clears a stale manifest entry even when no symlink is present", () => {
+		const removed: string[] = [];
+		const writes: Array<[string, string]> = [];
+		const result = runUninstall({
+			extDir: "/ext",
+			pkg,
+			isLink: () => false,
+			fileExists: () => false,
+			readDir: () => [],
+			readManifestFile: () => JSON.stringify([{ identifier: { id: "hrovatin.dreb-vscode" } }]),
+			remove: (p: string) => removed.push(p),
+			writeManifestFile: (p: string, d: string) => writes.push([p, d]),
+			log: () => {},
+		});
+		expect(result).toMatchObject({ reason: "removed" });
+		expect(removed).toEqual([]); // nothing on disk to unlink
+		expect(JSON.parse(writes[0][1])).toEqual([]);
+	});
+
+	it("reports 'nothing' and writes nothing when clean", () => {
+		const removed: string[] = [];
+		const writes: Array<[string, string]> = [];
+		const logs: string[] = [];
+		const result = runUninstall({
+			extDir: "/ext",
+			pkg,
+			isLink: () => false,
+			fileExists: () => false,
+			readDir: () => [],
+			readManifestFile: () => undefined,
+			remove: (p: string) => removed.push(p),
+			writeManifestFile: (p: string, d: string) => writes.push([p, d]),
+			log: (m: string) => logs.push(m),
+		});
+		expect(result).toMatchObject({ reason: "nothing" });
+		expect(removed).toEqual([]);
+		expect(writes).toEqual([]);
+		expect(logs.join("\n")).toContain("Nothing to remove");
+	});
+
+	it("tolerates a malformed manifest (treats as empty, no rewrite)", () => {
+		const writes: Array<[string, string]> = [];
+		const result = runUninstall({
+			extDir: "/ext",
+			pkg,
+			isLink: () => false,
+			fileExists: () => false,
+			readDir: () => [],
+			readManifestFile: () => "{not json",
+			remove: () => {},
+			writeManifestFile: (p: string, d: string) => writes.push([p, d]),
+			log: () => {},
+		});
+		// Malformed => parsed as [], removal is a no-op, so nothing is rewritten.
+		expect(result).toMatchObject({ reason: "nothing" });
+		expect(writes).toEqual([]);
 	});
 });

--- a/packages/vscode/test/install-extension.test.ts
+++ b/packages/vscode/test/install-extension.test.ts
@@ -3,6 +3,7 @@ import {
 	lstatSync,
 	mkdirSync,
 	mkdtempSync,
+	readFileSync,
 	readlinkSync,
 	realpathSync,
 	rmSync,
@@ -22,6 +23,7 @@ import {
 	linkName,
 	manifestPath,
 	parseArgs,
+	parseManifest,
 	readManifest,
 	removeEntry,
 	removeExisting,
@@ -266,11 +268,48 @@ describe("runInstall (side-effecting install core)", () => {
 		expect(removed).toContain("/ext/hrovatin.dreb-vscode-0.1.0");
 		expect(removed).not.toContain("/ext/unrelated.ext");
 		const entries = JSON.parse(writes[0][1]);
-		// Exactly one dreb entry (deduped), unrelated entry preserved.
-		expect(
-			entries.filter((e: { identifier: { id: string } }) => e.identifier.id === "hrovatin.dreb-vscode"),
-		).toHaveLength(1);
+		// Exactly one dreb entry (deduped), and it is the freshly-built entry —
+		// the stale `version: "0.0.9"` is replaced, not merely kept alongside.
+		const drebEntries = entries.filter(
+			(e: { identifier: { id: string } }) => e.identifier.id === "hrovatin.dreb-vscode",
+		);
+		expect(drebEntries).toHaveLength(1);
+		expect(drebEntries[0].version).toBe(pkg.version);
+		expect(drebEntries[0].location.path).toBe("/ext/hrovatin.dreb-vscode");
+		expect(drebEntries[0].metadata.installedTimestamp).toBe(12345);
 		expect(entries.some((e: { identifier: { id: string } }) => e.identifier.id === "other.ext")).toBe(true);
+	});
+
+	it("aborts without overwriting when extensions.json is present but malformed (finding 1)", () => {
+		const writes: Array<[string, string]> = [];
+		const errors: string[] = [];
+		let exitCode: number | undefined;
+		const result = runInstall({
+			pkgRoot: "/repo/packages/vscode",
+			pkg,
+			extDir: "/ext",
+			fileExists: () => true,
+			makeDir: () => {},
+			isLink: () => false,
+			readLink: () => undefined,
+			remove: () => {},
+			createSymlink: () => {},
+			readDir: () => [],
+			// A truncated/hand-broken manifest that still lists the user's other extensions.
+			readManifestFile: () => '[{"identifier":{"id":"other.ext"}',
+			writeManifestFile: (p: string, d: string) => writes.push([p, d]),
+			now: () => 12345,
+			log: () => {},
+			error: (m: string) => errors.push(m),
+			exit: (c: number) => {
+				exitCode = c;
+			},
+		});
+		expect(result).toMatchObject({ ok: false, reason: "manifest-malformed" });
+		expect(exitCode).toBe(1);
+		// Crucially: the manifest is NOT rewritten, so other extensions survive.
+		expect(writes).toEqual([]);
+		expect(errors.join("\n")).toContain("not a valid JSON array");
 	});
 
 	it("re-links when an existing symlink points at a different target", () => {
@@ -323,6 +362,13 @@ describe("runInstall (side-effecting install core)", () => {
 			const second = runInstall({ pkgRoot, pkg, extDir, log: () => {}, error: () => {}, exit: () => {} });
 			expect(second).toMatchObject({ ok: true, reason: "already-linked" });
 			expect(lstatSync(linkPath).isSymbolicLink()).toBe(true);
+
+			// Idempotent against the manifest too: the second (already-linked) run
+			// re-registers via upsert, so the entry is refreshed but never duplicated.
+			const manifest = JSON.parse(readFileSync(join(extDir, "extensions.json"), "utf8"));
+			expect(
+				manifest.filter((e: { identifier: { id: string } }) => e.identifier.id === "hrovatin.dreb-vscode"),
+			).toHaveLength(1);
 		});
 	});
 
@@ -445,6 +491,28 @@ describe("extensions.json manifest helpers (issue 92)", () => {
 		});
 	});
 
+	describe("parseManifest (distinguishes absent from malformed — finding 1)", () => {
+		it("treats a missing file as empty, not malformed", () => {
+			expect(parseManifest(undefined)).toEqual({ entries: [], malformed: false });
+		});
+		it("treats an empty / whitespace-only file as empty, not malformed", () => {
+			expect(parseManifest("")).toEqual({ entries: [], malformed: false });
+			expect(parseManifest("  \n")).toEqual({ entries: [], malformed: false });
+		});
+		it("returns the entries for a valid JSON array", () => {
+			expect(parseManifest('[{"identifier":{"id":"a.b"}}]')).toEqual({
+				entries: [{ identifier: { id: "a.b" } }],
+				malformed: false,
+			});
+		});
+		it("flags a present-but-unparseable file as malformed", () => {
+			expect(parseManifest("{not json")).toEqual({ entries: [], malformed: true });
+		});
+		it("flags a present non-array file as malformed", () => {
+			expect(parseManifest('{"identifier":{"id":"a.b"}}')).toEqual({ entries: [], malformed: true });
+		});
+	});
+
 	describe("buildManifestEntry", () => {
 		it("builds the VS Code entry shape with a file:// location and metadata", () => {
 			const entry = buildManifestEntry({
@@ -530,6 +598,12 @@ describe("extensions.json manifest helpers (issue 92)", () => {
 		});
 		it("returns [] when only the canonical link is present", () => {
 			expect(staleInstallNames(["hrovatin.dreb-vscode"], "hrovatin.dreb-vscode")).toEqual([]);
+		});
+		it("ignores a sibling extension that only shares the id prefix (finding 3)", () => {
+			// `<id>-extras` is a different extension, not a versioned copy of `<id>` —
+			// only a version-shaped suffix (`-` + digit) counts, so it is never deleted.
+			const names = ["hrovatin.dreb-vscode-0.1.0", "hrovatin.dreb-vscode-extras", "hrovatin.dreb-vscode-beta"];
+			expect(staleInstallNames(names, "hrovatin.dreb-vscode")).toEqual(["hrovatin.dreb-vscode-0.1.0"]);
 		});
 	});
 });

--- a/packages/vscode/test/uninstall-extension.test.ts
+++ b/packages/vscode/test/uninstall-extension.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -70,5 +70,42 @@ describe("uninstall-extension.mjs main() — end-to-end (finding 2)", () => {
 	it("reports 'Nothing to remove' when no link exists (guard's other arm)", () => {
 		const out = runUninstall(extDir);
 		expect(out).toContain("Nothing to remove");
+	});
+});
+
+describe("uninstall-extension.mjs main() — end-to-end manifest cleanup (issue 92)", () => {
+	let dir: string;
+	let extDir: string;
+	const pkg = { publisher: "hrovatin", name: "dreb-vscode" };
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "dreb-uninstall-manifest-"));
+		extDir = join(dir, "extensions");
+		mkdirSync(extDir, { recursive: true });
+	});
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("removes the symlink, versioned copy, and manifest entry via the real script", () => {
+		const name = linkName(pkg);
+		const target = join(dir, "repo");
+		mkdirSync(target);
+		symlinkSync(target, join(extDir, name), "dir");
+		mkdirSync(join(extDir, `${name}-0.1.0`)); // stale versioned copy
+		const manifest = join(extDir, "extensions.json");
+		writeFileSync(manifest, JSON.stringify([{ identifier: { id: name } }, { identifier: { id: "keep.me" } }]));
+
+		const out = execFileSync(
+			process.execPath,
+			[join(dirname(fileURLToPath(import.meta.url)), "..", "scripts", "uninstall-extension.mjs"), "--dir", extDir],
+			{ encoding: "utf8" },
+		);
+
+		expect(out).toContain("Removed");
+		expect(isSymlink(join(extDir, name))).toBe(false);
+		expect(existsSync(join(extDir, `${name}-0.1.0`))).toBe(false);
+		const entries = JSON.parse(readFileSync(manifest, "utf8"));
+		expect(entries).toEqual([{ identifier: { id: "keep.me" } }]);
 	});
 });


### PR DESCRIPTION
Closes #92

Make the repo-local VSCode extension install self-sufficient: register the extension in `~/.vscode/extensions/extensions.json` on install (so modern VS Code actually discovers it), reconcile any prior install state, and remove all traces on uninstall.

Implementation plan posted as a comment below.
