### PR TITLE
Render LaTeX math equations in VS Code extension webview

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4474,6 +4474,13 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/katex": {
+			"version": "0.16.8",
+			"resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
+			"integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/mime-types": {
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.4.tgz",
@@ -5560,6 +5567,16 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"license": "MIT"
+		},
+		"node_modules/commander": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+			"integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 12"
+			}
 		},
 		"node_modules/concurrently": {
 			"version": "10.0.3",
@@ -7529,6 +7546,23 @@
 				"safe-buffer": "^5.0.1"
 			}
 		},
+		"node_modules/katex": {
+			"version": "0.18.4",
+			"resolved": "https://registry.npmjs.org/katex/-/katex-0.18.4.tgz",
+			"integrity": "sha512-IMPntbRLOU+eu88XDiFKqQ8Akhr9Tv7jDMXqPhjG9SI1JMA4DIgXk4x9k4skJz2NZJXBRbC+2pYBLj9olqcZow==",
+			"dev": true,
+			"funding": [
+				"https://opencollective.com/katex",
+				"https://github.com/sponsors/katex"
+			],
+			"license": "MIT",
+			"dependencies": {
+				"commander": "^8.3.0"
+			},
+			"bin": {
+				"katex": "cli.js"
+			}
+		},
 		"node_modules/koffi": {
 			"version": "2.15.2",
 			"resolved": "https://registry.npmjs.org/koffi/-/koffi-2.15.2.tgz",
@@ -7875,6 +7909,17 @@
 			},
 			"engines": {
 				"node": ">= 18"
+			}
+		},
+		"node_modules/marked-katex-extension": {
+			"version": "5.1.12",
+			"resolved": "https://registry.npmjs.org/marked-katex-extension/-/marked-katex-extension-5.1.12.tgz",
+			"integrity": "sha512-DgfH0CFrOuVwVEXNJ+rTtYOtZZECpHhA0bu7xBiACAJI4geeaCZfDq+hiJ1yJx780fDh2HWHlr+NySxuc2DD1w==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"katex": ">=0.16 <0.19",
+				"marked": ">=4 <19"
 			}
 		},
 		"node_modules/matcher": {
@@ -11603,10 +11648,13 @@
 				"@dreb/coding-agent": "*"
 			},
 			"devDependencies": {
+				"@types/katex": "^0.16.8",
 				"@types/node": "^22.10.5",
 				"@types/vscode": "^1.100.0",
 				"dompurify": "^3.4.11",
+				"katex": "^0.18.4",
 				"marked": "^15.0.12",
+				"marked-katex-extension": "^5.1.12",
 				"solid-js": "^1.9.14",
 				"typescript": "^5.9.2",
 				"vite": "^8.1.3",

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -152,7 +152,16 @@ File paths and code symbols that appear in an answer render as **clickable links
 - **Reliability lives in the client, not the model.** The agent is never trusted to emit valid links: the webview linkifies syntactically/greedily but only *grounds* ambiguous symbols against real tool hits, and the host **validates** on click (a path that does not exist, or a symbol that resolves nowhere, shows an unobtrusive notice — never a broken jump). References that match nothing real simply stay plain text.
 - Links are wired via **event delegation → `postToHost`** (not `href` navigation), so they work under the webview's strict `default-src 'none'` CSP.
 
-Grounding + linkification are pure and unit-tested in `webview/code-links.ts` (`buildGroundedRefs` parses the tool-output formats; `linkifyAnswer` walks the sanitized answer DOM without corrupting existing markdown links/code spans). The open/resolve logic is driven through the vscode-free `host/source-link-ui.ts` port (real impl `host/vscode-source-link-ui.ts`), so the controller stays testable. A grounded symbol carries its usage location so the host can jump even before the language server resolves; semantic-search-based resolution is a possible future deepening.
+Grounding + linkification are pure and unit-tested in `webview/code-links.ts` (`buildGroundedRefs` parses the tool-output formats; `linkifyAnswer` walks the sanitized answer DOM without corrupting existing markdown links/code spans — it skips rendered-math subtrees so equations are never linkified). The open/resolve logic is driven through the vscode-free `host/source-link-ui.ts` port (real impl `host/vscode-source-link-ui.ts`), so the controller stays testable. A grounded symbol carries its usage location so the host can jump even before the language server resolves; semantic-search-based resolution is a possible future deepening.
+
+## Math rendering
+
+LaTeX math in an answer is typeset with **KaTeX**. Both display and inline math render, in either delimiter style the model emits:
+
+- **Display** — `$$…$$` or `\[…\]` render as centered equations.
+- **Inline** — `$…$` or `\(…\)` render inline with the surrounding text.
+
+Ordinary `$` in prose is safe: inline `$…$` uses **standard** (no-space) matching, so currency like "$5 and $10" is not mistaken for math. Math inside `` `code` `` spans and fenced blocks stays literal, and an unclosed delimiter (e.g. mid-stream) simply renders as plain text until it closes. Malformed or unsupported LaTeX degrades to its visible source (KaTeX `throwOnError:false`) rather than blanking the message. The rendered HTML/MathML still passes through DOMPurify (KaTeX runs with `trust:false`, so there is no XSS surface). Rendering lives in `webview/markdown.ts` and is unit-tested in `test/markdown.test.ts`; KaTeX's stylesheet + fonts are bundled into the webview (`dist/webview`), so nothing loads over the network.
 
 ## Session tree — restore checkpoint + fork
 

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -216,10 +216,13 @@
 		"@dreb/coding-agent": "*"
 	},
 	"devDependencies": {
+		"@types/katex": "^0.16.8",
 		"@types/node": "^22.10.5",
 		"@types/vscode": "^1.100.0",
 		"dompurify": "^3.4.11",
+		"katex": "^0.18.4",
 		"marked": "^15.0.12",
+		"marked-katex-extension": "^5.1.12",
 		"solid-js": "^1.9.14",
 		"typescript": "^5.9.2",
 		"vite": "^8.1.3",

--- a/packages/vscode/src/webview/code-links.ts
+++ b/packages/vscode/src/webview/code-links.ts
@@ -209,6 +209,10 @@ function walk(parent: Node, refs: GroundedRefs): void {
 			const el = child as Element;
 			// Never nest links inside an existing anchor.
 			if (el.tagName === "A") continue;
+			// Never descend into rendered math (KaTeX). Its text nodes are layout
+			// glyphs and its MathML <annotation> carries the raw LaTeX source —
+			// linkifying inside would corrupt the equation.
+			if (el.classList.contains("katex")) continue;
 			walk(el, refs);
 		}
 	}

