### PR TITLE
Preflight dependency check for install-vscode

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,9 @@
 		"verify-git-hooks": "node scripts/verify-git-hooks.js",
 		"verify-workspace-links": "node scripts/verify-workspace-links.js",
 		"verify-engines": "node scripts/verify-engines.js",
+		"verify-deps": "node scripts/verify-deps.js",
 		"test": "npm run test --workspaces --if-present",
-		"install-vscode": "npm run build && node packages/vscode/scripts/install-extension.mjs",
+		"install-vscode": "node scripts/verify-deps.js && npm run build && node packages/vscode/scripts/install-extension.mjs",
 		"uninstall-vscode": "node packages/vscode/scripts/uninstall-extension.mjs",
 		"coverage": "vitest --run --coverage --coverage.reporter=json-summary --coverage.reporter=text-summary",
 		"prepare": "husky"

--- a/packages/coding-agent/test/verify-deps.test.ts
+++ b/packages/coding-agent/test/verify-deps.test.ts
@@ -1,0 +1,154 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const scriptPath = join(__dirname, "../../../scripts/verify-deps.js");
+const tempDirs: string[] = [];
+
+type PackageJson = Record<string, unknown>;
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+function createTempProject(rootPackage: PackageJson): string {
+	const dir = mkdtempSync(join(tmpdir(), "verify-deps-"));
+	tempDirs.push(dir);
+	mkdirSync(join(dir, "packages"), { recursive: true });
+	writeJson(join(dir, "package.json"), { workspaces: ["packages/*"], ...rootPackage });
+	return dir;
+}
+
+function writeWorkspacePackage(projectDir: string, packageName: string, packageJson: PackageJson): void {
+	const packageDir = join(projectDir, "packages", packageName);
+	mkdirSync(packageDir, { recursive: true });
+	writeJson(join(packageDir, "package.json"), packageJson);
+}
+
+/** Simulate an installed dependency by creating node_modules/<name>/package.json
+ * under `baseDir` (the repo root for a hoisted install, or a workspace dir). */
+function installDep(baseDir: string, name: string): void {
+	const packageDir = join(baseDir, "node_modules", name);
+	mkdirSync(packageDir, { recursive: true });
+	writeJson(join(packageDir, "package.json"), { name, version: "1.0.0" });
+}
+
+function writeJson(path: string, value: PackageJson): void {
+	writeFileSync(path, `${JSON.stringify(value, null, "\t")}\n`, "utf-8");
+}
+
+function runVerifyDeps(cwd: string) {
+	return spawnSync(process.execPath, [scriptPath], {
+		cwd,
+		encoding: "utf-8",
+	});
+}
+
+describe("verify-deps script", () => {
+	it("exits 0 when every declared dependency is installed", () => {
+		const projectDir = createTempProject({ dependencies: { marked: "^1.0.0" } });
+		writeWorkspacePackage(projectDir, "vscode", {
+			dependencies: { katex: "^0.18.4" },
+			devDependencies: { vitest: "^4.0.0" },
+		});
+		installDep(projectDir, "marked");
+		installDep(projectDir, "katex");
+		installDep(projectDir, "vitest");
+
+		const result = runVerifyDeps(projectDir);
+
+		expect(result.status).toBe(0);
+		expect(result.stdout).toContain("All workspace dependencies are installed.");
+		expect(result.stderr).toBe("");
+	});
+
+	it("exits 1 with an actionable message when a direct dependency is missing", () => {
+		const projectDir = createTempProject({});
+		writeWorkspacePackage(projectDir, "vscode", { dependencies: { katex: "^0.18.4" } });
+		// katex intentionally not installed
+
+		const result = runVerifyDeps(projectDir);
+
+		expect(result.status).toBe(1);
+		expect(result.stderr).toContain("dreb: dependencies not installed (missing: katex).");
+		expect(result.stderr).toContain("Run `npm install` at the repo root, then retry.");
+	});
+
+	it("counts a type-only package (package.json but no entry point) as installed", () => {
+		const projectDir = createTempProject({});
+		writeWorkspacePackage(projectDir, "vscode", { devDependencies: { "@types/katex": "^0.16.8" } });
+		installDep(projectDir, "@types/katex");
+
+		const result = runVerifyDeps(projectDir);
+
+		expect(result.status).toBe(0);
+		expect(result.stdout).toContain("All workspace dependencies are installed.");
+	});
+
+	it("skips optionalDependencies and peerDependencies even when absent", () => {
+		const projectDir = createTempProject({});
+		writeWorkspacePackage(projectDir, "vscode", {
+			optionalDependencies: { "@rollup/rollup-linux-x64-gnu": "^4.0.0" },
+			peerDependencies: { react: "^19.0.0" },
+		});
+		// neither is installed
+
+		const result = runVerifyDeps(projectDir);
+
+		expect(result.status).toBe(0);
+		expect(result.stdout).toContain("All workspace dependencies are installed.");
+		expect(result.stderr).toBe("");
+	});
+
+	it("aggregates missing dependencies across multiple workspaces, sorted", () => {
+		const projectDir = createTempProject({});
+		writeWorkspacePackage(projectDir, "vscode", { dependencies: { katex: "^0.18.4" } });
+		writeWorkspacePackage(projectDir, "ai", { dependencies: { "marked-katex-extension": "^5.0.0" } });
+
+		const result = runVerifyDeps(projectDir);
+
+		expect(result.status).toBe(1);
+		expect(result.stderr).toContain("(missing: katex, marked-katex-extension).");
+	});
+
+	it("resolves a workspace dependency hoisted to the root node_modules", () => {
+		const projectDir = createTempProject({});
+		writeWorkspacePackage(projectDir, "vscode", { dependencies: { katex: "^0.18.4" } });
+		// installed only at the repo root, not in the workspace's own node_modules
+		installDep(projectDir, "katex");
+
+		const result = runVerifyDeps(projectDir);
+
+		expect(result.status).toBe(0);
+		expect(result.stdout).toContain("All workspace dependencies are installed.");
+	});
+
+	it("also checks the root package's own dependencies", () => {
+		const projectDir = createTempProject({ devDependencies: { husky: "^9.0.0" } });
+		// husky intentionally not installed
+
+		const result = runVerifyDeps(projectDir);
+
+		expect(result.status).toBe(1);
+		expect(result.stderr).toContain("(missing: husky).");
+	});
+
+	it("exits 1 with a diagnostic when a workspace package.json is invalid", () => {
+		const projectDir = createTempProject({});
+		const packageDir = join(projectDir, "packages", "broken");
+		mkdirSync(packageDir, { recursive: true });
+		writeFileSync(join(packageDir, "package.json"), "{ not json\n", "utf-8");
+
+		const result = runVerifyDeps(projectDir);
+
+		expect(result.status).toBe(1);
+		expect(result.stderr).toContain("ERROR: failed to read or parse packages/broken/package.json");
+		expect(result.stderr).toContain("Fix: correct the invalid JSON syntax in the reported file(s).");
+	});
+});

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -200,6 +200,8 @@ This extension is distributed as part of the dreb repo, not as a published `.vsi
 npm run install-vscode        # builds the repo, then links packages/vscode into ~/.vscode/extensions
 ```
 
