### PR TITLE
VS Code extension: resolve webview resource roots via realpath so symlink install renders

### DIFF
--- a/packages/vscode/src/host/extension-paths.ts
+++ b/packages/vscode/src/host/extension-paths.ts
@@ -14,19 +14,43 @@
 
 import { realpathSync } from "node:fs";
 
+/** Outcome of a realpath resolution attempt. */
+export interface RealFsPathResolution {
+	/** The resolved real path on success, or the raw input path on fallback. */
+	path: string;
+	/** True when `realpath` succeeded; false when the raw path was used as a fallback. */
+	resolved: boolean;
+}
+
 /**
- * Resolve a filesystem path through symlinks, falling back to the raw path when
- * resolution fails (e.g. a dangling link after the repo was moved/deleted).
+ * Resolve a filesystem path through symlinks, reporting whether resolution
+ * actually succeeded. On failure (e.g. a dangling link after the repo was
+ * moved/deleted) it returns the raw path with `resolved: false` and invokes the
+ * optional `onError` hook — callers use the flag to avoid permanently caching a
+ * fallback so a transient failure can self-heal on a later call.
  *
- * `realpath` is injectable so the fallback branch is unit-testable without a real
- * filesystem. For a plain (non-symlinked) path this is effectively a no-op —
- * `realpathSync` returns the same canonical path — so `.vsix` and F5 installs are
- * unaffected.
+ * `realpath` and `onError` are injectable so the fallback branch is unit-testable
+ * without a real filesystem. For a plain (non-symlinked) path this is effectively
+ * a no-op — `realpathSync` returns the same canonical path — so `.vsix` and F5
+ * installs are unaffected.
+ */
+export function tryResolveRealFsPath(
+	rawFsPath: string,
+	realpath: (p: string) => string = realpathSync,
+	onError?: (err: unknown) => void,
+): RealFsPathResolution {
+	try {
+		return { path: realpath(rawFsPath), resolved: true };
+	} catch (err) {
+		onError?.(err);
+		return { path: rawFsPath, resolved: false };
+	}
+}
+
+/**
+ * Convenience wrapper around {@link tryResolveRealFsPath} that returns just the
+ * resolved (or fallback) path, discarding the success flag.
  */
 export function resolveRealFsPath(rawFsPath: string, realpath: (p: string) => string = realpathSync): string {
-	try {
-		return realpath(rawFsPath);
-	} catch {
-		return rawFsPath;
-	}
+	return tryResolveRealFsPath(rawFsPath, realpath).path;
 }

--- a/packages/vscode/src/host/extension-paths.ts
+++ b/packages/vscode/src/host/extension-paths.ts
@@ -47,10 +47,46 @@ export function tryResolveRealFsPath(
 	}
 }
 
+/** Mutable cache for the extension's realpath-resolved install directory. */
+export interface ExtensionRealDirState {
+	/** Last SUCCESSFUL realpath resolution; unset until one succeeds so a
+	 * transient failure never pins a fallback (see {@link resolveExtensionRealDir}). */
+	cache?: string;
+}
+
+/** Fresh state for an extension activation. */
+export function createExtensionRealDirState(): ExtensionRealDirState {
+	return {};
+}
+
+export interface ResolveExtensionRealDirDeps {
+	/** Raw extension install path (`context.extensionUri.fsPath`), or undefined
+	 * before activation has set the context. */
+	rawFsPath?: string;
+	/** Realpath resolver (defaults to `realpathSync`); injectable for tests. */
+	realpath?: (p: string) => string;
+	/** Called with the raw path and error when realpath fails and the raw path is
+	 * used as a fallback (never on success). */
+	onError?: (rawFsPath: string, err: unknown) => void;
+}
+
 /**
- * Convenience wrapper around {@link tryResolveRealFsPath} that returns just the
- * resolved (or fallback) path, discarding the success flag.
+ * Resolve the extension's own directory through symlinks, memoizing **only a
+ * successful** resolution. On failure it returns the raw path **without** caching,
+ * so a later call re-attempts realpath and self-heals once the filesystem
+ * recovers — a transient failure must never pin the (possibly-symlinked) fallback
+ * for the whole session, or the webview roots built from it would 404 (blank chat)
+ * until a full window reload. Returns `undefined` when no raw path is available
+ * (pre-activation). Mutates `state`.
  */