--- a/packages/vscode/src/webview/index.tsx
+++ b/packages/vscode/src/webview/index.tsx
@@ -1,6 +1,10 @@
 import { render } from "solid-js/web";
 import { App } from "./app.js";
 import "./styles.css";
+// KaTeX stylesheet + fonts for rendered LaTeX math (see webview/markdown.ts).
+// vite bundles this into main.css and emits the fonts as hashed assets under
+// dist/webview/assets (see vite.config.mts assetFileNames).
+import "katex/dist/katex.min.css";
 
 const root = document.getElementById("root");
 if (!root) throw new Error("dreb webview: #root element missing");

--- a/packages/vscode/src/webview/markdown.ts
+++ b/packages/vscode/src/webview/markdown.ts
@@ -1,12 +1,126 @@
 import DOMPurify from "dompurify";
-import { marked } from "marked";
+import katex from "katex";
+import { Marked } from "marked";
+import markedKatex from "marked-katex-extension";
 
 /**
- * Render assistant Markdown to sanitized HTML for the answer pane. Model output
- * is untrusted, so every rendered string passes through DOMPurify before it
- * reaches the DOM.
+ * Render assistant Markdown to sanitized HTML for the answer pane, with LaTeX
+ * math typeset by KaTeX. Model output is untrusted, so every rendered string
+ * still passes through DOMPurify before it reaches the DOM.
+ *
+ * Math delimiters:
+ *   - `$$…$$` / `$…$`   — marked-katex-extension, in **standard** mode
+ *     (`nonStandard:false`), so ordinary `$` in prose/currency (e.g. "$5 and
+ *     $10") is NOT parsed as math.
+ *   - `\[…\]` / `\(…\)` — the supplementary tokenizers below (LLMs commonly emit
+ *     these). They run at marked's inline level *before* the escape/codespan
+ *     tokenizers, so the delimiters are captured intact and math inside
+ *     `code` spans / fenced blocks stays literal.
+ *
+ * KaTeX runs with `throwOnError:false` (bad/unsupported LaTeX renders in an
+ * error color showing its source rather than throwing and blanking the whole
+ * message), `strict:"ignore"` (tolerate stray Unicode in model output), and
+ * `trust:false` (no `\href`→`javascript:` or raw-HTML injection).
  */