+> **After pulling an update**, run `npm install` first if it added new dependencies — `install-vscode` preflights this and stops with a clear "run `npm install`" message rather than a cryptic bundler error.
+
 Then reload the editor (**Developer: Reload Window**) and run **dreb: Open Chat**.
 
 - VS Code Insiders: `node packages/vscode/scripts/install-extension.mjs --insiders`

--- a/scripts/verify-deps.js
+++ b/scripts/verify-deps.js
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+/**
+ * Verify that every declared workspace dependency is actually installed in
+ * node_modules, and fail fast with an actionable message if not.
+ *
+ * This guards convenience flows like `install-vscode` (which runs the full
+ * `npm run build`): when an update adds a new dependency and the user has not
+ * re-run `npm install`, the bundler otherwise dies deep inside vite/rolldown
+ * with a cryptic "failed to resolve import" trace. This preflight turns that
+ * into a single "run `npm install`" instruction.
+ *
+ * Scope: the root package plus every workspace package. Only `dependencies` and
+ * `devDependencies` are checked — `optionalDependencies` and `peerDependencies`
+ * are deliberately skipped, because platform-specific optional packages (e.g.
+ * `@rollup/rollup-linux-x64-gnu`, marked optional/peer in the lockfile) are
+ * legitimately absent on any given machine and must not trip a false alarm.
+ *
+ * Exit code 1 if any required dependency is missing.
+ */
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+const rootPkg = JSON.parse(readFileSync("package.json", "utf-8"));
+const workspaceEntries = Array.isArray(rootPkg.workspaces) ? rootPkg.workspaces : [];
+
+let foundReadOrParseError = false;
+const missing = new Map();
+
+function isEnoent(error) {
+	return error && typeof error === "object" && "code" in error && error.code === "ENOENT";
+}
+
+/** All package.json paths to inspect: the root package plus every workspace. */
+function packageJsonPaths() {
+	const paths = ["package.json"];
+	for (const workspaceEntry of workspaceEntries) {
+		paths.push(...packageJsonPathsForWorkspace(workspaceEntry));
+	}
+	return paths;
+}
+
+function packageJsonPathsForWorkspace(workspaceEntry) {
+	if (workspaceEntry.endsWith("/*")) {
+		const workspaceRoot = workspaceEntry.slice(0, -2);
+		let packageDirs;
+		try {
+			packageDirs = readdirSync(workspaceRoot);
+		} catch (error) {
+			if (isEnoent(error)) {
+				return [];
+			}
+
+			const message = error instanceof Error ? error.message : String(error);
+			console.error(`ERROR: failed to read workspace directory ${workspaceRoot}: ${message}`);
+			foundReadOrParseError = true;
+			return [];
+		}
+
+		return packageDirs.map((pkgDir) => join(workspaceRoot, pkgDir, "package.json"));
+	}
+
+	return [join(workspaceEntry, "package.json")];
+}
+
+/**
+ * True when `name` is installed as seen from `fromDir`. Walks node_modules
+ * directories from the package's own directory up to the repo root, mirroring
+ * Node's resolution so a hoisted dependency in the root node_modules counts.
+ * We probe for the package's package.json (present even for `@types/*` packages
+ * that expose no runtime entry point) rather than resolving a main module, so
+ * an `exports`-restricted package is never misreported as missing.
+ */
+function isInstalled(name, fromDir) {
+	let dir = fromDir;
+	while (true) {
+		if (existsSync(join(dir, "node_modules", name, "package.json"))) {
+			return true;
+		}
+		if (dir === "" || dir === ".") {
+			break;
+		}
+		const parent = dir.includes("/") ? dir.slice(0, dir.lastIndexOf("/")) : ".";
+		if (parent === dir) {
+			break;
+		}
+		dir = parent;
+	}
+	return false;
+}
+
+function packageDir(pkgPath) {
+	if (pkgPath === "package.json") {
+		return ".";
+	}
+	return pkgPath.slice(0, pkgPath.length - "/package.json".length);
+}
+
+function checkPackage(pkgPath) {
+	let pkg;
+	try {
+		pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+	} catch (error) {
+		if (isEnoent(error)) {
+			return;
+		}
+
+		const message = error instanceof Error ? error.message : String(error);
+		console.error(`ERROR: failed to read or parse ${pkgPath}: ${message}`);
+		foundReadOrParseError = true;
+		return;
+	}
+
+	const fromDir = packageDir(pkgPath);
+	const required = { ...(pkg.dependencies ?? {}), ...(pkg.devDependencies ?? {}) };
+	for (const name of Object.keys(required)) {
+		if (!isInstalled(name, fromDir) && !missing.has(name)) {
+			missing.set(name, pkgPath);
+		}
+	}
+}
+
+for (const pkgPath of packageJsonPaths()) {
+	checkPackage(pkgPath);
+}
+
+if (foundReadOrParseError || missing.size > 0) {
+	console.error("");
+	if (foundReadOrParseError) {
+		console.error("Fix: correct the invalid JSON syntax in the reported file(s).");
+	}
+	if (missing.size > 0) {
+		const names = [...missing.keys()].sort().join(", ");
+		console.error(`dreb: dependencies not installed (missing: ${names}).`);
+		console.error("      Run `npm install` at the repo root, then retry.");
+	}
+	process.exit(1);
+}
+
+console.log("All workspace dependencies are installed.");


### PR DESCRIPTION
Add a preflight dependency check to `install-vscode` so that a stale `node_modules` (e.g. after pulling an update that adds a new dependency) fails fast with an actionable message instead of a cryptic bundler crash.

## Summary

When an update adds a dependency (as PR #102 did with `katex`), running `npm run install-vscode` without first running `npm install` fails deep inside vite/rolldown with "failed to resolve import". This PR adds `scripts/verify-deps.js`, wired into `install-vscode`, that detects missing workspace dependencies and tells the user to run `npm install`.

Based on the `vscode` branch (targets `vscode`, not `master`) so it flows into `karin` on the next rebuild.

Implementation plan posted as a comment below.
