### PR TITLE
Interleave activity boxes and answer blocks in VSCode transcript streaming order

### DIFF
--- a/packages/vscode/scripts/install-extension.d.mts
+++ b/packages/vscode/scripts/install-extension.d.mts
@@ -31,9 +31,9 @@ export function buildManifestEntry(opts: {
 
 export function sameId(a: unknown, b: unknown): boolean;
 
-export function upsertEntry(entries: ManifestEntry[], entry: ManifestEntry): ManifestEntry[];
+export function upsertEntry<T extends { identifier: { id: string } }>(entries: readonly T[], entry: T): T[];
 
-export function removeEntry(entries: ManifestEntry[], id: string): ManifestEntry[];
+export function removeEntry<T extends { identifier: { id: string } }>(entries: readonly T[], id: string): T[];
 
 export function staleInstallNames(names: string[], name: string): string[];
 

--- a/packages/vscode/src/shared/projection.ts
+++ b/packages/vscode/src/shared/projection.ts
@@ -29,8 +29,9 @@ export interface ToolActivity {
 export type ActivityItem = ThinkingActivity | ToolActivity;
 
 /** One collapsible activity box: a contiguous run of thinking + tool calls that
- * arrived with no answer text between them. Its `items` share object references
- * with {@link ResponseGroup.activity}, so a tool-result update mutates both. */
+ * arrived with no answer text between them. These `items` are the sole store of
+ * the run's activity — the flat aggregate ({@link runActivity}) is derived from
+ * them — so a tool-result update mutates exactly the object the box renders. */
 export interface ActivitySegment {
 	kind: "activity";
 	items: ActivityItem[];
@@ -56,24 +57,27 @@ export interface ResponseGroup {
 	kind: "response";
 	id: number;
 	/** Ordered interleaving of activity boxes and answer blocks for this run —
-	 * the render source of truth. */
+	 * the single render source of truth *and* the sole store of activity items.
+	 * The flat activity aggregate used by grounded refs / the summary is DERIVED
+	 * from these segments via {@link runActivity}, so there is never a second copy
+	 * to fall out of sync (see the mid-stream-snapshot regression this avoids: a
+	 * JSON-serialized snapshot would duplicate a shared reference, leaving a
+	 * separately-stored aggregate frozen while the rendered segment updated). */
 	segments: ResponseSegment[];
-	/** Thinking + tool activity aggregated across the whole run, in arrival order.
-	 * Shares object references with the activity segments' `items`; used for
-	 * grounded refs and the run summary, not for rendering order. */
-	activity: ActivityItem[];
 	/** Accumulated final-answer markdown aggregated across the whole run. Used for
 	 * persistence/crash-recovery bookkeeping (offset math), not for rendering. */
 	answer: string;
-	/** Internal: `activity.length` when the last answer text was appended. Used to
+	/** Internal: activity-item count when the last answer text was appended. Used to
 	 * detect a new narration block (activity arrived since the last text) so
 	 * consecutive text blocks in one run are separated instead of concatenated in
 	 * the `answer` aggregate. Not rendered. */
 	answerActivityMark?: number;
 	/** True between agent_start and agent_end for this run. */
 	streaming: boolean;
-	/** Whole-run collapse state, set when the run ends; individual boxes also carry
-	 * their own {@link ActivitySegment.collapsed}. */
+	/** Run-level state: set true once the run ends (a coarse "this run is
+	 * finished" flag, e.g. asserted in tests). Individual activity boxes carry
+	 * their own {@link ActivitySegment.collapsed}, which is what the renderer
+	 * actually reads to fold each box. */
 	collapsed: boolean;
 	/** Provider failure text, if this run ended in an error. */
 	error?: string;
@@ -235,7 +239,6 @@ function activeResponse(state: TranscriptState, create: boolean): ResponseGroup 
 		kind: "response",
 		id: state.nextResponseId++,
 		segments: [],
-		activity: [],
 		answer: "",
 		streaming: true,
 		collapsed: false,
@@ -244,18 +247,40 @@ function activeResponse(state: TranscriptState, create: boolean): ResponseGroup 
 	return group;
 }
 
+/** All activity items of a run, flattened across its activity segments in arrival
+ * order. Derived on demand from {@link ResponseGroup.segments} (the sole store),
+ * so grounded refs and the summary always read the same live objects the boxes
+ * render — never a separately-stored copy that a snapshot round-trip could
+ * freeze. */
+export function runActivity(group: ResponseGroup): ActivityItem[] {
+	const items: ActivityItem[] = [];
+	for (const segment of group.segments) if (segment.kind === "activity") items.push(...segment.items);
+	return items;
+}
+
+/** Count of a run's activity items without materializing the flattened array
+ * (used for the answer-aggregate's narration-block bookkeeping). */
+function activityCount(group: ResponseGroup): number {
+	let n = 0;
+	for (const segment of group.segments) if (segment.kind === "activity") n += segment.items.length;
+	return n;
+}
+
 function lastThinking(group: ResponseGroup): ThinkingActivity | undefined {
-	const last = group.activity[group.activity.length - 1];
-	return last?.kind === "thinking" ? last : undefined;
+	// The most recent activity item overall lives at the end of the trailing
+	// activity segment (a later answer segment would mean a new thinking starts a
+	// fresh box, so there is no in-flight thought to extend).
+	const last = group.segments[group.segments.length - 1];
+	if (!last || last.kind !== "activity") return undefined;
+	const item = last.items[last.items.length - 1];
+	return item?.kind === "thinking" ? item : undefined;
 }
 
 /** Append an activity item to the run: extend the trailing activity segment, or
- * open a new box when the last segment is an answer block (or there is none). The
- * same object reference lands in both the ordered {@link ResponseGroup.segments}
- * and the flat {@link ResponseGroup.activity} aggregate, so a later tool-result
- * update mutates both views at once. */
+ * open a new box when the last segment is an answer block (or there is none).
+ * Items live only here (in {@link ResponseGroup.segments}); the flat aggregate is
+ * derived via {@link runActivity}, so there is no second copy to keep in sync. */
 function pushActivity(group: ResponseGroup, item: ActivityItem): void {
-	group.activity.push(item);
 	const last = group.segments[group.segments.length - 1];
 	if (last && last.kind === "activity") last.items.push(item);
 	else group.segments.push({ kind: "activity", items: [item], collapsed: false });
@@ -270,11 +295,11 @@ function appendAnswerText(group: ResponseGroup, text: string): void {
 	if (!text) return;
 	// Aggregate (persistence bookkeeping only — not rendered).
 	const mark = group.answerActivityMark ?? 0;
-	if (group.answer.length > 0 && group.activity.length > mark && !group.answer.endsWith("\n\n")) {
+	if (group.answer.length > 0 && activityCount(group) > mark && !group.answer.endsWith("\n\n")) {
 		group.answer += group.answer.endsWith("\n") ? "\n" : "\n\n";
 	}
 	group.answer += text;
-	group.answerActivityMark = group.activity.length;
+	group.answerActivityMark = activityCount(group);
 	// Ordered segments (render source of truth).
 	const last = group.segments[group.segments.length - 1];
 	if (last && last.kind === "answer") {
@@ -286,9 +311,16 @@ function appendAnswerText(group: ResponseGroup, text: string): void {
 }
 
 function findTool(group: ResponseGroup, toolCallId: string): ToolActivity | undefined {
-	for (let i = group.activity.length - 1; i >= 0; i--) {
-		const item = group.activity[i];
-		if (item.kind === "tool" && item.toolCallId === toolCallId) return item;
+	// Scan the segments (the sole store) newest-first so the returned object is
+	// the exact one the box renders — a status/result mutation therefore always
+	// reaches the DOM, even after a snapshot round-trip.
+	for (let s = group.segments.length - 1; s >= 0; s--) {
+		const segment = group.segments[s];
+		if (segment.kind !== "activity") continue;
+		for (let i = segment.items.length - 1; i >= 0; i--) {
+			const item = segment.items[i];
+			if (item.kind === "tool" && item.toolCallId === toolCallId) return item;
+		}
 	}
 	return undefined;
 }
@@ -624,11 +656,6 @@ export function activityItemsSummary(items: readonly ActivityItem[]): string {
 	return parts.length > 0 ? parts.join(" · ") : "no activity";
 }
 
-/** One-line summary of a whole response's activity (all boxes combined). */
-export function activitySummary(group: ResponseGroup): string {
-	return activityItemsSummary(group.activity);
-}
-
 /**
  * The id of the response group eligible for a **Retry** control, or `undefined`
  * when none is. Only the *most recent* turn qualifies, and only when it ended in
@@ -733,7 +760,6 @@ export function foldMessagesIntoState(state: TranscriptState, messages: readonly
 			kind: "response",
 			id: state.nextResponseId++,
 			segments: [],
-			activity: [],
 			answer: "",
 			streaming: false,
 			collapsed: true,

--- a/packages/vscode/src/shared/projection.ts
+++ b/packages/vscode/src/shared/projection.ts
@@ -28,21 +28,52 @@ export interface ToolActivity {
 
 export type ActivityItem = ThinkingActivity | ToolActivity;
 
+/** One collapsible activity box: a contiguous run of thinking + tool calls that
+ * arrived with no answer text between them. Its `items` share object references
+ * with {@link ResponseGroup.activity}, so a tool-result update mutates both. */
+export interface ActivitySegment {
+	kind: "activity";
+	items: ActivityItem[];
+	/** Per-box collapse state: a box auto-collapses once the next segment (an
+	 * answer block, or the run's end) opens after it. */
+	collapsed: boolean;
+}
+
+/** One clean answer block: a contiguous run of assistant text with no activity
+ * between deltas. */
+export interface AnswerSegment {
+	kind: "answer";
+	text: string;
+}
+
+/** Ordered piece of a response run. Segments interleave in true arrival order so
+ * the transcript renders `activity → answer → activity → answer` as it actually
+ * streamed, instead of hoisting all activity above all answer text. This is what
+ * {@link ResponseView} iterates. */
+export type ResponseSegment = ActivitySegment | AnswerSegment;
+
 export interface ResponseGroup {
 	kind: "response";
 	id: number;
-	/** Thinking + tool activity, in arrival order (rendered in the activity box). */
+	/** Ordered interleaving of activity boxes and answer blocks for this run —
+	 * the render source of truth. */
+	segments: ResponseSegment[];
+	/** Thinking + tool activity aggregated across the whole run, in arrival order.
+	 * Shares object references with the activity segments' `items`; used for
+	 * grounded refs and the run summary, not for rendering order. */
 	activity: ActivityItem[];
-	/** Accumulated final-answer markdown (assistant text content). */
+	/** Accumulated final-answer markdown aggregated across the whole run. Used for
+	 * persistence/crash-recovery bookkeeping (offset math), not for rendering. */
 	answer: string;
 	/** Internal: `activity.length` when the last answer text was appended. Used to
 	 * detect a new narration block (activity arrived since the last text) so
-	 * consecutive text blocks in one run are separated instead of concatenated.
-	 * Not rendered. */
+	 * consecutive text blocks in one run are separated instead of concatenated in
+	 * the `answer` aggregate. Not rendered. */
 	answerActivityMark?: number;
 	/** True between agent_start and agent_end for this run. */
 	streaming: boolean;
-	/** Activity box collapse state; auto-collapses when the run ends. */
+	/** Whole-run collapse state, set when the run ends; individual boxes also carry
+	 * their own {@link ActivitySegment.collapsed}. */
 	collapsed: boolean;
 	/** Provider failure text, if this run ended in an error. */
 	error?: string;
@@ -203,6 +234,7 @@ function activeResponse(state: TranscriptState, create: boolean): ResponseGroup 
 	const group: ResponseGroup = {
 		kind: "response",
 		id: state.nextResponseId++,
+		segments: [],
 		activity: [],
 		answer: "",
 		streaming: true,
@@ -217,18 +249,40 @@ function lastThinking(group: ResponseGroup): ThinkingActivity | undefined {
 	return last?.kind === "thinking" ? last : undefined;
 }
 
-/** Append assistant answer text, inserting a blank-line separator when a new text
- * block begins after intervening activity (a tool call or thinking) since the last
- * text was written. This keeps consecutive narration blocks in a single run from
- * running together into one wall of text. */
+/** Append an activity item to the run: extend the trailing activity segment, or
+ * open a new box when the last segment is an answer block (or there is none). The
+ * same object reference lands in both the ordered {@link ResponseGroup.segments}
+ * and the flat {@link ResponseGroup.activity} aggregate, so a later tool-result
+ * update mutates both views at once. */
+function pushActivity(group: ResponseGroup, item: ActivityItem): void {
+	group.activity.push(item);
+	const last = group.segments[group.segments.length - 1];
+	if (last && last.kind === "activity") last.items.push(item);
+	else group.segments.push({ kind: "activity", items: [item], collapsed: false });
+}
+
+/** Append assistant answer text. Extends the trailing answer segment, or opens a
+ * new answer block (collapsing the activity box that preceded it, since that box
+ * is now finished). Also maintains the flat {@link ResponseGroup.answer} aggregate
+ * used for crash-recovery offset math — with the historical blank-line separator
+ * so the recovered suffix keeps narration blocks readable. */
 function appendAnswerText(group: ResponseGroup, text: string): void {
 	if (!text) return;
+	// Aggregate (persistence bookkeeping only — not rendered).
 	const mark = group.answerActivityMark ?? 0;
 	if (group.answer.length > 0 && group.activity.length > mark && !group.answer.endsWith("\n\n")) {
 		group.answer += group.answer.endsWith("\n") ? "\n" : "\n\n";
 	}
 	group.answer += text;
 	group.answerActivityMark = group.activity.length;
+	// Ordered segments (render source of truth).
+	const last = group.segments[group.segments.length - 1];
+	if (last && last.kind === "answer") {
+		last.text += text;
+	} else {
+		if (last && last.kind === "activity") last.collapsed = true;
+		group.segments.push({ kind: "answer", text });
+	}
 }
 
 function findTool(group: ResponseGroup, toolCallId: string): ToolActivity | undefined {
@@ -248,6 +302,8 @@ function closeActiveResponse(state: TranscriptState, error?: string): void {
 	if (group) {
 		group.streaming = false;
 		group.collapsed = true;
+		// Collapse every activity box now that the run has ended.
+		for (const segment of group.segments) if (segment.kind === "activity") segment.collapsed = true;
 		if (error) group.error = group.error ?? error;
 	}
 }
@@ -401,12 +457,12 @@ export function applyEvent(state: TranscriptState, event: any): void {
 					state.sawTextDeltaInBlock = false;
 					break;
 				case "thinking_start":
-					group.activity.push({ kind: "thinking", text: "" });
+					pushActivity(group, { kind: "thinking", text: "" });
 					break;
 				case "thinking_delta": {
 					const thinking = lastThinking(group);
 					if (thinking) thinking.text += stream.delta ?? "";
-					else group.activity.push({ kind: "thinking", text: stream.delta ?? "" });
+					else pushActivity(group, { kind: "thinking", text: stream.delta ?? "" });
 					break;
 				}
 				case "thinking_end": {
@@ -449,7 +505,7 @@ export function applyEvent(state: TranscriptState, event: any): void {
 				existing.status = "running";
 				existing.resultText = "";
 			} else {
-				group.activity.push({
+				pushActivity(group, {
 					kind: "tool",
 					toolCallId,
 					toolName: String(event.toolName),
@@ -558,14 +614,19 @@ export function applyEvent(state: TranscriptState, event: any): void {
 	}
 }
 
-/** One-line summary of a response's activity for the collapsed header. */
-export function activitySummary(group: ResponseGroup): string {
-	const toolCount = group.activity.filter((a) => a.kind === "tool").length;
-	const thoughtCount = group.activity.filter((a) => a.kind === "thinking").length;
+/** One-line summary of a set of activity items for a box's collapsed header. */
+export function activityItemsSummary(items: readonly ActivityItem[]): string {
+	const toolCount = items.filter((a) => a.kind === "tool").length;
+	const thoughtCount = items.filter((a) => a.kind === "thinking").length;
 	const parts: string[] = [];
 	if (thoughtCount > 0) parts.push(`${thoughtCount} thought${thoughtCount === 1 ? "" : "s"}`);
 	if (toolCount > 0) parts.push(`${toolCount} tool call${toolCount === 1 ? "" : "s"}`);
 	return parts.length > 0 ? parts.join(" · ") : "no activity";
+}
+
+/** One-line summary of a whole response's activity (all boxes combined). */
+export function activitySummary(group: ResponseGroup): string {
+	return activityItemsSummary(group.activity);
 }
 
 /**
@@ -624,9 +685,9 @@ function foldAssistantContent(group: ResponseGroup, content: unknown): void {
 		if (part?.type === "text" && typeof part.text === "string") {
 			appendAnswerText(group, part.text);
 		} else if (part?.type === "thinking" && typeof part.thinking === "string") {
-			group.activity.push({ kind: "thinking", text: part.thinking });
+			pushActivity(group, { kind: "thinking", text: part.thinking });
 		} else if (part?.type === "toolCall") {
-			group.activity.push({
+			pushActivity(group, {
 				kind: "tool",
 				toolCallId: String(part.id ?? ""),
 				toolName: String(part.name ?? "tool"),
@@ -671,6 +732,7 @@ export function foldMessagesIntoState(state: TranscriptState, messages: readonly
 		const created: ResponseGroup = {
 			kind: "response",
 			id: state.nextResponseId++,
+			segments: [],
 			activity: [],
 			answer: "",
 			streaming: false,
@@ -710,6 +772,13 @@ export function foldMessagesIntoState(state: TranscriptState, messages: readonly
 			}
 		}
 		// Other/unknown roles (defensive): ignored — they never render a turn.
+	}
+
+	// Rebuilt turns are all historical/complete, so collapse every activity box —
+	// matching the live projection, where `agent_end` collapses them.
+	for (const item of state.items) {
+		if (item.kind !== "response") continue;
+		for (const segment of item.segments) if (segment.kind === "activity") segment.collapsed = true;
 	}
 }
 

--- a/packages/vscode/src/webview/app.tsx
+++ b/packages/vscode/src/webview/app.tsx
@@ -4,8 +4,9 @@ import { type ComposerPrefillMode, mergeComposerPrefill } from "../shared/compos
 import { formatContextUsage, formatCost, formatModel, formatThinking } from "../shared/format.js";
 import { activeMention, isFullPickerTrigger, mentionReference, replaceMention } from "../shared/mention.js";
 import {
+	type ActivitySegment,
 	type AskQuestion,
-	activitySummary,
+	activityItemsSummary,
 	applyEvent,
 	type Checkpoint,
 	createTranscriptState,
@@ -426,21 +427,31 @@ export function SuggestionBar(props: {
 export function ResponseView(props: { group: ResponseGroup; onRetry?: () => void }) {
 	return (
 		<div class="dreb-response">
-			<Show when={props.group.activity.length > 0}>
-				<ActivityBox group={props.group} />
-			</Show>
-			<Show when={props.group.answer.length > 0}>
-				{/* Sanitized markdown with grounded, clickable code links. Links are
-				    wired via event delegation (postToHost) rather than href navigation,
-				    so they work under the webview's strict CSP. */}
-				{/* biome-ignore lint/a11y/noStaticElementInteractions: delegates activation of the rendered-markdown <a> links (the anchors are the interactive elements) */}
-				{/* biome-ignore lint/a11y/useKeyWithClickEvents: the links are keyboard-focusable anchors inside innerHTML; delegation only forwards their activation */}
-				<div
-					class="dreb-answer"
-					onClick={onCodeLinkClick}
-					innerHTML={linkifyAnswer(renderMarkdown(props.group.answer), buildGroundedRefs(props.group.activity))}
-				/>
-			</Show>
+			<For each={props.group.segments}>
+				{(segment, index) =>
+					segment.kind === "activity" ? (
+						<ActivityBox
+							segment={segment}
+							streaming={props.group.streaming && index() === props.group.segments.length - 1}
+						/>
+					) : (
+						<Show when={segment.text.length > 0}>
+							{/* Sanitized markdown with grounded, clickable code links. Links are
+							    wired via event delegation (postToHost) rather than href navigation,
+							    so they work under the webview's strict CSP. Grounded refs come from
+							    the whole run's tool activity so a path read in an earlier box still
+							    linkifies in a later answer block. */}
+							{/* biome-ignore lint/a11y/noStaticElementInteractions: delegates activation of the rendered-markdown <a> links (the anchors are the interactive elements) */}
+							{/* biome-ignore lint/a11y/useKeyWithClickEvents: the links are keyboard-focusable anchors inside innerHTML; delegation only forwards their activation */}
+							<div
+								class="dreb-answer"
+								onClick={onCodeLinkClick}
+								innerHTML={linkifyAnswer(renderMarkdown(segment.text), buildGroundedRefs(props.group.activity))}
+							/>
+						</Show>
+					)
+				}
+			</For>
 			<Show when={props.group.aborted}>
 				<div
 					class="dreb-aborted"
@@ -577,23 +588,24 @@ export function TreePanel(props: { tree: SessionTreeDto; onNavigate: (entryId: s
 	);
 }
 
-function ActivityBox(props: { group: ResponseGroup }) {
+function ActivityBox(props: { segment: ActivitySegment; streaming: boolean }) {
 	const [open, setOpen] = createSignal(true);
-	// Auto-collapse once the run finishes; the user can reopen freely afterward.
+	// Auto-collapse once this box finishes (an answer follows it, or the run ends);
+	// the user can reopen freely afterward.
 	let autoCollapsed = false;
 	createEffect(() => {
-		if (props.group.collapsed && !autoCollapsed) {
+		if (props.segment.collapsed && !autoCollapsed) {
 			autoCollapsed = true;
 			setOpen(false);
 		}
 	});
-	const summary = createMemo(() => activitySummary(props.group));
+	const summary = createMemo(() => activityItemsSummary(props.segment.items));
 
 	return (
 		<div class="dreb-activity">
 			<button type="button" class="dreb-activity-head" onClick={() => setOpen(!open())}>
 				<span class="dreb-caret">{open() ? "▾" : "▸"}</span>
-				<Show when={props.group.streaming} fallback={<span class="dreb-activity-label">Worked · {summary()}</span>}>
+				<Show when={props.streaming} fallback={<span class="dreb-activity-label">Worked · {summary()}</span>}>
 					<span class="dreb-activity-label">
 						<span class="dreb-spinner" /> Working · {summary()}
 					</span>
@@ -601,7 +613,7 @@ function ActivityBox(props: { group: ResponseGroup }) {
 			</button>
 			<Show when={open()}>
 				<div class="dreb-activity-body">
-					<For each={props.group.activity}>
+					<For each={props.segment.items}>
 						{(item) =>
 							item.kind === "thinking" ? <div class="dreb-thinking">{item.text}</div> : <ToolCard tool={item} />
 						}

--- a/packages/vscode/src/webview/app.tsx
+++ b/packages/vscode/src/webview/app.tsx
@@ -12,6 +12,7 @@ import {
 	createTranscriptState,
 	type ResponseGroup,
 	retryableResponseId,
+	runActivity,
 	type SuggestionState,
 	type ToolActivity,
 	type TranscriptState,
@@ -446,7 +447,10 @@ export function ResponseView(props: { group: ResponseGroup; onRetry?: () => void
 							<div
 								class="dreb-answer"
 								onClick={onCodeLinkClick}
-								innerHTML={linkifyAnswer(renderMarkdown(segment.text), buildGroundedRefs(props.group.activity))}
+								innerHTML={linkifyAnswer(
+									renderMarkdown(segment.text),
+									buildGroundedRefs(runActivity(props.group)),
+								)}
 							/>
 						</Show>
 					)

--- a/packages/vscode/test/app-retry.test.tsx
+++ b/packages/vscode/test/app-retry.test.tsx
@@ -24,7 +24,7 @@ import { ResponseView, RetryBanner } from "../src/webview/app.js";
 const erroredGroup = (): ResponseGroup => ({
 	kind: "response",
 	id: 1,
-	activity: [],
+	segments: [],
 	answer: "",
 	streaming: false,
 	collapsed: true,

--- a/packages/vscode/test/install-extension.test.ts
+++ b/packages/vscode/test/install-extension.test.ts
@@ -159,7 +159,7 @@ describe("runInstall (side-effecting install core)", () => {
 		});
 		expect(codes).toEqual([1]);
 		expect(result).toMatchObject({ ok: false, reason: "missing-build" });
-		expect(result.ok === false && result.missing).toEqual([
+		expect(result.ok === false && result.reason === "missing-build" && result.missing).toEqual([
 			"/repo/packages/vscode/dist/host/extension.js",
 			"/repo/packages/coding-agent/dist/cli.js",
 		]);

--- a/packages/vscode/test/projection.test.ts
+++ b/packages/vscode/test/projection.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, it } from "vitest";
 import {
-	activitySummary,
+	type ActivityItem,
+	activityItemsSummary,
 	alignCheckpoints,
 	applyEvent,
 	createTranscriptState,
 	foldMessagesIntoState,
 	type ResponseGroup,
 	retryableResponseId,
+	runActivity,
 	type TranscriptState,
 } from "../src/shared/projection.js";
 
@@ -47,9 +49,9 @@ describe("projection", () => {
 		expect(state.items[0]).toEqual({ kind: "user", text: "hello" });
 		const group = onlyResponse(state);
 		expect(group.answer).toBe("Here is the answer.");
-		expect(group.activity).toHaveLength(2);
-		expect(group.activity[0]).toEqual({ kind: "thinking", text: "pondering done" });
-		expect(group.activity[1]).toMatchObject({
+		expect(runActivity(group)).toHaveLength(2);
+		expect(runActivity(group)[0]).toEqual({ kind: "thinking", text: "pondering done" });
+		expect(runActivity(group)[1]).toMatchObject({
 			kind: "tool",
 			toolCallId: "t1",
 			toolName: "read",
@@ -102,8 +104,51 @@ describe("projection", () => {
 		expect(box2.kind === "activity" && box2.items.map((i) => i.kind)).toEqual(["tool", "thinking"]);
 		expect(ans2).toEqual({ kind: "answer", text: "Second result." });
 		// The aggregate views still hold the whole run.
-		expect(group.activity).toHaveLength(4);
+		expect(runActivity(group)).toHaveLength(4);
 		expect(group.answer).toBe("First result.\n\nSecond result.");
+	});
+
+	it("delivers a post-snapshot tool result to the rendered segment item (regression: mid-stream reload)", () => {
+		// A run streaming a still-running tool inside an activity box.
+		const state = run([
+			{ type: "agent_start" },
+			{ type: "message_start", message: { role: "assistant" } },
+			{ type: "tool_execution_start", toolCallId: "t1", toolName: "read", args: { path: "a.ts" } },
+		]);
+
+		// Simulate the host→webview snapshot boundary: VS Code's postMessage
+		// JSON-serializes the transcript, dropping any shared object references.
+		// Before the single-source-of-truth fix, the flat `activity` aggregate and
+		// the rendered `segments[].items` became two distinct copies here, so a
+		// later tool_execution_end mutated only the aggregate (walked by findTool)
+		// while the box kept rendering a stuck "running" spinner. Reproduce that
+		// boundary and assert the item the box actually renders reflects completion.
+		const rehydrated: TranscriptState = JSON.parse(JSON.stringify(state));
+		applyEvent(rehydrated, { type: "tool_execution_end", toolCallId: "t1", result: "file body", isError: false });
+
+		const box = onlyResponse(rehydrated).segments.find((s) => s.kind === "activity");
+		const tool = box?.kind === "activity" ? box.items.find((i) => i.kind === "tool") : undefined;
+		expect(tool).toMatchObject({ status: "done", resultText: "file body" });
+		// The derived aggregate reflects it too (single source of truth).
+		expect(runActivity(onlyResponse(rehydrated))[0]).toMatchObject({ status: "done", resultText: "file body" });
+	});
+
+	it("delivers post-snapshot thinking deltas to the rendered segment item (regression: mid-stream reload)", () => {
+		const state = run([
+			{ type: "agent_start" },
+			{ type: "message_start", message: { role: "assistant" } },
+			{ type: "message_update", assistantMessageEvent: { type: "thinking_start" } },
+			{ type: "message_update", assistantMessageEvent: { type: "thinking_delta", delta: "first" } },
+		]);
+		const rehydrated: TranscriptState = JSON.parse(JSON.stringify(state));
+		applyEvent(rehydrated, {
+			type: "message_update",
+			assistantMessageEvent: { type: "thinking_delta", delta: " second" },
+		});
+
+		const box = onlyResponse(rehydrated).segments.find((s) => s.kind === "activity");
+		const thought = box?.kind === "activity" ? box.items[0] : undefined;
+		expect(thought).toEqual({ kind: "thinking", text: "first second" });
 	});
 
 	it("coalesces consecutive thinking/tools into one box, and collapses finished boxes", () => {
@@ -352,7 +397,7 @@ describe("projection", () => {
 			{ type: "agent_end" },
 		]);
 
-		const tools = onlyResponse(state).activity.filter((a) => a.kind === "tool");
+		const tools = runActivity(onlyResponse(state)).filter((a) => a.kind === "tool");
 		expect(tools).toHaveLength(2);
 		expect(tools[0]).toMatchObject({ toolCallId: "t1", toolName: "read", status: "error", resultText: "t1 output" });
 		expect(tools[1]).toMatchObject({ toolCallId: "t2", toolName: "bash", status: "done", resultText: "t2 output" });
@@ -382,22 +427,14 @@ describe("projection", () => {
 		expect(state.statusText).toBeUndefined();
 	});
 
-	it("summarizes activity for the collapsed header", () => {
-		const group: ResponseGroup = {
-			kind: "response",
-			segments: [],
-			id: 1,
-			activity: [
-				{ kind: "thinking", text: "x" },
-				{ kind: "tool", toolCallId: "t1", toolName: "read", args: {}, status: "done", resultText: "" },
-				{ kind: "tool", toolCallId: "t2", toolName: "bash", args: {}, status: "done", resultText: "" },
-			],
-			answer: "",
-			streaming: false,
-			collapsed: true,
-		};
-		expect(activitySummary(group)).toBe("1 thought · 2 tool calls");
-		expect(activitySummary({ ...group, activity: [] })).toBe("no activity");
+	it("summarizes a box's activity items for the collapsed header", () => {
+		const items: ActivityItem[] = [
+			{ kind: "thinking", text: "x" },
+			{ kind: "tool", toolCallId: "t1", toolName: "read", args: {}, status: "done", resultText: "" },
+			{ kind: "tool", toolCallId: "t2", toolName: "bash", args: {}, status: "done", resultText: "" },
+		];
+		expect(activityItemsSummary(items)).toBe("1 thought · 2 tool calls");
+		expect(activityItemsSummary([])).toBe("no activity");
 	});
 
 	describe("background agents", () => {
@@ -497,8 +534,8 @@ describe("foldMessagesIntoState (Phase 6 full-content rebuild)", () => {
 		expect(groups).toHaveLength(1);
 		const g = groups[0];
 		expect(g.answer).toBe("here is the answer");
-		expect(activitySummary(g)).toBe("1 thought · 1 tool call");
-		const tool = g.activity.find((a) => a.kind === "tool");
+		expect(activityItemsSummary(runActivity(g))).toBe("1 thought · 1 tool call");
+		const tool = runActivity(g).find((a) => a.kind === "tool");
 		expect(tool).toMatchObject({ toolCallId: "t1", toolName: "read", status: "done", resultText: "file body" });
 	});
 
@@ -551,8 +588,8 @@ describe("foldMessagesIntoState (Phase 6 full-content rebuild)", () => {
 			{ role: "assistant", content: [{ type: "text", text: "done" }], stopReason: "stop" },
 		]);
 		const g = state.items.find((i): i is ResponseGroup => i.kind === "response");
-		const ok = g?.activity.find((a) => a.kind === "tool" && a.toolCallId === "ok");
-		const pending = g?.activity.find((a) => a.kind === "tool" && a.toolCallId === "pending");
+		const ok = g && runActivity(g).find((a) => a.kind === "tool" && a.toolCallId === "ok");
+		const pending = g && runActivity(g).find((a) => a.kind === "tool" && a.toolCallId === "pending");
 		expect(ok).toMatchObject({ status: "error", resultText: "boom" });
 		expect(pending).toMatchObject({ status: "running", resultText: "" });
 	});
@@ -572,7 +609,7 @@ describe("foldMessagesIntoState (Phase 6 full-content rebuild)", () => {
 		// Aborted/empty turn: an empty group, not a "(aborted)" placeholder.
 		expect(groups[1].error).toBeUndefined();
 		expect(groups[1].answer).toBe("");
-		expect(groups[1].activity).toEqual([]);
+		expect(runActivity(groups[1])).toEqual([]);
 	});
 
 	it("resets transient state (streaming, uiRequests, errors)", () => {
@@ -596,7 +633,6 @@ describe("alignCheckpoints (Phase 6)", () => {
 				kind: "response",
 				segments: [],
 				id: i + 1,
-				activity: [],
 				answer: `a${i}`,
 				streaming: false,
 				collapsed: true,
@@ -619,7 +655,6 @@ describe("alignCheckpoints (Phase 6)", () => {
 			kind: "response",
 			segments: [],
 			id: 1,
-			activity: [],
 			answer: "ok",
 			streaming: false,
 			collapsed: true,
@@ -628,7 +663,6 @@ describe("alignCheckpoints (Phase 6)", () => {
 			kind: "response",
 			segments: [],
 			id: 2,
-			activity: [],
 			answer: "",
 			streaming: true,
 			collapsed: false,
@@ -649,7 +683,6 @@ describe("alignCheckpoints (Phase 6)", () => {
 			kind: "response",
 			segments: [],
 			id: 1,
-			activity: [],
 			answer: "a",
 			streaming: false,
 			collapsed: true,
@@ -658,7 +691,6 @@ describe("alignCheckpoints (Phase 6)", () => {
 			kind: "response",
 			segments: [],
 			id: 2,
-			activity: [],
 			answer: "",
 			streaming: false,
 			collapsed: true,
@@ -668,7 +700,6 @@ describe("alignCheckpoints (Phase 6)", () => {
 			kind: "response",
 			segments: [],
 			id: 3,
-			activity: [],
 			answer: "c",
 			streaming: false,
 			collapsed: true,

--- a/packages/vscode/test/projection.test.ts
+++ b/packages/vscode/test/projection.test.ts
@@ -73,6 +73,65 @@ describe("projection", () => {
 		expect(onlyResponse(state).answer).toBe("Let me look. First the config.\n\nNow the answer.");
 	});
 
+	it("interleaves activity boxes and answer blocks in true streaming order (segments)", () => {
+		const state = run([
+			{ type: "agent_start" },
+			{ type: "message_start", message: { role: "assistant" } },
+			// Box 1: think + tool
+			{ type: "message_update", assistantMessageEvent: { type: "thinking_start" } },
+			{ type: "message_update", assistantMessageEvent: { type: "thinking_delta", delta: "planning" } },
+			{ type: "tool_execution_start", toolCallId: "t1", toolName: "read", args: { path: "a.ts" } },
+			{ type: "tool_execution_end", toolCallId: "t1", result: "body", isError: false },
+			// Answer 1
+			{ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "First result." } },
+			// Box 2: tool + think (arrives AFTER answer 1 — must open a new box, not join box 1)
+			{ type: "tool_execution_start", toolCallId: "t2", toolName: "grep", args: { pattern: "x" } },
+			{ type: "tool_execution_end", toolCallId: "t2", result: "hit", isError: false },
+			{ type: "message_update", assistantMessageEvent: { type: "thinking_start" } },
+			{ type: "message_update", assistantMessageEvent: { type: "thinking_delta", delta: "more" } },
+			// Answer 2
+			{ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "Second result." } },
+			{ type: "agent_end" },
+		]);
+
+		const group = onlyResponse(state);
+		expect(group.segments.map((s) => s.kind)).toEqual(["activity", "answer", "activity", "answer"]);
+		const [box1, ans1, box2, ans2] = group.segments;
+		expect(box1.kind === "activity" && box1.items.map((i) => i.kind)).toEqual(["thinking", "tool"]);
+		expect(ans1).toEqual({ kind: "answer", text: "First result." });
+		expect(box2.kind === "activity" && box2.items.map((i) => i.kind)).toEqual(["tool", "thinking"]);
+		expect(ans2).toEqual({ kind: "answer", text: "Second result." });
+		// The aggregate views still hold the whole run.
+		expect(group.activity).toHaveLength(4);
+		expect(group.answer).toBe("First result.\n\nSecond result.");
+	});
+
+	it("coalesces consecutive thinking/tools into one box, and collapses finished boxes", () => {
+		const state = run([
+			{ type: "agent_start" },
+			{ type: "message_start", message: { role: "assistant" } },
+			{ type: "message_update", assistantMessageEvent: { type: "thinking_start" } },
+			{ type: "tool_execution_start", toolCallId: "t1", toolName: "read", args: {} },
+			{ type: "tool_execution_end", toolCallId: "t1", result: "b", isError: false },
+			{ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "answer" } },
+		]);
+
+		const streaming = onlyResponse(state);
+		expect(streaming.segments).toHaveLength(2);
+		const box = streaming.segments[0];
+		expect(box.kind === "activity" && box.items).toHaveLength(2);
+		// The box is finished (an answer opened after it) → collapsed even while the run streams.
+		expect(box.kind === "activity" && box.collapsed).toBe(true);
+
+		// A trailing box (no answer after it) collapses only when the run ends.
+		applyEvent(state, { type: "tool_execution_start", toolCallId: "t2", toolName: "grep", args: {} });
+		const trailing = onlyResponse(state).segments[2];
+		expect(trailing.kind === "activity" && trailing.collapsed).toBe(false);
+		applyEvent(state, { type: "agent_end" });
+		const closed = onlyResponse(state).segments[2];
+		expect(closed.kind === "activity" && closed.collapsed).toBe(true);
+	});
+
 	it("marks the run streaming, then collapses activity at agent_end", () => {
 		const state = createTranscriptState();
 		applyEvent(state, { type: "agent_start" });
@@ -326,6 +385,7 @@ describe("projection", () => {
 	it("summarizes activity for the collapsed header", () => {
 		const group: ResponseGroup = {
 			kind: "response",
+			segments: [],
 			id: 1,
 			activity: [
 				{ kind: "thinking", text: "x" },
@@ -442,6 +502,33 @@ describe("foldMessagesIntoState (Phase 6 full-content rebuild)", () => {
 		expect(tool).toMatchObject({ toolCallId: "t1", toolName: "read", status: "done", resultText: "file body" });
 	});
 
+	it("rebuilds interleaved answer/activity into ordered segments matching the live stream", () => {
+		const state = createTranscriptState();
+		foldMessagesIntoState(state, [
+			{ role: "user", content: "go" },
+			// One run: text, then a tool call, then more text — content parts in order.
+			{
+				role: "assistant",
+				content: [
+					{ type: "text", text: "First." },
+					{ type: "toolCall", id: "t1", name: "read", arguments: { path: "a.txt" } },
+				],
+				stopReason: "toolUse",
+			},
+			{ role: "toolResult", toolCallId: "t1", toolName: "read", content: [{ type: "text", text: "body" }] },
+			{ role: "assistant", content: [{ type: "text", text: "Second." }], stopReason: "stop" },
+		]);
+
+		const g = state.items.find((i): i is ResponseGroup => i.kind === "response");
+		if (!g) throw new Error("no response group");
+		expect(g.segments.map((s) => s.kind)).toEqual(["answer", "activity", "answer"]);
+		expect(g.segments[0]).toEqual({ kind: "answer", text: "First." });
+		expect(g.segments[2]).toEqual({ kind: "answer", text: "Second." });
+		// Every rebuilt (historical) box is collapsed.
+		const box = g.segments[1];
+		expect(box.kind === "activity" && box.collapsed).toBe(true);
+	});
+
 	it("marks a tool as error when its result is an error, and leaves an unmatched tool running", () => {
 		const state = createTranscriptState();
 		foldMessagesIntoState(state, [
@@ -507,6 +594,7 @@ describe("alignCheckpoints (Phase 6)", () => {
 		for (let i = 0; i < count; i++) {
 			state.items.push({
 				kind: "response",
+				segments: [],
 				id: i + 1,
 				activity: [],
 				answer: `a${i}`,
@@ -527,8 +615,24 @@ describe("alignCheckpoints (Phase 6)", () => {
 
 	it("skips only actively-streaming groups (the in-flight turn has no persisted entry yet)", () => {
 		const state = createTranscriptState();
-		state.items.push({ kind: "response", id: 1, activity: [], answer: "ok", streaming: false, collapsed: true });
-		state.items.push({ kind: "response", id: 2, activity: [], answer: "", streaming: true, collapsed: false });
+		state.items.push({
+			kind: "response",
+			segments: [],
+			id: 1,
+			activity: [],
+			answer: "ok",
+			streaming: false,
+			collapsed: true,
+		});
+		state.items.push({
+			kind: "response",
+			segments: [],
+			id: 2,
+			activity: [],
+			answer: "",
+			streaming: true,
+			collapsed: false,
+		});
 		expect(alignCheckpoints(state, ["e1"], new Set(["e1"]))).toEqual([
 			{ responseId: 1, entryId: "e1", canRestore: false, canFork: true },
 		]);
@@ -541,9 +645,18 @@ describe("alignCheckpoints (Phase 6)", () => {
 		// Fork is offered only where the backend allows it: the errored turn B is
 		// NOT in the forkable set, so its canFork is false.
 		const state = createTranscriptState();
-		state.items.push({ kind: "response", id: 1, activity: [], answer: "a", streaming: false, collapsed: true });
 		state.items.push({
 			kind: "response",
+			segments: [],
+			id: 1,
+			activity: [],
+			answer: "a",
+			streaming: false,
+			collapsed: true,
+		});
+		state.items.push({
+			kind: "response",
+			segments: [],
 			id: 2,
 			activity: [],
 			answer: "",
@@ -551,7 +664,15 @@ describe("alignCheckpoints (Phase 6)", () => {
 			collapsed: true,
 			error: "rate limited",
 		});
-		state.items.push({ kind: "response", id: 3, activity: [], answer: "c", streaming: false, collapsed: true });
+		state.items.push({
+			kind: "response",
+			segments: [],
+			id: 3,
+			activity: [],
+			answer: "c",
+			streaming: false,
+			collapsed: true,
+		});
 		expect(alignCheckpoints(state, ["a", "b", "c"], new Set(["a", "c"]))).toEqual([
 			{ responseId: 1, entryId: "a", canRestore: true, canFork: true },
 			{ responseId: 2, entryId: "b", canRestore: true, canFork: false },

--- a/packages/vscode/test/projection.test.ts
+++ b/packages/vscode/test/projection.test.ts
@@ -539,6 +539,46 @@ describe("foldMessagesIntoState (Phase 6 full-content rebuild)", () => {
 		expect(tool).toMatchObject({ toolCallId: "t1", toolName: "read", status: "done", resultText: "file body" });
 	});
 
+	it("coalesces a rebuilt burst of back-to-back tool calls (separate messages) into ONE box", () => {
+		// Two tool calls arriving as SEPARATE assistant+toolResult message pairs with
+		// no intervening answer text must fold into a single activity box — identical
+		// to how the live stream coalesces consecutive tools (AC 2 / AC 3). Guards the
+		// rebuild path's across-message coalescing, which shares pushActivity with live.
+		const state = createTranscriptState();
+		foldMessagesIntoState(state, [
+			{ role: "user", content: "do both" },
+			{
+				role: "assistant",
+				content: [{ type: "toolCall", id: "t1", name: "read", arguments: { path: "a.txt" } }],
+				stopReason: "toolUse",
+			},
+			{ role: "toolResult", toolCallId: "t1", toolName: "read", content: [{ type: "text", text: "body a" }] },
+			// A SECOND tool call in its own assistant turn, with NO answer text between.
+			{
+				role: "assistant",
+				content: [{ type: "toolCall", id: "t2", name: "grep", arguments: { pattern: "x" } }],
+				stopReason: "toolUse",
+			},
+			{ role: "toolResult", toolCallId: "t2", toolName: "grep", content: [{ type: "text", text: "body b" }] },
+			{ role: "assistant", content: [{ type: "text", text: "done" }], stopReason: "stop" },
+		]);
+
+		const g = state.items.find((i): i is ResponseGroup => i.kind === "response");
+		if (!g) throw new Error("no response group");
+		// Exactly ONE activity box (not two stacked boxes), holding both tools in order.
+		const activityBoxes = g.segments.filter((s) => s.kind === "activity");
+		expect(activityBoxes).toHaveLength(1);
+		const box = activityBoxes[0];
+		expect(box.kind === "activity" && box.items.map((i) => i.kind)).toEqual(["tool", "tool"]);
+		expect(box.kind === "activity" && box.items.map((i) => (i.kind === "tool" ? i.toolCallId : null))).toEqual([
+			"t1",
+			"t2",
+		]);
+		// Whole run: one box, then the final answer.
+		expect(g.segments.map((s) => s.kind)).toEqual(["activity", "answer"]);
+		expect(g.answer).toBe("done");
+	});
+
 	it("rebuilds interleaved answer/activity into ordered segments matching the live stream", () => {
 		const state = createTranscriptState();
 		foldMessagesIntoState(state, [

--- a/packages/vscode/test/response-click.test.tsx
+++ b/packages/vscode/test/response-click.test.tsx
@@ -14,7 +14,7 @@
 
 import { render } from "solid-js/web/dist/web.js";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { ResponseGroup, ToolActivity } from "../src/shared/projection.js";
+import type { ResponseGroup, ResponseSegment, ToolActivity } from "../src/shared/projection.js";
 
 const hoisted = vi.hoisted(() => ({ posted: [] as unknown[] }));
 
@@ -28,14 +28,23 @@ vi.mock("../src/webview/vscode-api.js", () => ({
 import { ResponseView } from "../src/webview/app.js";
 
 function group(partial: Partial<ResponseGroup>): ResponseGroup {
+	const activity = partial.activity ?? [];
+	const answer = partial.answer ?? "";
+	// Derive the ordered segments the renderer consumes from the aggregate
+	// activity/answer fields, so existing test cases keep their simple shape.
+	const segments: ResponseSegment[] = partial.segments ?? [
+		...(activity.length > 0 ? [{ kind: "activity" as const, items: activity, collapsed: true }] : []),
+		...(answer.length > 0 ? [{ kind: "answer" as const, text: answer }] : []),
+	];
 	return {
 		kind: "response",
 		id: 1,
-		activity: [],
-		answer: "",
 		streaming: false,
 		collapsed: true,
 		...partial,
+		activity,
+		answer,
+		segments,
 	};
 }
 
@@ -103,5 +112,28 @@ describe("ResponseView code-link click wiring", () => {
 		answer.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
 
 		expect(hoisted.posted).toEqual([]);
+	});
+
+	it("renders interleaved activity boxes and answer blocks in segment order", () => {
+		const host = mount(
+			group({
+				segments: [
+					{ kind: "activity", items: [{ kind: "thinking", text: "plan" }], collapsed: true },
+					{ kind: "answer", text: "First result." },
+					{ kind: "activity", items: [searchTool("1. src/x.ts:L1 (fn go)")], collapsed: true },
+					{ kind: "answer", text: "Second result." },
+				],
+			}),
+		);
+		// Two distinct activity boxes render (not one merged box hoisted to the top).
+		expect(host.querySelectorAll(".dreb-activity")).toHaveLength(2);
+		// The two answer blocks render in order, between/after the boxes.
+		const answers = [...host.querySelectorAll(".dreb-answer")].map((el) => el.textContent?.trim());
+		expect(answers).toEqual(["First result.", "Second result."]);
+		// Document order is box → answer → box → answer.
+		const kinds = [...host.querySelectorAll(".dreb-activity, .dreb-answer")].map((el) =>
+			el.classList.contains("dreb-activity") ? "box" : "answer",
+		);
+		expect(kinds).toEqual(["box", "answer", "box", "answer"]);
 	});
 });

--- a/packages/vscode/test/response-click.test.tsx
+++ b/packages/vscode/test/response-click.test.tsx
@@ -14,7 +14,7 @@
 
 import { render } from "solid-js/web/dist/web.js";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { ResponseGroup, ResponseSegment, ToolActivity } from "../src/shared/projection.js";
+import type { ActivityItem, ResponseGroup, ResponseSegment, ToolActivity } from "../src/shared/projection.js";
 
 const hoisted = vi.hoisted(() => ({ posted: [] as unknown[] }));
 
@@ -27,13 +27,15 @@ vi.mock("../src/webview/vscode-api.js", () => ({
 
 import { ResponseView } from "../src/webview/app.js";
 
-function group(partial: Partial<ResponseGroup>): ResponseGroup {
-	const activity = partial.activity ?? [];
-	const answer = partial.answer ?? "";
-	// Derive the ordered segments the renderer consumes from the aggregate
-	// activity/answer fields, so existing test cases keep their simple shape.
-	const segments: ResponseSegment[] = partial.segments ?? [
-		...(activity.length > 0 ? [{ kind: "activity" as const, items: activity, collapsed: true }] : []),
+function group(partial: Partial<ResponseGroup> & { activity?: ActivityItem[] }): ResponseGroup {
+	const { activity, ...rest } = partial;
+	const answer = rest.answer ?? "";
+	// Derive the ordered segments the renderer consumes from the convenience
+	// activity/answer inputs, so existing test cases keep their simple shape.
+	// `activity` is a factory-only input — the group stores items solely in
+	// `segments` now.
+	const segments: ResponseSegment[] = rest.segments ?? [
+		...(activity && activity.length > 0 ? [{ kind: "activity" as const, items: activity, collapsed: true }] : []),
 		...(answer.length > 0 ? [{ kind: "answer" as const, text: answer }] : []),
 	];
 	return {
@@ -41,8 +43,7 @@ function group(partial: Partial<ResponseGroup>): ResponseGroup {
 		id: 1,
 		streaming: false,
 		collapsed: true,
-		...partial,
-		activity,
+		...rest,
 		answer,
 		segments,
 	};
@@ -135,5 +136,54 @@ describe("ResponseView code-link click wiring", () => {
 			el.classList.contains("dreb-activity") ? "box" : "answer",
 		);
 		expect(kinds).toEqual(["box", "answer", "box", "answer"]);
+	});
+
+	it("linkifies a later answer using a symbol grounded by a tool in an EARLIER box (whole-run refs)", () => {
+		// The grounding tool lives two segments before the answer that references
+		// it — proving ResponseView grounds each answer against the WHOLE run's
+		// activity (buildGroundedRefs(runActivity(group))), not just its own
+		// segment. A segment-local grounding would drop this cross-box link.
+		const host = mount(
+			group({
+				segments: [
+					{ kind: "activity", items: [searchTool("1. src/widget.ts:L7-20 (class Widget)")], collapsed: true },
+					{ kind: "answer", text: "Looking into it." },
+					{ kind: "activity", items: [{ kind: "thinking", text: "still thinking" }], collapsed: true },
+					{ kind: "answer", text: "The Widget class is the culprit." },
+				],
+			}),
+		);
+		const answers = [...host.querySelectorAll(".dreb-answer")] as HTMLElement[];
+		const laterAnswer = answers[answers.length - 1];
+		const link = laterAnswer.querySelector("a.dreb-code-link") as HTMLAnchorElement;
+		expect(link?.dataset.symbol).toBe("Widget");
+
+		link.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+		expect(hoisted.posted).toEqual([
+			{ type: "open-source", ref: { symbol: "Widget", path: "src/widget.ts", line: 7 } },
+		]);
+	});
+
+	it("shows the working spinner only on the trailing activity box while streaming", () => {
+		const host = mount(
+			group({
+				streaming: true,
+				segments: [
+					// An earlier, finished box (an answer opened after it).
+					{ kind: "activity", items: [{ kind: "thinking", text: "first" }], collapsed: true },
+					{ kind: "answer", text: "Interim." },
+					// The trailing, in-flight box.
+					{ kind: "activity", items: [{ kind: "thinking", text: "second" }], collapsed: false },
+				],
+			}),
+		);
+		const boxes = [...host.querySelectorAll(".dreb-activity")] as HTMLElement[];
+		expect(boxes).toHaveLength(2);
+		// Exactly one spinner, on the last (in-flight) box.
+		expect(host.querySelectorAll(".dreb-spinner")).toHaveLength(1);
+		expect(boxes[0].querySelector(".dreb-spinner")).toBeNull();
+		expect(boxes[0].textContent).toContain("Worked");
+		expect(boxes[1].querySelector(".dreb-spinner")).toBeTruthy();
+		expect(boxes[1].textContent).toContain("Working");
 	});
 });

--- a/packages/vscode/test/session-controller.test.ts
+++ b/packages/vscode/test/session-controller.test.ts
@@ -7,6 +7,7 @@ import {
 	SessionController,
 } from "../src/host/session-controller.js";
 import type { SourceLinkUi } from "../src/host/source-link-ui.js";
+import { runActivity } from "../src/shared/projection.js";
 import type { OpenSourceRef, SessionTreeNodeDto } from "../src/shared/protocol.js";
 
 /** Fake RpcClient that captures calls and lets a test drive events/exit. */
@@ -2232,8 +2233,8 @@ describe("SessionController session tree (Phase 6)", () => {
 		const group = items.find((i) => i.kind === "response");
 		if (group?.kind !== "response") throw new Error("expected a response group");
 		expect(group.answer).toBe("here is the answer");
-		expect(group.activity.filter((a) => a.kind === "thinking")).toHaveLength(1);
-		const tool = group.activity.find((a) => a.kind === "tool");
+		expect(runActivity(group).filter((a) => a.kind === "thinking")).toHaveLength(1);
+		const tool = runActivity(group).find((a) => a.kind === "tool");
 		expect(tool).toMatchObject({ toolName: "read", status: "done", resultText: "file body" });
 		// The single restore/fork control keys to the run-terminal entry (a2).
 		expect(controller.getCheckpoints().map((c) => `${c.entryId}:${c.canRestore}:${c.canFork}`)).toEqual([


### PR DESCRIPTION
Closes #97

Render VSCode transcript activity boxes and answer blocks in true streaming order by replacing the flat `activity`/`answer` model on `ResponseGroup` with an ordered segment list.

Base branch is the `vscode` component branch (where `packages/vscode` lives); karin is rebuilt from components separately.

Implementation plan posted as a comment below.