+
+const KATEX_OPTIONS = { throwOnError: false, strict: "ignore" as const, trust: false };
+
+/** Render one `\(…\)` / `\[…\]` chunk to KaTeX HTML. */
+function renderTex(tex: string, displayMode: boolean): string {
+	return katex.renderToString(tex, { ...KATEX_OPTIONS, displayMode });
+}
+
+/**
+ * Supplementary marked extension for LaTeX-style `\(…\)` (inline) and `\[…\]`
+ * (display) delimiters, which marked-katex-extension does not cover. Both are
+ * registered at the inline level so they win over the core escape/codespan
+ * tokenizers and can span newlines within a paragraph.
+ */
+const bracketMath = {
+	extensions: [
+		{
+			name: "inlineBracketMath",
+			level: "inline" as const,
+			start(src: string) {
+				const i = src.indexOf("\\(");
+				return i < 0 ? undefined : i;
+			},
+			tokenizer(src: string) {
+				const m = /^\\\(([\s\S]+?)\\\)/.exec(src);
+				if (!m) return undefined;
+				return { type: "inlineBracketMath", raw: m[0], text: m[1] };
+			},
+			renderer(token: { text: string }) {
+				return renderTex(token.text, false);
+			},
+		},
+		{
+			name: "displayBracketMath",
+			level: "inline" as const,
+			start(src: string) {
+				const i = src.indexOf("\\[");
+				return i < 0 ? undefined : i;
+			},
+			tokenizer(src: string) {
+				const m = /^\\\[([\s\S]+?)\\\]/.exec(src);
+				if (!m) return undefined;
+				return { type: "displayBracketMath", raw: m[0], text: m[1].trim() };
+			},
+			renderer(token: { text: string }) {
+				return renderTex(token.text, true);
+			},
+		},
+	],
+};
+
+// A dedicated instance (not the global `marked`) so configuration is applied
+// exactly once and never mutates global state shared with other importers.
+const marked = new Marked(
+	{ async: false, gfm: true, breaks: true },
+	markedKatex({ ...KATEX_OPTIONS, nonStandard: false }),
+	bracketMath,
+);
+
+// KaTeX emits nested <span> (with inline `style` for layout) plus MathML
+// (<math><semantics>…<annotation encoding="application/x-tex">). Preserve those
+// tags/attributes so sanitization doesn't gut the equation — in particular,
+// unwrapping <annotation> would leak the raw LaTeX source as visible text.
+// KaTeX with `trust:false` never emits event handlers or `javascript:` URLs, so
+// widening the allow-list here stays XSS-safe.
+const SANITIZE_OPTIONS = {
+	ADD_TAGS: [
+		"math",
+		"semantics",
+		"annotation",
+		"mrow",
+		"mi",
+		"mo",
+		"mn",
+		"ms",
+		"mtext",
+		"mspace",
+		"msup",
+		"msub",
+		"msubsup",
+		"mfrac",
+		"msqrt",
+		"mroot",
+		"munder",
+		"mover",
+		"munderover",
+		"mtable",
+		"mtr",
+		"mtd",
+		"mpadded",
+		"mphantom",
+		"mstyle",
+		"menclose",
+		"merror",
+	],
+	ADD_ATTR: ["encoding", "display", "displaystyle", "scriptlevel", "mathvariant", "aria-hidden", "style"],
+};
+
 export function renderMarkdown(text: string): string {
-	const html = marked.parse(text, { async: false, gfm: true, breaks: true }) as string;
-	return DOMPurify.sanitize(html);
+	const html = marked.parse(text) as string;
+	return DOMPurify.sanitize(html, SANITIZE_OPTIONS);
 }