-export function resolveRealFsPath(rawFsPath: string, realpath: (p: string) => string = realpathSync): string {
-	return tryResolveRealFsPath(rawFsPath, realpath).path;
+export function resolveExtensionRealDir(
+	state: ExtensionRealDirState,
+	deps: ResolveExtensionRealDirDeps,
+): string | undefined {
+	if (state.cache) return state.cache;
+	const raw = deps.rawFsPath;
+	if (!raw) return undefined;
+	const { path, resolved } = tryResolveRealFsPath(raw, deps.realpath, (err) => deps.onError?.(raw, err));
+	if (resolved) state.cache = path;
+	return path;
 }

--- a/packages/vscode/src/host/extension-paths.ts
+++ b/packages/vscode/src/host/extension-paths.ts
@@ -1,0 +1,32 @@
+/**
+ * Pure filesystem-path helpers for the extension host.
+ *
+ * No `vscode` import, so these are unit-testable in plain node. The realpath
+ * resolution here backs both repo-relative CLI resolution and — crucially — the
+ * webview `localResourceRoots` / `asWebviewUri` construction: a repo-local
+ * install (`npm run install-vscode`) symlinks `packages/vscode` into
+ * `~/.vscode/extensions`, and VS Code's webview resource server realpath-resolves
+ * every requested file before checking it against the allowed roots. If the roots
+ * are built from the symlink path, the resolved file path won't match and the
+ * webview's `main.js`/`main.css` 404 (blank chat). Resolving the root to its real
+ * path here makes both sides agree.
+ */
+
+import { realpathSync } from "node:fs";
+
+/**
+ * Resolve a filesystem path through symlinks, falling back to the raw path when
+ * resolution fails (e.g. a dangling link after the repo was moved/deleted).
+ *
+ * `realpath` is injectable so the fallback branch is unit-testable without a real
+ * filesystem. For a plain (non-symlinked) path this is effectively a no-op —
+ * `realpathSync` returns the same canonical path — so `.vsix` and F5 installs are
+ * unaffected.
+ */
+export function resolveRealFsPath(rawFsPath: string, realpath: (p: string) => string = realpathSync): string {
+	try {
+		return realpath(rawFsPath);
+	} catch {
+		return rawFsPath;
+	}
+}

--- a/packages/vscode/src/host/extension.ts
+++ b/packages/vscode/src/host/extension.ts
@@ -13,6 +13,7 @@
  */
 
 import { randomUUID } from "node:crypto";
+import { realpathSync } from "node:fs";
 import { homedir } from "node:os";
 import { relative, sep } from "node:path";
 import * as vscode from "vscode";
@@ -20,7 +21,7 @@ import type { LiveSessionInput } from "../shared/session-list.js";
 import { formatTabTitle } from "../shared/tab-title.js";
 import { buildArgs } from "./build-args.js";
 import { resolveCliPath } from "./cli-path.js";
-import { resolveRealFsPath } from "./extension-paths.js";
+import { tryResolveRealFsPath } from "./extension-paths.js";
 import type { resolveNodePath } from "./node-path.js";
 import { createNodeRuntimeCacheState, resolveNodeRuntimeCached } from "./node-runtime-cache.js";
 import type { ReviewUi } from "./review-ui.js";
@@ -559,8 +560,19 @@ function extensionDirReal(): string | undefined {
 	if (extensionRealDirCache) return extensionRealDirCache;
 	const raw = extensionContext?.extensionUri.fsPath;
 	if (!raw) return undefined;
-	extensionRealDirCache = resolveRealFsPath(raw);
-	return extensionRealDirCache;
+	const { path, resolved } = tryResolveRealFsPath(raw, realpathSync, (err) =>
+		console.warn(
+			`[dreb] failed to resolve the extension's real path for "${raw}"; using it as-is. ` +
+				"Webview assets may 404 (blank chat) under a symlinked (npm run install-vscode) install.",
+			err,
+		),
+	);
+	// Cache only a successful resolution: a transient realpath failure must not
+	// pin the (possibly-symlinked) fallback for the whole session, or the webview
+	// roots built from it would 404 until a full window reload. Leaving the cache
+	// unset lets a later call retry and self-heal.
+	if (resolved) extensionRealDirCache = path;
+	return path;
 }
 
 /**

--- a/packages/vscode/src/host/extension.ts
+++ b/packages/vscode/src/host/extension.ts
@@ -13,7 +13,6 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { realpathSync } from "node:fs";
 import { homedir } from "node:os";
 import { relative, sep } from "node:path";
 import * as vscode from "vscode";
@@ -21,6 +20,7 @@ import type { LiveSessionInput } from "../shared/session-list.js";
 import { formatTabTitle } from "../shared/tab-title.js";
 import { buildArgs } from "./build-args.js";
 import { resolveCliPath } from "./cli-path.js";
+import { resolveRealFsPath } from "./extension-paths.js";
 import type { resolveNodePath } from "./node-path.js";
 import { createNodeRuntimeCacheState, resolveNodeRuntimeCached } from "./node-runtime-cache.js";
 import type { ReviewUi } from "./review-ui.js";
@@ -108,7 +108,7 @@ export function activate(context: vscode.ExtensionContext): void {
 	inventory = createSessionInventory();
 	flags = new SessionFlagsStore(context.globalState);
 	order = new SessionOrderStore(context.globalState);
-	sessionsView = new SessionsViewProvider(context.extensionUri, {
+	sessionsView = new SessionsViewProvider(extensionRootUriReal(), {
 		inventory,
 		flags,
 		order,
@@ -129,8 +129,8 @@ export function activate(context: vscode.ExtensionContext): void {
 			),
 		activeKey: () => pool.active?.key,
 		pathForKey: (key) => pool.get(key)?.controller.sessionPath ?? (key.startsWith("new:") ? undefined : key),
-		openSession: (key) => void openSession(context, key),
-		newSession: () => void openNewSession(context),
+		openSession: (key) => void openSession(key),
+		newSession: () => void openNewSession(),
 		renameSession: (key, name) => renameSession(key, name),
 		deleteSession: (key) => deleteSession(key),
 		stopSession: (key) => stopSession(key),
@@ -138,14 +138,14 @@ export function activate(context: vscode.ExtensionContext): void {
 
 	context.subscriptions.push(
 		vscode.window.registerWebviewViewProvider(SessionsViewProvider.viewId, sessionsView),
-		vscode.commands.registerCommand("dreb.openChat", () => void openActiveOrNew(context)),
-		vscode.commands.registerCommand("dreb.sessions.newSession", () => void openNewSession(context)),
+		vscode.commands.registerCommand("dreb.openChat", () => void openActiveOrNew()),
+		vscode.commands.registerCommand("dreb.sessions.newSession", () => void openNewSession()),
 		vscode.commands.registerCommand("dreb.sessions.refresh", () => sessionsView?.refresh()),
 		vscode.commands.registerCommand("dreb.tagSelectionToChat", () =>
-			tagSelectionToChat(selectionTagDeps(() => openActiveOrNew(context))),
+			tagSelectionToChat(selectionTagDeps(() => openActiveOrNew())),
 		),
 		vscode.commands.registerCommand("dreb.tagSelectionToNewChat", () =>
-			tagSelectionToChat(selectionTagDeps(() => openNewSession(context))),
+			tagSelectionToChat(selectionTagDeps(() => openNewSession())),
 		),
 		vscode.commands.registerCommand("dreb.review.openDiff", (arg?: unknown) => {
 			const resolved = resolveReviewTarget(arg);
@@ -210,7 +210,7 @@ export async function deactivate(): Promise<void> {
 
 /** Open (or resume) a session by pool key. Reveals a live panel, or spawns a
  * controller resuming that session's `.jsonl` (disk-only rows key by path). */
-async function openSession(context: vscode.ExtensionContext, key: string): Promise<ChatSession | undefined> {
+async function openSession(key: string): Promise<ChatSession | undefined> {
 	try {
 		const keyPath = key.startsWith("new:") ? undefined : key;
 		// A crashed session (child gone, controller not disposed) is treated as
@@ -224,7 +224,7 @@ async function openSession(context: vscode.ExtensionContext, key: string): Promi
 				? existing.controller.sessionPath
 				: undefined;
 		const resumePath = keyPath ?? crashedPath;
-		const session = await pool.open(key, () => createSession(context, key, resumePath));
+		const session = await pool.open(key, () => createSession(key, resumePath));
 		pool.setActive(key);
 		scheduleSidebarRefresh();
 		return session;
@@ -235,8 +235,8 @@ async function openSession(context: vscode.ExtensionContext, key: string): Promi
 }
 
 /** Start a brand-new session in the current workspace. */
-async function openNewSession(context: vscode.ExtensionContext): Promise<ChatSession | undefined> {
-	return openSession(context, `new:${randomUUID()}`);
+async function openNewSession(): Promise<ChatSession | undefined> {
+	return openSession(`new:${randomUUID()}`);
 }
 
 /** Reveal the last-active session, or start a new one — used by the chat command
@@ -245,12 +245,12 @@ async function openNewSession(context: vscode.ExtensionContext): Promise<ChatSes
  * `pool.active`) so that tagging from the editor targets the chat the user was
  * last in, rather than spawning a new one just because focus moved from the chat
  * webview to the code editor. */
-async function openActiveOrNew(context: vscode.ExtensionContext): Promise<ChatSession | undefined> {
+async function openActiveOrNew(): Promise<ChatSession | undefined> {
 	return resolveActiveOrNew(pool, {
 		isDisposed: (s) => s.controller.isDisposed(),
 		hasFailed: (s) => s.controller.hasFailed(),
 		reveal: (s) => revealSession(s),
-		openNew: () => openNewSession(context),
+		openNew: () => openNewSession(),
 	});
 }
 
@@ -292,7 +292,7 @@ function selectionTagDeps(open: () => Promise<ChatSession | undefined>): TagSele
  * view attach/detach so the agent keeps running when the tab is closed. Only the
  * panel + webview bridge are *view-bound*; {@link attachView} builds them and
  * `onDidDispose` detaches (backgrounds) them without killing the controller. */
-function createSession(context: vscode.ExtensionContext, key: string, sessionPath?: string): ChatSession {
+function createSession(key: string, sessionPath?: string): ChatSession {
 	const config = vscode.workspace.getConfiguration("dreb");
 	const cwd = workspaceCwd();
 	const { cli, node } = resolveRuntime(config);
@@ -352,7 +352,7 @@ function createSession(context: vscode.ExtensionContext, key: string, sessionPat
 	// Reset the inactivity cap whenever the user drives the session.
 	controller.onUserInput(() => session.sleep.onUserInput());
 
-	attachView(context, session);
+	attachView(session);
 
 	if (!cli.ok) {
 		// Surface an actionable error into the transcript; the webview shows it
@@ -371,15 +371,16 @@ function createSession(context: vscode.ExtensionContext, key: string, sessionPat
 /** Build and attach a fresh chat panel + webview bridge to a session's
  * controller — on first creation and again when reopening a backgrounded session
  * whose original panel was closed. */
-function attachView(context: vscode.ExtensionContext, session: ChatSession): void {
+function attachView(session: ChatSession): void {
+	const extensionRootUri = extensionRootUriReal();
 	const panel = vscode.window.createWebviewPanel("dreb.chat", panelTitle(session), vscode.ViewColumn.Active, {
 		enableScripts: true,
 		retainContextWhenHidden: true,
-		localResourceRoots: [vscode.Uri.joinPath(context.extensionUri, "dist", "webview")],
+		localResourceRoots: [vscode.Uri.joinPath(extensionRootUri, "dist", "webview")],
 	});
 
 	const connection = connectWebview(panel.webview, session.controller);
-	panel.webview.html = getWebviewHtml(panel.webview, context.extensionUri, makeNonce());
+	panel.webview.html = getWebviewHtml(panel.webview, extensionRootUri, makeNonce());
 	session.panel = panel;
 	session.connection = connection;
 	session.sleep.onAttach();
@@ -424,7 +425,7 @@ function revealSession(session: ChatSession): void {
 		{
 			reveal: () => session.panel?.reveal(vscode.ViewColumn.Active),
 			rebuild: () => {
-				if (ctx) attachView(ctx, session);
+				if (ctx) attachView(session);
 			},
 		},
 	);
@@ -558,12 +559,25 @@ function extensionDirReal(): string | undefined {
 	if (extensionRealDirCache) return extensionRealDirCache;
 	const raw = extensionContext?.extensionUri.fsPath;
 	if (!raw) return undefined;
-	try {
-		extensionRealDirCache = realpathSync(raw);
-	} catch {
-		extensionRealDirCache = raw;
-	}
+	extensionRealDirCache = resolveRealFsPath(raw);
 	return extensionRealDirCache;
+}
+
+/**
+ * This extension's root as a `vscode.Uri` with symlinks resolved. Webview
+ * `localResourceRoots` and `asWebviewUri` must be built from this (not the raw,
+ * possibly-symlinked `context.extensionUri`): VS Code's webview resource server
+ * realpath-resolves each requested file before checking it against the allowed
+ * roots, so under a `npm run install-vscode` symlink install a symlink-path root
+ * won't match the file's real path and the webview assets 404 (blank chat).
+ * Falls back to the raw extension Uri if resolution is somehow unavailable.
+ */
+function extensionRootUriReal(): vscode.Uri {
+	const real = extensionDirReal();
+	if (real) return vscode.Uri.file(real);
+	// Unreachable in practice (activate always sets extensionContext first), but
+	// keep a safe fallback rather than throwing during webview construction.
+	return (extensionContext as vscode.ExtensionContext).extensionUri;
 }
 
 /**

--- a/packages/vscode/src/host/extension.ts
+++ b/packages/vscode/src/host/extension.ts
@@ -13,7 +13,6 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { realpathSync } from "node:fs";
 import { homedir } from "node:os";
 import { relative, sep } from "node:path";
 import * as vscode from "vscode";
@@ -21,7 +20,7 @@ import type { LiveSessionInput } from "../shared/session-list.js";
 import { formatTabTitle } from "../shared/tab-title.js";
 import { buildArgs } from "./build-args.js";
 import { resolveCliPath } from "./cli-path.js";
-import { tryResolveRealFsPath } from "./extension-paths.js";
+import { createExtensionRealDirState, resolveExtensionRealDir } from "./extension-paths.js";
 import type { resolveNodePath } from "./node-path.js";
 import { createNodeRuntimeCacheState, resolveNodeRuntimeCached } from "./node-runtime-cache.js";
 import type { ReviewUi } from "./review-ui.js";
@@ -548,31 +547,25 @@ function workspaceCwd(): string {
 }
 
 /** Cached real (symlink-resolved) directory of this extension's install. */
-let extensionRealDirCache: string | undefined;
+const extensionRealDirState = createExtensionRealDirState();
 
 /**
  * This extension's own directory with symlinks resolved. A repo-local install
  * symlinks `packages/vscode` into `~/.vscode/extensions`, so `extensionUri.fsPath`
  * is the symlink; `realpath` yields the actual monorepo path, which repo-relative
- * CLI resolution needs to reach the sibling `packages/coding-agent`.
+ * CLI resolution needs to reach the sibling `packages/coding-agent`. The
+ * cache-only-on-success self-heal lives in `resolveExtensionRealDir`.
  */
 function extensionDirReal(): string | undefined {
-	if (extensionRealDirCache) return extensionRealDirCache;
-	const raw = extensionContext?.extensionUri.fsPath;
-	if (!raw) return undefined;
-	const { path, resolved } = tryResolveRealFsPath(raw, realpathSync, (err) =>
-		console.warn(
-			`[dreb] failed to resolve the extension's real path for "${raw}"; using it as-is. ` +
-				"Webview assets may 404 (blank chat) under a symlinked (npm run install-vscode) install.",
-			err,
-		),
-	);
-	// Cache only a successful resolution: a transient realpath failure must not
-	// pin the (possibly-symlinked) fallback for the whole session, or the webview
-	// roots built from it would 404 until a full window reload. Leaving the cache
-	// unset lets a later call retry and self-heal.
-	if (resolved) extensionRealDirCache = path;
-	return path;
+	return resolveExtensionRealDir(extensionRealDirState, {
+		rawFsPath: extensionContext?.extensionUri.fsPath,
+		onError: (raw, err) =>
+			console.warn(
+				`[dreb] failed to resolve the extension's real path for "${raw}"; using it as-is. ` +
+					"Webview assets may 404 (blank chat) under a symlinked (npm run install-vscode) install.",
+				err,
+			),
+	});
 }
 
 /**

--- a/packages/vscode/src/host/extension.ts
+++ b/packages/vscode/src/host/extension.ts
@@ -108,7 +108,7 @@ export function activate(context: vscode.ExtensionContext): void {
 	inventory = createSessionInventory();
 	flags = new SessionFlagsStore(context.globalState);
 	order = new SessionOrderStore(context.globalState);
-	sessionsView = new SessionsViewProvider(extensionRootUriReal(), {
+	sessionsView = new SessionsViewProvider(() => extensionRootUriReal(), {
 		inventory,
 		flags,
 		order,

--- a/packages/vscode/src/host/sessions-view.ts
+++ b/packages/vscode/src/host/sessions-view.ts
@@ -57,7 +57,7 @@ export class SessionsViewProvider implements vscode.WebviewViewProvider {
 	private readonly model: SessionsViewModel;
 
 	constructor(
-		private readonly extensionUri: vscode.Uri,
+		private readonly resolveExtensionUri: () => vscode.Uri,
 		deps: Omit<SessionsViewDeps, "post">,
 	) {
 		this.model = new SessionsViewModel({ ...deps, post: (msg) => this.post(msg) });
@@ -65,11 +65,17 @@ export class SessionsViewProvider implements vscode.WebviewViewProvider {
 
 	resolveWebviewView(view: vscode.WebviewView): void {
 		this.view = view;
+		// Re-resolve the extension root here (not once at construction) so the
+		// sidebar self-heals like the chat panel: if the realpath resolution failed
+		// at activation, a later view (re)resolve picks up the recovered real path
+		// instead of pinning the symlink fallback (which would 404 the sidebar
+		// assets until a full window reload).
+		const extensionUri = this.resolveExtensionUri();
 		view.webview.options = {
 			enableScripts: true,
-			localResourceRoots: [vscode.Uri.joinPath(this.extensionUri, "dist", "webview-sidebar")],
+			localResourceRoots: [vscode.Uri.joinPath(extensionUri, "dist", "webview-sidebar")],
 		};
-		view.webview.html = getSidebarHtml(view.webview, this.extensionUri, makeNonce());
+		view.webview.html = getSidebarHtml(view.webview, extensionUri, makeNonce());
 		view.webview.onDidReceiveMessage((msg: SidebarToHost) => void this.model.handle(msg));
 		view.onDidDispose(() => {
 			if (this.view === view) this.view = undefined;

--- a/packages/vscode/test/extension-paths.test.ts
+++ b/packages/vscode/test/extension-paths.test.ts
@@ -2,55 +2,28 @@ import { mkdtempSync, rmSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { resolveRealFsPath, tryResolveRealFsPath } from "../src/host/extension-paths.js";
-
-describe("resolveRealFsPath", () => {
-	it("returns the raw path unchanged for a plain (non-symlinked) real path (no-op)", () => {
-		// A .vsix / F5 install is a real directory: realpath returns the same path.
-		expect(resolveRealFsPath("/real/path", (p) => p)).toBe("/real/path");
-	});
-
-	it("resolves a symlink to its real target (the npm run install-vscode case)", () => {
-		const target = "/Users/me/Documents/code/dreb/packages/vscode";
-		const fakeRealpath = (p: string) => (p === "/Users/me/.vscode/extensions/pub.name" ? target : p);
-		expect(resolveRealFsPath("/Users/me/.vscode/extensions/pub.name", fakeRealpath)).toBe(target);
-	});
-
-	it("falls back to the raw path when realpath throws (dangling link / moved repo)", () => {
-		const raw = "/Users/me/.vscode/extensions/pub.name";
-		const throwing = () => {
-			throw new Error("ENOENT");
-		};
-		expect(resolveRealFsPath(raw, throwing)).toBe(raw);
-	});
-
-	describe("against the real filesystem", () => {
-		let dir: string;
-		beforeEach(() => {
-			dir = mkdtempSync(join(tmpdir(), "dreb-extpaths-"));
-		});
-		afterEach(() => {
-			rmSync(dir, { recursive: true, force: true });
-		});
-
-		it("uses the default realpathSync and falls back when a symlink target is missing", () => {
-			const real = join(dir, "real-ext");
-			const link = join(dir, "linked-ext");
-			// Symlink whose target does not exist -> realpathSync throws -> raw fallback.
-			symlinkSync(real, link, "dir");
-			expect(resolveRealFsPath(link)).toBe(link);
-		});
-	});
-});
+import {
+	createExtensionRealDirState,
+	resolveExtensionRealDir,
+	tryResolveRealFsPath,
+} from "../src/host/extension-paths.js";
 
 describe("tryResolveRealFsPath", () => {
-	it("reports resolved:true with the real target on success", () => {
-		const target = "/Users/me/Documents/code/dreb/packages/vscode";
-		const result = tryResolveRealFsPath("/Users/me/.vscode/extensions/pub.name", () => target);
-		expect(result).toEqual({ path: target, resolved: true });
+	it("returns the raw path unchanged for a plain (non-symlinked) real path (no-op)", () => {
+		// A .vsix / F5 install is a real directory: realpath returns the same path.
+		expect(tryResolveRealFsPath("/real/path", (p) => p)).toEqual({ path: "/real/path", resolved: true });
 	});
 
-	it("reports resolved:false with the raw path when realpath throws", () => {
+	it("reports resolved:true with the real target on success (the npm run install-vscode case)", () => {
+		const target = "/Users/me/Documents/code/dreb/packages/vscode";
+		const fakeRealpath = (p: string) => (p === "/Users/me/.vscode/extensions/pub.name" ? target : p);
+		expect(tryResolveRealFsPath("/Users/me/.vscode/extensions/pub.name", fakeRealpath)).toEqual({
+			path: target,
+			resolved: true,
+		});
+	});
+
+	it("reports resolved:false with the raw path when realpath throws (dangling link / moved repo)", () => {
 		const raw = "/Users/me/.vscode/extensions/pub.name";
 		const result = tryResolveRealFsPath(raw, () => {
 			throw new Error("ENOENT");
@@ -76,5 +49,66 @@ describe("tryResolveRealFsPath", () => {
 		onError.mockClear();
 		tryResolveRealFsPath("/raw", (p) => p, onError);
 		expect(onError).not.toHaveBeenCalled();
+	});
+
+	describe("against the real filesystem", () => {
+		let dir: string;
+		beforeEach(() => {
+			dir = mkdtempSync(join(tmpdir(), "dreb-extpaths-"));
+		});
+		afterEach(() => {
+			rmSync(dir, { recursive: true, force: true });
+		});
+
+		it("uses the default realpathSync and falls back when a symlink target is missing", () => {
+			const real = join(dir, "real-ext");
+			const link = join(dir, "linked-ext");
+			// Symlink whose target does not exist -> realpathSync throws -> raw fallback.
+			symlinkSync(real, link, "dir");
+			expect(tryResolveRealFsPath(link)).toEqual({ path: link, resolved: false });
+		});
+	});
+});
+
+describe("resolveExtensionRealDir", () => {
+	const RAW = "/Users/me/.vscode/extensions/pub.name";
+	const TARGET = "/Users/me/Documents/code/dreb/packages/vscode";
+
+	it("returns undefined when no raw path is available (pre-activation)", () => {
+		const state = createExtensionRealDirState();
+		expect(resolveExtensionRealDir(state, { rawFsPath: undefined, realpath: (p) => p })).toBeUndefined();
+	});
+
+	it("resolves and caches a successful resolution (does not re-resolve on the next call)", () => {
+		const state = createExtensionRealDirState();
+		const realpath = vi.fn((p: string) => (p === RAW ? TARGET : p));
+
+		expect(resolveExtensionRealDir(state, { rawFsPath: RAW, realpath })).toBe(TARGET);
+		expect(resolveExtensionRealDir(state, { rawFsPath: RAW, realpath })).toBe(TARGET);
+		// Cached after the first success: realpath is not called again.
+		expect(realpath).toHaveBeenCalledTimes(1);
+	});
+
+	it("does NOT cache a failed resolution, so a later call self-heals once realpath recovers", () => {
+		const state = createExtensionRealDirState();
+		const onError = vi.fn();
+		let shouldThrow = true;
+		const realpath = vi.fn((p: string) => {
+			if (shouldThrow) throw new Error("EMFILE");
+			return p === RAW ? TARGET : p;
+		});
+
+		// First call: transient failure -> returns raw fallback, NOT cached.
+		expect(resolveExtensionRealDir(state, { rawFsPath: RAW, realpath, onError })).toBe(RAW);
+		expect(state.cache).toBeUndefined();
+		expect(onError).toHaveBeenCalledTimes(1);
+		expect(onError).toHaveBeenCalledWith(RAW, expect.any(Error));
+
+		// Filesystem recovers: a later call retries and resolves the real target.
+		shouldThrow = false;
+		expect(resolveExtensionRealDir(state, { rawFsPath: RAW, realpath, onError })).toBe(TARGET);
+		expect(state.cache).toBe(TARGET);
+		// The self-heal re-attempted realpath rather than returning the pinned fallback.
+		expect(realpath).toHaveBeenCalledTimes(2);
 	});
 });

--- a/packages/vscode/test/extension-paths.test.ts
+++ b/packages/vscode/test/extension-paths.test.ts
@@ -1,8 +1,8 @@
 import { mkdtempSync, rmSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { resolveRealFsPath } from "../src/host/extension-paths.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveRealFsPath, tryResolveRealFsPath } from "../src/host/extension-paths.js";
 
 describe("resolveRealFsPath", () => {
 	it("returns the raw path unchanged for a plain (non-symlinked) real path (no-op)", () => {
@@ -40,5 +40,41 @@ describe("resolveRealFsPath", () => {
 			symlinkSync(real, link, "dir");
 			expect(resolveRealFsPath(link)).toBe(link);
 		});
+	});
+});
+
+describe("tryResolveRealFsPath", () => {
+	it("reports resolved:true with the real target on success", () => {
+		const target = "/Users/me/Documents/code/dreb/packages/vscode";
+		const result = tryResolveRealFsPath("/Users/me/.vscode/extensions/pub.name", () => target);
+		expect(result).toEqual({ path: target, resolved: true });
+	});
+
+	it("reports resolved:false with the raw path when realpath throws", () => {
+		const raw = "/Users/me/.vscode/extensions/pub.name";
+		const result = tryResolveRealFsPath(raw, () => {
+			throw new Error("ENOENT");
+		});
+		// resolved:false is what lets the caller avoid caching the fallback and retry.
+		expect(result).toEqual({ path: raw, resolved: false });
+	});
+
+	it("invokes onError with the thrown error on fallback, and not on success", () => {
+		const onError = vi.fn();
+		const err = new Error("EMFILE");
+
+		tryResolveRealFsPath(
+			"/raw",
+			() => {
+				throw err;
+			},
+			onError,
+		);
+		expect(onError).toHaveBeenCalledTimes(1);
+		expect(onError).toHaveBeenCalledWith(err);
+
+		onError.mockClear();
+		tryResolveRealFsPath("/raw", (p) => p, onError);
+		expect(onError).not.toHaveBeenCalled();
 	});
 });

--- a/packages/vscode/test/extension-paths.test.ts
+++ b/packages/vscode/test/extension-paths.test.ts
@@ -1,0 +1,44 @@
+import { mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resolveRealFsPath } from "../src/host/extension-paths.js";
+
+describe("resolveRealFsPath", () => {
+	it("returns the raw path unchanged for a plain (non-symlinked) real path (no-op)", () => {
+		// A .vsix / F5 install is a real directory: realpath returns the same path.
+		expect(resolveRealFsPath("/real/path", (p) => p)).toBe("/real/path");
+	});
+
+	it("resolves a symlink to its real target (the npm run install-vscode case)", () => {
+		const target = "/Users/me/Documents/code/dreb/packages/vscode";
+		const fakeRealpath = (p: string) => (p === "/Users/me/.vscode/extensions/pub.name" ? target : p);
+		expect(resolveRealFsPath("/Users/me/.vscode/extensions/pub.name", fakeRealpath)).toBe(target);
+	});
+
+	it("falls back to the raw path when realpath throws (dangling link / moved repo)", () => {
+		const raw = "/Users/me/.vscode/extensions/pub.name";
+		const throwing = () => {
+			throw new Error("ENOENT");
+		};
+		expect(resolveRealFsPath(raw, throwing)).toBe(raw);
+	});
+
+	describe("against the real filesystem", () => {
+		let dir: string;
+		beforeEach(() => {
+			dir = mkdtempSync(join(tmpdir(), "dreb-extpaths-"));
+		});
+		afterEach(() => {
+			rmSync(dir, { recursive: true, force: true });
+		});
+
+		it("uses the default realpathSync and falls back when a symlink target is missing", () => {
+			const real = join(dir, "real-ext");
+			const link = join(dir, "linked-ext");
+			// Symlink whose target does not exist -> realpathSync throws -> raw fallback.
+			symlinkSync(real, link, "dir");
+			expect(resolveRealFsPath(link)).toBe(link);
+		});
+	});
+});

--- a/packages/vscode/test/sessions-view.test.ts
+++ b/packages/vscode/test/sessions-view.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from "vitest";
+
+// The sidebar view only needs `Uri` (joinPath/file) from vscode to build its
+// resource root + HTML. A minimal path-joining Uri is enough to prove the root
+// is re-resolved from the injected thunk on every view resolve (the self-heal),
+// rather than captured once at construction.
+vi.mock("vscode", () => {
+	class Uri {
+		constructor(public fsPath: string) {}
+		static file(p: string): Uri {
+			return new Uri(p);
+		}
+		static joinPath(base: Uri, ...segs: string[]): Uri {
+			return new Uri([base.fsPath, ...segs].join("/"));
+		}
+		toString(): string {
+			return this.fsPath;
+		}
+	}
+	return { Uri };
+});
+
+import * as vscode from "vscode";
+import { SessionsViewProvider } from "../src/host/sessions-view.js";
+
+/** Minimal fake WebviewView capturing the options + HTML the provider sets. */
+function makeView() {
+	let html = "";
+	let options: { localResourceRoots?: vscode.Uri[] } | undefined;
+	const view = {
+		webview: {
+			get options() {
+				return options;
+			},
+			set options(v: any) {
+				options = v;
+			},
+			get html() {
+				return html;
+			},
+			set html(v: string) {
+				html = v;
+			},
+			asWebviewUri: (u: vscode.Uri) => u,
+			cspSource: "vscode-webview:",
+			onDidReceiveMessage: () => ({ dispose() {} }),
+		},
+		onDidDispose: () => ({ dispose() {} }),
+	};
+	return {
+		view: view as unknown as vscode.WebviewView,
+		root: () => options?.localResourceRoots?.[0]?.fsPath,
+		html: () => html,
+	};
+}
+
+// The provider constructs a SessionsViewModel from these, but `resolveWebviewView`
+// never touches the model, so a bare stub cast is sufficient for this test.
+const stubDeps = {} as any;
+
+describe("SessionsViewProvider — resource root self-heal", () => {
+	it("resolves the extension root from the thunk at view-resolve time (not captured at construction)", () => {
+		const resolve = vi.fn(() => vscode.Uri.file("/real/monorepo/packages/vscode"));
+		const provider = new SessionsViewProvider(resolve, stubDeps);
+
+		// Constructing the provider must NOT eagerly resolve the root.
+		expect(resolve).not.toHaveBeenCalled();
+
+		const { view, root, html } = makeView();
+		provider.resolveWebviewView(view);
+
+		expect(resolve).toHaveBeenCalledTimes(1);
+		expect(root()).toBe("/real/monorepo/packages/vscode/dist/webview-sidebar");
+		expect(html()).toContain("/real/monorepo/packages/vscode/dist/webview-sidebar/main.js");
+	});
+
+	it("re-resolves on a later view resolve, so a recovered realpath heals a prior symlink fallback", () => {
+		// First resolve returns the raw symlink fallback (realpath had failed);
+		// a later resolve returns the recovered real path.
+		const FALLBACK = "/Users/me/.vscode/extensions/pub.name";
+		const REAL = "/Users/me/Documents/code/dreb/packages/vscode";
+		const resolve = vi
+			.fn<[], vscode.Uri>()
+			.mockReturnValueOnce(vscode.Uri.file(FALLBACK))
+			.mockReturnValue(vscode.Uri.file(REAL));
+		const provider = new SessionsViewProvider(resolve, stubDeps);
+
+		const first = makeView();
+		provider.resolveWebviewView(first.view);
+		expect(first.root()).toBe(`${FALLBACK}/dist/webview-sidebar`);
+
+		// The view is disposed and re-created (e.g. collapse/expand or reload);
+		// the sidebar picks up the recovered path instead of pinning the fallback.
+		const second = makeView();
+		provider.resolveWebviewView(second.view);
+		expect(resolve).toHaveBeenCalledTimes(2);
+		expect(second.root()).toBe(`${REAL}/dist/webview-sidebar`);
+		expect(second.html()).toContain(`${REAL}/dist/webview-sidebar/main.js`);
+	});
+});


### PR DESCRIPTION
Closes #94

Fix the blank VS Code chat panel under `npm run install-vscode`: the webview's `localResourceRoots` and asset URIs are built from the symlinked `context.extensionUri`, but VS Code realpath-canonicalizes requested files before checking them against the allowed roots, so the chat panel's `main.js`/`main.css` return 404. Resolve the extension dir to its realpath (reusing the symlink-aware `extensionDirReal()` logic) for the panel + sidebar resource roots.

Implementation plan posted as a comment below.