--- a/packages/vscode/test/markdown.test.tsx
+++ b/packages/vscode/test/markdown.test.tsx
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import { buildGroundedRefs, linkifyAnswer } from "../src/webview/code-links.js";
+import { renderMarkdown } from "../src/webview/markdown.js";
+
+/** Parse rendered HTML into a detached element for structural assertions. */
+function dom(html: string): HTMLElement {
+	const el = document.createElement("div");
+	el.innerHTML = html;
+	return el;
+}
+
+describe("renderMarkdown — LaTeX math", () => {
+	it("renders display math ($$…$$) as typeset KaTeX, not literal text", () => {
+		const html = renderMarkdown("$$A + B \\rightleftharpoons AB$$");
+		const el = dom(html);
+		expect(el.querySelector(".katex")).not.toBeNull();
+		// The literal delimiters must be gone.
+		expect(el.textContent).not.toContain("$$");
+	});
+
+	it("renders inline math ($…$) as typeset KaTeX", () => {
+		const el = dom(renderMarkdown("The constant $K_D$ matters."));
+		expect(el.querySelector(".katex")).not.toBeNull();
+		// Inline, not display.
+		expect(el.querySelector(".katex-display")).toBeNull();
+		expect(el.textContent).toContain("The constant");
+	});
+
+	it("renders \\(…\\) inline math", () => {
+		const el = dom(renderMarkdown("Euler: \\(e^{i\\pi} + 1 = 0\\)."));
+		expect(el.querySelector(".katex")).not.toBeNull();
+		expect(el.querySelector(".katex-display")).toBeNull();
+	});
+
+	it("renders \\[…\\] display math", () => {
+		const el = dom(renderMarkdown("\\[ x = \\frac{-b}{2a} \\]"));
+		expect(el.querySelector(".katex-display")).not.toBeNull();
+	});
+
+	it("renders the reported K_D equation with \\frac and subscripts", () => {
+		const el = dom(renderMarkdown("$$K_D = \\frac{[A][B]}{[AB]} = \\frac{k_d}{k_a}$$"));
+		expect(el.querySelector(".katex")).not.toBeNull();
+		// \frac produces a fraction structure in the MathML output.
+		expect(el.querySelector("mfrac")).not.toBeNull();
+		// The *visible* HTML render (not the x-tex annotation, which intentionally
+		// keeps the source) must not show a literal `\frac` command.
+		expect(el.querySelector(".katex-html")?.textContent ?? "").not.toContain("\\frac");
+	});
+
+	it("does NOT treat currency / ordinary $ text as math", () => {
+		const el = dom(renderMarkdown("It costs $5 and $10 total."));
+		expect(el.querySelector(".katex")).toBeNull();
+		expect(el.textContent).toContain("$5");
+		expect(el.textContent).toContain("$10");
+	});
+
+	it("degrades malformed LaTeX to visible source without throwing", () => {
+		let html = "";
+		expect(() => {
+			html = renderMarkdown("$\\frac{unbalanced$");
+		}).not.toThrow();
+		expect(html.length).toBeGreaterThan(0);
+		// throwOnError:false surfaces the source in a katex-error span rather than
+		// producing a blank message.
+		const el = dom(html);
+		expect(el.textContent).toContain("frac");
+	});
+
+	it("preserves KaTeX/MathML through sanitization", () => {
+		const el = dom(renderMarkdown("$x^2$"));
+		expect(el.querySelector(".katex")).not.toBeNull();
+		// MathML semantics + the x-tex annotation must survive (not be unwrapped,
+		// which would leak raw LaTeX as visible text).
+		expect(el.querySelector("annotation")).not.toBeNull();
+		// KaTeX relies on inline styles for layout — they must not be stripped.
+		expect(el.innerHTML).toContain("style=");
+	});
+
+	it("does not allow XSS through the widened allow-list", () => {
+		const el = dom(renderMarkdown('Hi <img src=x onerror="alert(1)"> $x$'));
+		expect(el.innerHTML).not.toContain("onerror");
+		expect(el.querySelector(".katex")).not.toBeNull();
+	});
+
+	it("blocks KaTeX \\href javascript: URLs (trust:false)", () => {
+		const el = dom(renderMarkdown("$\\href{javascript:alert(1)}{x}$"));
+		// trust:false makes KaTeX refuse \href — it renders as an error, never an
+		// actual link. The raw source survives only inside the inert x-tex
+		// <annotation>; what matters is that no clickable/navigable URL is emitted.
+		expect(el.querySelector("a")).toBeNull();
+		expect(el.innerHTML.toLowerCase()).not.toContain('href="javascript:');
+		expect(el.innerHTML.toLowerCase()).not.toContain("href='javascript:");
+	});
+
+	it("keeps math inside inline code spans literal", () => {
+		const el = dom(renderMarkdown("Use `$x^2$` verbatim."));
+		expect(el.querySelector(".katex")).toBeNull();
+		expect(el.querySelector("code")?.textContent).toContain("$x^2$");
+	});
+
+	it("keeps math inside fenced code blocks literal", () => {
+		const el = dom(renderMarkdown("```\n$x^2$\n\\(y\\)\n```"));
+		expect(el.querySelector(".katex")).toBeNull();
+		expect(el.querySelector("pre code")?.textContent).toContain("$x^2$");
+	});
+
+	it("leaves an unclosed delimiter (mid-stream) as literal text", () => {
+		let html = "";
+		expect(() => {
+			html = renderMarkdown("Half-streamed $$A + B \\rightlefth");
+		}).not.toThrow();
+		const el = dom(html);
+		expect(el.querySelector(".katex")).toBeNull();
+		expect(el.textContent).toContain("$$A + B");
+	});
+});
+
+describe("linkifyAnswer × rendered math", () => {
+	it("does not linkify tokens inside a rendered equation", () => {
+		// A grounded symbol that also appears as a variable in the math.
+		const refs = buildGroundedRefs([
+			{ kind: "tool", name: "grep", args: { path: "src/x.ts" }, resultText: "src/x.ts:1: x" } as never,
+		]);
+		const rendered = renderMarkdown("See $x = 1$ and src/x.ts:1 below.");
+		const linked = linkifyAnswer(rendered, refs);
+		const el = dom(linked);
+		// The equation subtree must be untouched (no injected anchors inside it).
+		const katex = el.querySelector(".katex");
+		expect(katex).not.toBeNull();
+		expect(katex?.querySelector("a")).toBeNull();
+		expect(katex?.querySelector(".dreb-code-link")).toBeNull();
+		// The real path reference outside the math still linkifies.
+		expect(el.querySelector(".dreb-code-link")).not.toBeNull();
+	});
+});

--- a/packages/vscode/test/markdown.test.tsx
+++ b/packages/vscode/test/markdown.test.tsx
@@ -15,6 +15,8 @@ describe("renderMarkdown — LaTeX math", () => {
 		const html = renderMarkdown("$$A + B \\rightleftharpoons AB$$");
 		const el = dom(html);
 		expect(el.querySelector(".katex")).not.toBeNull();
+		// `$$…$$` must render as *display* math (centered block), not inline.
+		expect(el.querySelector(".katex-display")).not.toBeNull();
 		// The literal delimiters must be gone.
 		expect(el.textContent).not.toContain("$$");
 	});
@@ -64,7 +66,11 @@ describe("renderMarkdown — LaTeX math", () => {
 		// throwOnError:false surfaces the source in a katex-error span rather than
 		// producing a blank message.
 		const el = dom(html);
-		expect(el.textContent).toContain("frac");
+		// The *visible* render must show the source (in a katex-error span), not
+		// merely the inert x-tex <annotation> that always preserves the raw TeX.
+		const visible = el.querySelector(".katex-error") ?? el.querySelector(".katex-html");
+		expect(visible).not.toBeNull();
+		expect(visible?.textContent ?? "").toContain("frac");
 	});
 
 	it("preserves KaTeX/MathML through sanitization", () => {

--- a/packages/vscode/test/sessions-view.test.ts
+++ b/packages/vscode/test/sessions-view.test.ts
@@ -80,7 +80,7 @@ describe("SessionsViewProvider — resource root self-heal", () => {
 		const FALLBACK = "/Users/me/.vscode/extensions/pub.name";
 		const REAL = "/Users/me/Documents/code/dreb/packages/vscode";
 		const resolve = vi
-			.fn<[], vscode.Uri>()
+			.fn<() => vscode.Uri>()
 			.mockReturnValueOnce(vscode.Uri.file(FALLBACK))
 			.mockReturnValue(vscode.Uri.file(REAL));
 		const provider = new SessionsViewProvider(resolve, stubDeps);

--- a/packages/vscode/vite.config.mts
+++ b/packages/vscode/vite.config.mts
@@ -16,7 +16,18 @@ export default defineConfig({
 		rollupOptions: {
 			output: {
 				entryFileNames: "main.js",
-				assetFileNames: "main[extname]",
+				// Keep the single stylesheet at the stable `main.css` the host HTML
+				// links, but give every other asset (KaTeX's ~60 font files) a
+				// distinct hashed name — a flat `main[extname]` would collapse them
+				// all onto one file, breaking font loading (tofu/missing glyphs).
+				assetFileNames: (assetInfo) => {
+					const name =
+						(assetInfo as { names?: string[]; name?: string }).names?.[0] ??
+						(assetInfo as { name?: string }).name ??
+						"";
+					if (name.endsWith(".css")) return "main.css";
+					return "assets/[name]-[hash][extname]";
+				},
 				chunkFileNames: "chunk-[name].js",
 			},
 		},


### PR DESCRIPTION
Closes #101

Render LaTeX math in the VS Code extension's main webview (`renderMarkdown`) using KaTeX via a tokenizer-level `marked` extension — display (`$$…$$`, `\[…\]`) and inline (`$…$`, `\(…\)`) math, with currency-`$` guards, graceful failure for malformed LaTeX, sanitizer-preserved math (no XSS), and correctly bundled fonts (no tofu).

Based on the `vscode` branch (not `master`). Part of epic #12.

Implementation plan posted as a comment below.
